### PR TITLE
[codex] add golangci-lint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,24 @@ jobs:
           path: benchmarks/results/
           if-no-files-found: warn
 
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.7.2
+
   test-matrix:
     name: test (${{ matrix.label }})
     runs-on: ${{ matrix.os }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+version: "2"
+
+linters:
+  default: standard

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -29,30 +30,30 @@ func runHelp(program string, args []string) error {
 
 	switch args[0] {
 	case "index":
-		return runIndex(nil, name, []string{"--help"}, semsearch.Paths{}, nil, indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
+		return runIndex(context.TODO(), name, []string{"--help"}, semsearch.Paths{}, nil, indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
 	case "search":
-		return runSearch(nil, name, []string{"--help"}, semsearch.Paths{}, nil, indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
+		return runSearch(context.TODO(), name, []string{"--help"}, semsearch.Paths{}, nil, indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
 	case "init":
-		return runInit(nil, name, []string{"--help"}, ".")
+		return runInit(context.TODO(), name, []string{"--help"}, ".")
 	case "create":
 		if len(args) > 1 && args[1] == "ci" {
-			return runCreate(nil, name, []string{"ci", "--help"}, ".")
+			return runCreate(context.TODO(), name, []string{"ci", "--help"}, ".")
 		}
 		return printCreateHelp(os.Stdout, name)
 	case "bind":
 		if len(args) > 1 && args[1] == "ci" {
-			return runBind(nil, name, []string{"ci", "--help"}, ".")
+			return runBind(context.TODO(), name, []string{"ci", "--help"}, ".")
 		}
 		return printBindHelp(os.Stdout, name)
 	case "remote":
 		if len(args) > 1 {
 			switch args[1] {
 			case "sync":
-				return runRemote(nil, name, []string{"sync", "--help"}, ".")
+				return runRemote(context.TODO(), name, []string{"sync", "--help"}, ".")
 			case "download":
-				return runRemote(nil, name, []string{"download", "--help"}, ".")
+				return runRemote(context.TODO(), name, []string{"download", "--help"}, ".")
 			case "bind":
-				return runRemote(nil, name, []string{"bind", "--help"}, ".")
+				return runRemote(context.TODO(), name, []string{"bind", "--help"}, ".")
 			}
 		}
 		return printRemoteHelp(os.Stdout, name)

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -161,7 +161,9 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 	if err != nil {
 		return err
 	}
-	defer repo.Close()
+	defer func() {
+		_ = repo.Close()
+	}()
 
 	service := indexing.Service{
 		Scanner:  scanner,

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -169,7 +169,9 @@ func runSearch(ctx context.Context, program string, args []string, paths semsear
 	if err != nil {
 		return err
 	}
-	defer repo.Close()
+	defer func() {
+		_ = repo.Close()
+	}()
 
 	fileWeights, err := semsearch.LoadFileWeights(targetPaths.LocalDir)
 	if err != nil {

--- a/internal/embed/llama/embedder.go
+++ b/internal/embed/llama/embedder.go
@@ -122,7 +122,7 @@ func New(cfg Config) (*Embedder, error) {
 
 	ctx, err := llama.InitFromModel(model, ctxParams)
 	if err != nil {
-		llama.ModelFree(model)
+		_ = llama.ModelFree(model)
 		llamaInitRefCounter--
 		if llamaInitRefCounter == 0 {
 			llama.Close()
@@ -158,11 +158,11 @@ func (e *Embedder) Close() {
 	defer e.mu.Unlock()
 
 	if e.ctx != 0 {
-		llama.Free(e.ctx)
+		_ = llama.Free(e.ctx)
 		e.ctx = 0
 	}
 	if e.model != 0 {
-		llama.ModelFree(e.model)
+		_ = llama.ModelFree(e.model)
 		e.model = 0
 	}
 

--- a/internal/indexdb/hash.go
+++ b/internal/indexdb/hash.go
@@ -23,7 +23,9 @@ func LogicalHash(ctx context.Context, dbPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("open db: %w", err)
 	}
-	defer db.Close()
+	defer func() {
+		_ = db.Close()
+	}()
 
 	if err := ensureLogicalHashSchema(ctx, db); err != nil {
 		return "", err
@@ -60,7 +62,9 @@ func LogicalHash(ctx context.Context, dbPath string) (string, error) {
 		}
 		return "", fmt.Errorf("query logical hash rows: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	sum := sha256.New()
 	writeHashBytes(sum, []byte("semsearch-logical-index-v2"))
@@ -130,7 +134,9 @@ func ensureLogicalHashSchema(ctx context.Context, db *sql.DB) error {
 	if err != nil {
 		return fmt.Errorf("inspect logical hash schema: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	present := make(map[string]bool, len(requiredTables))
 	for rows.Next() {

--- a/internal/indexdb/sqlite.go
+++ b/internal/indexdb/sqlite.go
@@ -331,7 +331,9 @@ func (s *Store) SearchBySnapshot(ctx context.Context, modelID string, snapshotID
 	if err != nil {
 		return nil, fmt.Errorf("search query: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	results := make([]search.SearchResult, 0, limit)
 	for rows.Next() {
@@ -394,7 +396,9 @@ func (s *Store) ListSymbolsBySnapshot(ctx context.Context, modelID string, snaps
 	if err != nil {
 		return nil, fmt.Errorf("list symbols: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	var results []search.SearchResult
 	for rows.Next() {

--- a/internal/indexdb/sqlite_test.go
+++ b/internal/indexdb/sqlite_test.go
@@ -18,7 +18,9 @@ func TestStoreLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open() error: %v", err)
 	}
-	defer store.Close()
+	defer func() {
+		_ = store.Close()
+	}()
 
 	const modelID = "embeddinggemma"
 
@@ -115,7 +117,9 @@ func TestActiveSnapshotIsolationAcrossModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open() error: %v", err)
 	}
-	defer store.Close()
+	defer func() {
+		_ = store.Close()
+	}()
 
 	if err := store.AddEmbedding(ctx, "embeddinggemma", "hash-gemma", []float32{1, 0, 0}); err != nil {
 		t.Fatalf("AddEmbedding(gemma) error: %v", err)
@@ -169,7 +173,9 @@ func TestLogicalHashIgnoresSnapshotOnlyChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open() error: %v", err)
 	}
-	defer store.Close()
+	defer func() {
+		_ = store.Close()
+	}()
 
 	modelID := "embeddinggemma"
 	vec := []float32{1, 0, 0}
@@ -230,7 +236,9 @@ func TestLogicalHashRejectsLegacySchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sql.Open() error: %v", err)
 	}
-	defer db.Close()
+	defer func() {
+		_ = db.Close()
+	}()
 
 	for _, stmt := range []string{
 		`CREATE TABLE comments (

--- a/internal/indexing/legacy_prefix.go
+++ b/internal/indexing/legacy_prefix.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -42,7 +41,9 @@ func ExtractPrefixedBlocks(path string, searchPrefix string, ctxPrefix string) (
 	if err != nil {
 		return nil, "", err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	isBinary, err := looksLikeBinaryFile(file)
 	if err != nil {
@@ -185,12 +186,4 @@ func firstNLines(text string, limit int) string {
 		lines[i] = strings.TrimRight(lines[i], " \t")
 	}
 	return strings.TrimSpace(strings.Join(lines, "\n"))
-}
-
-func trimPathBase(path string) string {
-	base := strings.TrimSpace(filepath.Base(path))
-	if base == "" || base == "." || base == string(filepath.Separator) {
-		return "unknown"
-	}
-	return base
 }

--- a/internal/indexing/scanner.go
+++ b/internal/indexing/scanner.go
@@ -104,7 +104,9 @@ func readSourceFile(path string) ([]byte, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	binary, err := looksLikeBinaryFile(file)
 	if err != nil {

--- a/internal/indexing/scanner_io_test.go
+++ b/internal/indexing/scanner_io_test.go
@@ -130,7 +130,9 @@ func TestLooksLikeBinaryFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open binary file: %v", err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	binary, err := looksLikeBinaryFile(f)
 	if err != nil {

--- a/internal/runtime/model_cache.go
+++ b/internal/runtime/model_cache.go
@@ -331,7 +331,9 @@ func validateGGUFFile(path string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	header := make([]byte, 4)
 	if _, err := io.ReadFull(f, header); err != nil {

--- a/internal/runtime/yzma.go
+++ b/internal/runtime/yzma.go
@@ -383,7 +383,9 @@ func recentLlamaVersions(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))

--- a/internal/semsearch/manifest.go
+++ b/internal/semsearch/manifest.go
@@ -168,7 +168,9 @@ func FileSHA256(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	sum := sha256.New()
 	if _, err := io.Copy(sum, f); err != nil {

--- a/internal/semsearch/remote.go
+++ b/internal/semsearch/remote.go
@@ -554,7 +554,9 @@ func readZipFile(file *zip.File) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open artifact member %s: %w", file.Name, err)
 	}
-	defer rc.Close()
+	defer func() {
+		_ = rc.Close()
+	}()
 
 	data, err := io.ReadAll(rc)
 	if err != nil {
@@ -581,7 +583,9 @@ func fetchRemoteBytes(ctx context.Context, rawURL string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %w", rawURL, err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, os.ErrNotExist

--- a/internal/termui/session.go
+++ b/internal/termui/session.go
@@ -125,7 +125,7 @@ func (u *terminalUI) Clear() {
 		return
 	}
 
-	fmt.Fprintf(u.out, "\r%s\r", strings.Repeat(" ", u.lastLen))
+	_, _ = fmt.Fprintf(u.out, "\r%s\r", strings.Repeat(" ", u.lastLen))
 	u.lastLen = 0
 }
 
@@ -138,9 +138,9 @@ func (u *terminalUI) render(message string, newline bool) {
 		padding = strings.Repeat(" ", diff)
 	}
 
-	fmt.Fprintf(u.out, "\r%s%s", message, padding)
+	_, _ = fmt.Fprintf(u.out, "\r%s%s", message, padding)
 	if newline {
-		fmt.Fprintln(u.out)
+		_, _ = fmt.Fprintln(u.out)
 		u.lastLen = 0
 		return
 	}


### PR DESCRIPTION
## Summary

This PR adds a real `golangci-lint` check to CI and cleans up the current codebase so the lint pass starts green.

## What changed

- add `.golangci.yml`
- add a dedicated `lint` job in CI using `golangci/golangci-lint-action`
- remove the temporary shell-based lint script approach
- fix current `errcheck`, `staticcheck`, and `unused` findings so the new lint job passes cleanly

## Why

The repository already had stable `gofmt` and `go vet` behavior, but it did not have a standard lint gate in CI. Using `golangci-lint` gives us a conventional Go lint path and makes future review/CI behavior more predictable.

## Validation

- `golangci-lint run ./...`
- `go test ./...`
