### PR TITLE
Refactor auto search to prefer semantic results

### DIFF
--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -80,7 +80,7 @@ func (s Service) Run(ctx context.Context, params Params, reporter Reporter) ([]R
 			return s.searchLexicalCurrent(ctx, params, reporter)
 		}
 
-		semanticResults, err := s.searchSemanticCurrent(ctx, params, reporter)
+		semanticResults, err := s.searchAutoSemanticCurrent(ctx, params, reporter)
 		if err != nil {
 			return nil, err
 		}
@@ -92,11 +92,27 @@ func (s Service) Run(ctx context.Context, params Params, reporter Reporter) ([]R
 		if err != nil {
 			return nil, err
 		}
-		if shouldPreferLexicalResults(semanticResults, lexicalResults) {
+		if shouldPreferLexicalResults(params.QueryText, semanticResults, lexicalResults) {
 			return lexicalResults, nil
 		}
 		return semanticResults, nil
 	}
+}
+
+func (s Service) searchAutoSemanticCurrent(ctx context.Context, params Params, reporter Reporter) ([]Result, error) {
+	results, err := s.searchSemanticCurrent(ctx, params, reporter)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) > 0 || params.MaxDistance <= 0 {
+		return results, nil
+	}
+
+	// Auto mode should stay semantic-first for natural-language queries even when
+	// the default distance cutoff is slightly too strict for the best candidates.
+	relaxed := params
+	relaxed.MaxDistance = 0
+	return s.searchSemanticCurrent(ctx, relaxed, reporter)
 }
 
 func (s Service) searchSemanticCurrent(ctx context.Context, params Params, _ Reporter) ([]Result, error) {
@@ -224,12 +240,15 @@ func resultSearchText(result SearchResult) string {
 	return strings.Join(parts, "\n")
 }
 
-func shouldPreferLexicalResults(semanticResults []Result, lexicalResults []Result) bool {
+func shouldPreferLexicalResults(query string, semanticResults []Result, lexicalResults []Result) bool {
 	if len(lexicalResults) == 0 {
 		return false
 	}
 	if len(semanticResults) == 0 {
 		return true
+	}
+	if !shouldPreferLexicalSearch(query) {
+		return false
 	}
 
 	semanticTop := semanticResults[0]
@@ -245,11 +264,12 @@ func shouldPreferLexicalResults(semanticResults []Result, lexicalResults []Resul
 }
 
 func shouldPreferLexicalSearch(query string) bool {
+	query = strings.TrimSpace(query)
 	tokens := searchQueryTokens(query)
 	if len(tokens) == 0 {
 		return false
 	}
-	if looksCodeLikeQuery(query) {
+	if !strings.ContainsFunc(query, unicode.IsSpace) && looksCodeLikeQuery(query) {
 		return true
 	}
 	if len(tokens) == 1 && len([]rune(tokens[0])) <= 3 {

--- a/internal/search/service_run_test.go
+++ b/internal/search/service_run_test.go
@@ -97,6 +97,41 @@ func TestServiceRunAutoFallsBackToLexical(t *testing.T) {
 	}
 }
 
+func TestServiceRunAutoKeepsSemanticResultsForNaturalLanguageQuery(t *testing.T) {
+	t.Parallel()
+
+	service := Service{
+		Repo: mockRepo{
+			semantic: []SearchResult{
+				{Path: "internal/runtime/model_cache.go", Line: 159, Name: "installEmbeddingModel", Documentation: "install qwen model", Distance: 0.9033},
+			},
+			lexical: []SearchResult{
+				{Path: "internal/embed/llama/model_profile.go", Line: 150, Documentation: "qwen profile"},
+			},
+		},
+		Embedder: mockEmbedder{},
+	}
+
+	results, err := service.Run(context.Background(), Params{
+		QueryText:   "qwen install",
+		Mode:        "auto",
+		Limit:       10,
+		MaxDistance: 0.85,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Service.Run(auto semantic-first) error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 semantic result, got %+v", results)
+	}
+	if results[0].Path != "internal/runtime/model_cache.go" {
+		t.Fatalf("expected semantic install result, got %+v", results)
+	}
+	if results[0].DisplayMetric == "lexical" {
+		t.Fatalf("expected semantic result to win for natural-language query, got %+v", results)
+	}
+}
+
 func TestServiceRunPropagatesEmbedErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -35,6 +35,9 @@ func TestShouldPreferLexicalSearch(t *testing.T) {
 		{query: "", want: false},
 		{query: "hui", want: true},
 		{query: "RunCLI", want: true},
+		{query: "internal/runtime/model_cache.go", want: true},
+		{query: "qwen install", want: false},
+		{query: "qwen3 install", want: false},
 		{query: "global model cache", want: false},
 	}
 
@@ -143,13 +146,19 @@ func TestShouldPreferLexicalResults(t *testing.T) {
 
 	semantic := []Result{{SearchResult: SearchResult{Distance: 0.9}}}
 	lexical := []Result{{LexicalScore: 0.7}}
-	if !shouldPreferLexicalResults(semantic, lexical) {
+	if !shouldPreferLexicalResults("RunCLI", semantic, lexical) {
 		t.Fatalf("expected lexical results to win when semantic top distance is weak")
 	}
 
 	semantic = []Result{{SearchResult: SearchResult{Distance: 0.72}}}
 	lexical = []Result{{LexicalScore: 0.95}}
-	if shouldPreferLexicalResults(semantic, lexical) {
+	if shouldPreferLexicalResults("qwen install", semantic, lexical) {
+		t.Fatalf("did not expect lexical results to win for natural-language query")
+	}
+
+	semantic = []Result{{SearchResult: SearchResult{Distance: 0.72}}}
+	lexical = []Result{{LexicalScore: 0.95}}
+	if shouldPreferLexicalResults("global model cache", semantic, lexical) {
 		t.Fatalf("did not expect lexical results to win when semantic top distance is strong")
 	}
 }


### PR DESCRIPTION
## What changed

This PR makes `unch search --mode auto` more semantic-first for natural-language queries.

- keep lexical-first behavior for clearly code-like single-token queries such as identifiers and paths
- avoid overriding semantic results with lexical results for multi-word natural-language queries
- add a second semantic pass without the default distance cutoff when auto mode would otherwise return no semantic matches
- add tests covering the new auto-mode behavior

## Why

Auto mode was too eager to fall back to lexical retrieval. Queries like `qwen install` were returning mostly lexical matches from profile and test files even though semantic search could find the actual installation path.

## Impact

Natural-language queries should now surface more semantic results by default, while exact code-like queries still keep the fast lexical path.

## Validation

- `go test ./internal/search ./internal/cli`
- `go test ./...`
- `go run . search "qwen install"`
