### PR TITLE
fix: skip unchanged local indexing

### DIFF
--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/uchebnick/unch/internal/embed/llama"
+	"github.com/uchebnick/unch/internal/filehashdb"
 	"github.com/uchebnick/unch/internal/indexdb"
 	"github.com/uchebnick/unch/internal/indexing"
 	"github.com/uchebnick/unch/internal/runtime"
@@ -103,6 +104,64 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 		resolvedDBPath = filepath.Join(targetPaths.LocalDir, "index.db")
 	}
 
+	modelID, err := runtime.CanonicalModelID(*modelPath, defaultModelPath)
+	if err != nil {
+		return fmt.Errorf("resolve model id: %w", err)
+	}
+	resolvedGitignore, err := indexing.ResolveGitignorePath(rootAbs, *gitignorePath)
+	if err != nil {
+		return fmt.Errorf("resolve gitignore: %w", err)
+	}
+
+	hashStore, err := filehashdb.Open(ctx, targetPaths.FileHashDB)
+	if err != nil {
+		return fmt.Errorf("open file hash db: %w", err)
+	}
+	defer func() {
+		_ = hashStore.Close()
+	}()
+
+	fileHashes, err := indexing.CollectFileHashes(rootAbs, resolvedGitignore, excludes)
+	if err != nil {
+		return fmt.Errorf("collect file hashes: %w", err)
+	}
+	scannerFingerprint := indexing.BuildScannerFingerprint(*commentPrefix, *contextPrefix, excludes)
+
+	s.Logf("file_hashes=%d", len(fileHashes))
+	s.Logf("scanner_fingerprint=%s", scannerFingerprint)
+
+	var currentFileHashes map[string]string
+	skipped, err := maybeSkipUnchangedIndex(
+		ctx,
+		targetPaths,
+		resolvedDBPath,
+		dbWasExplicit,
+		currentManifest,
+		hashStore,
+		modelID,
+		scannerFingerprint,
+		fileHashes,
+		s,
+	)
+	if err != nil {
+		return err
+	}
+	if skipped {
+		return nil
+	}
+
+	if currentState, ok, err := hashStore.Current(ctx, modelID); err != nil {
+		return fmt.Errorf("read current file hash state: %w", err)
+	} else if ok && currentState.ScannerFingerprint == scannerFingerprint {
+		currentFileHashes = currentState.Files
+	}
+
+	fileHashStateVersion, err := hashStore.BeginState(ctx, modelID, scannerFingerprint)
+	if err != nil {
+		return fmt.Errorf("begin file hash state: %w", err)
+	}
+	s.Logf("staged_file_hash_state_version=%d", fileHashStateVersion)
+
 	resolvedLibPath, libNote, err := runtimes.ResolveOrInstallYzmaLibPath(ctx, *libPath, targetPaths.LocalDir, s)
 	if err != nil {
 		return err
@@ -118,10 +177,7 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 	if modelNote != "" {
 		s.Logf("%s", modelNote)
 	}
-	modelID, err := runtime.CanonicalModelID(*modelPath, defaultModelPath)
-	if err != nil {
-		return fmt.Errorf("resolve model id: %w", err)
-	}
+
 	resolvedContextSize := *contextSize
 	if resolvedContextSize <= 0 {
 		resolvedContextSize = defaultContextSize(resolvedModelPath)
@@ -129,11 +185,6 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 	resolvedBatchSize := *batchSize
 	if resolvedBatchSize <= 0 {
 		resolvedBatchSize = defaultBatchSize(resolvedModelPath)
-	}
-
-	resolvedGitignore, err := indexing.ResolveGitignorePath(rootAbs, *gitignorePath)
-	if err != nil {
-		return fmt.Errorf("resolve gitignore: %w", err)
 	}
 
 	s.Logf("db=%s", resolvedDBPath)
@@ -169,15 +220,19 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 		Scanner:  scanner,
 		Repo:     repo,
 		Embedder: embedder,
+		Hashes:   hashStore,
 	}
 
 	result, err := service.Run(ctx, indexing.Params{
-		Root:          rootAbs,
-		GitignorePath: resolvedGitignore,
-		Excludes:      excludes,
-		ContextPrefix: *contextPrefix,
-		CommentPrefix: *commentPrefix,
-		ModelID:       modelID,
+		Root:                 rootAbs,
+		GitignorePath:        resolvedGitignore,
+		Excludes:             excludes,
+		ContextPrefix:        *contextPrefix,
+		CommentPrefix:        *commentPrefix,
+		ModelID:              modelID,
+		CurrentFileHashes:    currentFileHashes,
+		NextFileHashes:       fileHashes,
+		FileHashStateVersion: fileHashStateVersion,
 	}, s)
 	if err != nil {
 		return err
@@ -189,6 +244,14 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 	}
 	s.Logf("manifest version=%d indexing_hash=%s", manifest.Version, manifest.IndexingHash)
 
+	if err := hashStore.ActivateState(ctx, modelID, fileHashStateVersion); err != nil {
+		return fmt.Errorf("activate file hash state: %w", err)
+	}
+	if err := hashStore.CleanupInactiveStates(ctx); err != nil {
+		return fmt.Errorf("cleanup inactive file hash states: %w", err)
+	}
+	s.Logf("file_hash_state_version=%d", fileHashStateVersion)
+
 	if result.IndexedSymbols == 0 {
 		s.Finish("No symbols found")
 		return nil
@@ -196,4 +259,45 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 
 	s.Finish(fmt.Sprintf("Indexed %d symbols in %d files", result.IndexedSymbols, result.IndexedFiles))
 	return nil
+}
+
+func maybeSkipUnchangedIndex(
+	ctx context.Context,
+	paths semsearch.Paths,
+	resolvedDBPath string,
+	dbWasExplicit bool,
+	currentManifest semsearch.Manifest,
+	hashStore *filehashdb.Store,
+	modelID string,
+	scannerFingerprint string,
+	fileHashes map[string]string,
+	s *termui.Session,
+) (bool, error) {
+	defaultDBPath := filepath.Join(paths.LocalDir, "index.db")
+	if dbWasExplicit || resolvedDBPath != defaultDBPath {
+		return false, nil
+	}
+	if currentManifest.Version <= 0 || semsearch.HasRemoteBinding(currentManifest) {
+		return false, nil
+	}
+	if _, err := os.Stat(resolvedDBPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat current index db: %w", err)
+	}
+
+	match, fileHashStateVersion, err := hashStore.Matches(ctx, modelID, scannerFingerprint, fileHashes)
+	if err != nil {
+		return false, fmt.Errorf("compare file hash state: %w", err)
+	}
+	if !match {
+		return false, nil
+	}
+
+	if s != nil {
+		s.Logf("file_hash_state_version=%d", fileHashStateVersion)
+		s.Finish("Index already up to date")
+	}
+	return true, nil
 }

--- a/internal/cli/index_skip_test.go
+++ b/internal/cli/index_skip_test.go
@@ -1,0 +1,191 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/uchebnick/unch/internal/filehashdb"
+	"github.com/uchebnick/unch/internal/semsearch"
+)
+
+func TestMaybeSkipUnchangedIndexSkipsMatchingLocalState(t *testing.T) {
+	t.Parallel()
+
+	localDir := t.TempDir()
+	dbPath := filepath.Join(localDir, "index.db")
+	if err := writeStubFile(dbPath); err != nil {
+		t.Fatalf("write index db: %v", err)
+	}
+
+	store, err := filehashdb.Open(context.Background(), filepath.Join(localDir, "filehashes.db"))
+	if err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+	}()
+
+	files := map[string]string{"internal/indexing/scanner.go": "abc123"}
+	version, err := store.StageState(context.Background(), "embeddinggemma", "scan-v1", files)
+	if err != nil {
+		t.Fatalf("StageState() error: %v", err)
+	}
+	if err := store.ActivateState(context.Background(), "embeddinggemma", version); err != nil {
+		t.Fatalf("ActivateState() error: %v", err)
+	}
+
+	skipped, err := maybeSkipUnchangedIndex(
+		context.Background(),
+		semsearch.Paths{LocalDir: localDir},
+		dbPath,
+		false,
+		semsearch.Manifest{Version: 7, Source: "local"},
+		store,
+		"embeddinggemma",
+		"scan-v1",
+		files,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("maybeSkipUnchangedIndex() error: %v", err)
+	}
+	if !skipped {
+		t.Fatalf("maybeSkipUnchangedIndex() = false, want true")
+	}
+}
+
+func TestMaybeSkipUnchangedIndexDoesNotSkipMismatchedState(t *testing.T) {
+	t.Parallel()
+
+	localDir := t.TempDir()
+	dbPath := filepath.Join(localDir, "index.db")
+	if err := writeStubFile(dbPath); err != nil {
+		t.Fatalf("write index db: %v", err)
+	}
+
+	store, err := filehashdb.Open(context.Background(), filepath.Join(localDir, "filehashes.db"))
+	if err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+	}()
+
+	version, err := store.StageState(context.Background(), "embeddinggemma", "scan-v1", map[string]string{"a.go": "aaa"})
+	if err != nil {
+		t.Fatalf("StageState() error: %v", err)
+	}
+	if err := store.ActivateState(context.Background(), "embeddinggemma", version); err != nil {
+		t.Fatalf("ActivateState() error: %v", err)
+	}
+
+	skipped, err := maybeSkipUnchangedIndex(
+		context.Background(),
+		semsearch.Paths{LocalDir: localDir},
+		dbPath,
+		false,
+		semsearch.Manifest{Version: 7, Source: "local"},
+		store,
+		"embeddinggemma",
+		"scan-v1",
+		map[string]string{"a.go": "bbb"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("maybeSkipUnchangedIndex() error: %v", err)
+	}
+	if skipped {
+		t.Fatalf("maybeSkipUnchangedIndex() = true, want false")
+	}
+}
+
+func TestMaybeSkipUnchangedIndexDoesNotSkipExplicitOrRemoteDB(t *testing.T) {
+	t.Parallel()
+
+	localDir := t.TempDir()
+	defaultDBPath := filepath.Join(localDir, "index.db")
+	if err := writeStubFile(defaultDBPath); err != nil {
+		t.Fatalf("write index db: %v", err)
+	}
+
+	store, err := filehashdb.Open(context.Background(), filepath.Join(localDir, "filehashes.db"))
+	if err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+	}()
+
+	files := map[string]string{"a.go": "aaa"}
+	version, err := store.StageState(context.Background(), "embeddinggemma", "scan-v1", files)
+	if err != nil {
+		t.Fatalf("StageState() error: %v", err)
+	}
+	if err := store.ActivateState(context.Background(), "embeddinggemma", version); err != nil {
+		t.Fatalf("ActivateState() error: %v", err)
+	}
+
+	cases := []struct {
+		name          string
+		resolvedDB    string
+		dbWasExplicit bool
+		manifest      semsearch.Manifest
+	}{
+		{
+			name:          "explicit db",
+			resolvedDB:    defaultDBPath,
+			dbWasExplicit: true,
+			manifest:      semsearch.Manifest{Version: 7, Source: "local"},
+		},
+		{
+			name:          "remote binding",
+			resolvedDB:    defaultDBPath,
+			dbWasExplicit: false,
+			manifest: semsearch.Manifest{
+				Version: 7,
+				Source:  "remote",
+				Remote:  &semsearch.Remote{CIURL: "https://github.com/acme/widgets/actions/workflows/searcher.yml"},
+			},
+		},
+		{
+			name:          "custom db path",
+			resolvedDB:    filepath.Join(localDir, "custom.db"),
+			dbWasExplicit: false,
+			manifest:      semsearch.Manifest{Version: 7, Source: "local"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.resolvedDB != defaultDBPath {
+				if err := writeStubFile(tc.resolvedDB); err != nil {
+					t.Fatalf("write custom db: %v", err)
+				}
+			}
+			skipped, err := maybeSkipUnchangedIndex(
+				context.Background(),
+				semsearch.Paths{LocalDir: localDir},
+				tc.resolvedDB,
+				tc.dbWasExplicit,
+				tc.manifest,
+				store,
+				"embeddinggemma",
+				"scan-v1",
+				files,
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("maybeSkipUnchangedIndex() error: %v", err)
+			}
+			if skipped {
+				t.Fatalf("maybeSkipUnchangedIndex() = true, want false")
+			}
+		})
+	}
+}
+
+func writeStubFile(path string) error {
+	return os.WriteFile(path, []byte("stub"), 0o644)
+}

--- a/internal/filehashdb/driver_cgo.go
+++ b/internal/filehashdb/driver_cgo.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package filehashdb
+
+import _ "github.com/mattn/go-sqlite3"

--- a/internal/filehashdb/driver_windows.go
+++ b/internal/filehashdb/driver_windows.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package filehashdb
+
+import _ "github.com/ncruces/go-sqlite3/driver"

--- a/internal/filehashdb/sqlite.go
+++ b/internal/filehashdb/sqlite.go
@@ -1,0 +1,335 @@
+package filehashdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+const SchemaVersion = 2
+
+type Store struct {
+	db *sql.DB
+}
+
+type State struct {
+	Version            int64
+	ModelID            string
+	ScannerFingerprint string
+	Files              map[string]string
+}
+
+func Open(ctx context.Context, dbPath string) (*Store, error) {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create db dir: %w", err)
+	}
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping db: %w", err)
+	}
+
+	store := &Store{db: db}
+	if err := store.init(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("init db: %w", err)
+	}
+	return store, nil
+}
+
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+func (s *Store) init(ctx context.Context) error {
+	var userVersion int
+	if err := s.db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&userVersion); err != nil {
+		return fmt.Errorf("read schema version: %w", err)
+	}
+
+	switch userVersion {
+	case 0, SchemaVersion:
+	case 1:
+		if err := s.resetSchema(ctx); err != nil {
+			return fmt.Errorf("reset legacy schema: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported schema version %d", userVersion)
+	}
+
+	stmts := []string{
+		`
+		CREATE TABLE IF NOT EXISTS file_hash_states (
+			state_version INTEGER PRIMARY KEY AUTOINCREMENT,
+			model_id TEXT NOT NULL,
+			scanner_fingerprint TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		`,
+		`
+		CREATE INDEX IF NOT EXISTS idx_file_hash_states_model_id
+		ON file_hash_states(model_id, state_version);
+		`,
+		`
+		CREATE TABLE IF NOT EXISTS current_model_states (
+			model_id TEXT PRIMARY KEY,
+			state_version INTEGER NOT NULL
+		);
+		`,
+		`
+		CREATE TABLE IF NOT EXISTS file_hashes (
+			state_version INTEGER NOT NULL,
+			path TEXT NOT NULL,
+			content_hash TEXT NOT NULL,
+			PRIMARY KEY (state_version, path)
+		);
+		`,
+		`
+		CREATE INDEX IF NOT EXISTS idx_file_hashes_state_version
+		ON file_hashes(state_version);
+		`,
+		fmt.Sprintf(`PRAGMA user_version = %d`, SchemaVersion),
+	}
+
+	for _, stmt := range stmts {
+		if _, err := s.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("exec schema: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) resetSchema(ctx context.Context) error {
+	stmts := []string{
+		`DROP TABLE IF EXISTS current_model_states;`,
+		`DROP TABLE IF EXISTS file_hash_states;`,
+		`DROP TABLE IF EXISTS state_meta;`,
+		`DROP TABLE IF EXISTS file_hashes;`,
+		`PRAGMA user_version = 0`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.db.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) Current(ctx context.Context, modelID string) (State, bool, error) {
+	var state State
+	state.ModelID = modelID
+
+	err := s.db.QueryRowContext(
+		ctx,
+		`SELECT fs.scanner_fingerprint, fs.state_version
+		 FROM current_model_states cms
+		 JOIN file_hash_states fs
+		   ON fs.state_version = cms.state_version
+		 WHERE cms.model_id = ? AND fs.model_id = ?`,
+		modelID,
+		modelID,
+	).Scan(&state.ScannerFingerprint, &state.Version)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return State{}, false, nil
+		}
+		return State{}, false, fmt.Errorf("select current state: %w", err)
+	}
+
+	rows, err := s.db.QueryContext(
+		ctx,
+		`SELECT path, content_hash FROM file_hashes WHERE state_version = ? ORDER BY path`,
+		state.Version,
+	)
+	if err != nil {
+		return State{}, false, fmt.Errorf("select file hashes: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	state.Files = make(map[string]string)
+	for rows.Next() {
+		var path string
+		var contentHash string
+		if err := rows.Scan(&path, &contentHash); err != nil {
+			return State{}, false, fmt.Errorf("scan file hash row: %w", err)
+		}
+		state.Files[path] = contentHash
+	}
+	if err := rows.Err(); err != nil {
+		return State{}, false, fmt.Errorf("iterate file hash rows: %w", err)
+	}
+
+	return state, true, nil
+}
+
+func (s *Store) Matches(ctx context.Context, modelID string, scannerFingerprint string, files map[string]string) (bool, int64, error) {
+	state, ok, err := s.Current(ctx, modelID)
+	if err != nil {
+		return false, 0, err
+	}
+	if !ok {
+		return false, 0, nil
+	}
+	if state.ScannerFingerprint != scannerFingerprint {
+		return false, state.Version, nil
+	}
+	if len(state.Files) != len(files) {
+		return false, state.Version, nil
+	}
+	for path, contentHash := range files {
+		if state.Files[path] != contentHash {
+			return false, state.Version, nil
+		}
+	}
+	return true, state.Version, nil
+}
+
+func (s *Store) BeginState(ctx context.Context, modelID string, scannerFingerprint string) (int64, error) {
+	result, err := s.db.ExecContext(
+		ctx,
+		`INSERT INTO file_hash_states(model_id, scanner_fingerprint) VALUES (?, ?)`,
+		modelID,
+		scannerFingerprint,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("insert state: %w", err)
+	}
+
+	stateVersion, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("read state version: %w", err)
+	}
+	return stateVersion, nil
+}
+
+func (s *Store) InsertFileHash(ctx context.Context, stateVersion int64, path string, contentHash string) error {
+	_, err := s.db.ExecContext(
+		ctx,
+		`INSERT INTO file_hashes(state_version, path, content_hash) VALUES (?, ?, ?)`,
+		stateVersion,
+		path,
+		contentHash,
+	)
+	if err != nil {
+		return fmt.Errorf("insert file hash for %s: %w", path, err)
+	}
+	return nil
+}
+
+func (s *Store) StageState(ctx context.Context, modelID string, scannerFingerprint string, files map[string]string) (int64, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	result, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO file_hash_states(model_id, scanner_fingerprint) VALUES (?, ?)`,
+		modelID,
+		scannerFingerprint,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("insert state: %w", err)
+	}
+
+	stateVersion, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("read state version: %w", err)
+	}
+
+	paths := make([]string, 0, len(files))
+	for path := range files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	stmt, err := tx.PrepareContext(
+		ctx,
+		`INSERT INTO file_hashes(state_version, path, content_hash) VALUES (?, ?, ?)`,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("prepare file hash insert: %w", err)
+	}
+	defer func() {
+		_ = stmt.Close()
+	}()
+
+	for _, path := range paths {
+		if _, err := stmt.ExecContext(ctx, stateVersion, path, files[path]); err != nil {
+			return 0, fmt.Errorf("insert file hash for %s: %w", path, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit tx: %w", err)
+	}
+
+	return stateVersion, nil
+}
+
+func (s *Store) ActivateState(ctx context.Context, modelID string, stateVersion int64) error {
+	var storedModelID string
+	err := s.db.QueryRowContext(
+		ctx,
+		`SELECT model_id FROM file_hash_states WHERE state_version = ?`,
+		stateVersion,
+	).Scan(&storedModelID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("unknown state version %d", stateVersion)
+		}
+		return fmt.Errorf("select staged state: %w", err)
+	}
+	if storedModelID != modelID {
+		return fmt.Errorf("state version %d belongs to model %q, not %q", stateVersion, storedModelID, modelID)
+	}
+
+	if _, err := s.db.ExecContext(
+		ctx,
+		`INSERT INTO current_model_states(model_id, state_version)
+		 VALUES (?, ?)
+		 ON CONFLICT(model_id) DO UPDATE SET state_version = excluded.state_version`,
+		modelID,
+		stateVersion,
+	); err != nil {
+		return fmt.Errorf("activate state: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Store) CleanupInactiveStates(ctx context.Context) error {
+	if _, err := s.db.ExecContext(
+		ctx,
+		`DELETE FROM file_hashes
+		 WHERE state_version NOT IN (SELECT state_version FROM current_model_states)`,
+	); err != nil {
+		return fmt.Errorf("delete inactive file hashes: %w", err)
+	}
+	if _, err := s.db.ExecContext(
+		ctx,
+		`DELETE FROM file_hash_states
+		 WHERE state_version NOT IN (SELECT state_version FROM current_model_states)`,
+	); err != nil {
+		return fmt.Errorf("delete inactive states: %w", err)
+	}
+	return nil
+}

--- a/internal/filehashdb/sqlite_test.go
+++ b/internal/filehashdb/sqlite_test.go
@@ -1,0 +1,198 @@
+package filehashdb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestStoreStageActivateAndCurrent(t *testing.T) {
+	t.Parallel()
+
+	store, err := Open(context.Background(), filepath.Join(t.TempDir(), "filehashes.db"))
+	if err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+	}()
+
+	version, err := store.StageState(context.Background(), "embeddinggemma", "scan-v1", map[string]string{
+		"a.go": "aaa",
+		"b.go": "bbb",
+	})
+	if err != nil {
+		t.Fatalf("StageState() error: %v", err)
+	}
+	if version != 1 {
+		t.Fatalf("StageState() version = %d, want 1", version)
+	}
+
+	if _, ok, err := store.Current(context.Background(), "embeddinggemma"); err != nil {
+		t.Fatalf("Current(before activate) error: %v", err)
+	} else if ok {
+		t.Fatalf("Current(before activate) ok = true, want false")
+	}
+
+	if err := store.ActivateState(context.Background(), "embeddinggemma", version); err != nil {
+		t.Fatalf("ActivateState() error: %v", err)
+	}
+
+	state, ok, err := store.Current(context.Background(), "embeddinggemma")
+	if err != nil {
+		t.Fatalf("Current() error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Current() ok = false, want true")
+	}
+	if state.Version != 1 {
+		t.Fatalf("Current() version = %d, want 1", state.Version)
+	}
+	if state.ScannerFingerprint != "scan-v1" {
+		t.Fatalf("Current() fingerprint = %q", state.ScannerFingerprint)
+	}
+	if len(state.Files) != 2 || state.Files["a.go"] != "aaa" || state.Files["b.go"] != "bbb" {
+		t.Fatalf("Current() files = %#v", state.Files)
+	}
+}
+
+func TestStoreMatchesAndCleanupInactiveStates(t *testing.T) {
+	t.Parallel()
+
+	store, err := Open(context.Background(), filepath.Join(t.TempDir(), "filehashes.db"))
+	if err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+	}()
+
+	firstVersion, err := store.StageState(context.Background(), "embeddinggemma", "scan-v1", map[string]string{
+		"a.go": "aaa",
+	})
+	if err != nil {
+		t.Fatalf("first StageState() error: %v", err)
+	}
+	if err := store.ActivateState(context.Background(), "embeddinggemma", firstVersion); err != nil {
+		t.Fatalf("ActivateState(first) error: %v", err)
+	}
+
+	match, version, err := store.Matches(context.Background(), "embeddinggemma", "scan-v1", map[string]string{
+		"a.go": "aaa",
+	})
+	if err != nil {
+		t.Fatalf("Matches() error: %v", err)
+	}
+	if !match || version != 1 {
+		t.Fatalf("Matches() = (%v, %d), want (true, 1)", match, version)
+	}
+
+	match, version, err = store.Matches(context.Background(), "embeddinggemma", "scan-v2", map[string]string{
+		"a.go": "aaa",
+	})
+	if err != nil {
+		t.Fatalf("Matches(fingerprint mismatch) error: %v", err)
+	}
+	if match || version != 1 {
+		t.Fatalf("Matches(fingerprint mismatch) = (%v, %d), want (false, 1)", match, version)
+	}
+
+	secondVersion, err := store.StageState(context.Background(), "embeddinggemma", "scan-v2", map[string]string{
+		"a.go": "aaa",
+		"b.go": "bbb",
+	})
+	if err != nil {
+		t.Fatalf("second StageState() error: %v", err)
+	}
+	if secondVersion != 2 {
+		t.Fatalf("second StageState() version = %d, want 2", secondVersion)
+	}
+
+	if err := store.ActivateState(context.Background(), "embeddinggemma", secondVersion); err != nil {
+		t.Fatalf("ActivateState(second) error: %v", err)
+	}
+	if err := store.CleanupInactiveStates(context.Background()); err != nil {
+		t.Fatalf("CleanupInactiveStates(after activate) error: %v", err)
+	}
+
+	state, ok, err := store.Current(context.Background(), "embeddinggemma")
+	if err != nil {
+		t.Fatalf("Current() error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Current() ok = false, want true")
+	}
+	if state.Version != 2 || state.ScannerFingerprint != "scan-v2" {
+		t.Fatalf("Current() = %+v", state)
+	}
+	if len(state.Files) != 2 || state.Files["b.go"] != "bbb" {
+		t.Fatalf("Current() files = %#v", state.Files)
+	}
+}
+
+func TestCleanupInactiveStatesDropsUnactivatedState(t *testing.T) {
+	t.Parallel()
+
+	store, err := Open(context.Background(), filepath.Join(t.TempDir(), "filehashes.db"))
+	if err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+	}()
+
+	firstVersion, err := store.StageState(context.Background(), "embeddinggemma", "scan-v1", map[string]string{
+		"a.go": "aaa",
+	})
+	if err != nil {
+		t.Fatalf("first StageState() error: %v", err)
+	}
+	if err := store.ActivateState(context.Background(), "embeddinggemma", firstVersion); err != nil {
+		t.Fatalf("ActivateState(first) error: %v", err)
+	}
+
+	secondVersion, err := store.StageState(context.Background(), "embeddinggemma", "scan-v2", map[string]string{
+		"a.go": "aaa",
+		"b.go": "bbb",
+	})
+	if err != nil {
+		t.Fatalf("second StageState() error: %v", err)
+	}
+
+	if err := store.CleanupInactiveStates(context.Background()); err != nil {
+		t.Fatalf("CleanupInactiveStates() error: %v", err)
+	}
+
+	if err := store.ActivateState(context.Background(), "embeddinggemma", secondVersion); err == nil {
+		t.Fatalf("ActivateState() succeeded for cleaned-up inactive state")
+	}
+
+	state, ok, err := store.Current(context.Background(), "embeddinggemma")
+	if err != nil {
+		t.Fatalf("Current() error: %v", err)
+	}
+	if !ok || state.Version != firstVersion {
+		t.Fatalf("Current() = (%+v, %v), want version %d", state, ok, firstVersion)
+	}
+}
+
+func TestActivateStateRejectsWrongModel(t *testing.T) {
+	t.Parallel()
+
+	store, err := Open(context.Background(), filepath.Join(t.TempDir(), "filehashes.db"))
+	if err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+	}()
+
+	version, err := store.StageState(context.Background(), "embeddinggemma", "scan-v1", map[string]string{"a.go": "aaa"})
+	if err != nil {
+		t.Fatalf("StageState() error: %v", err)
+	}
+
+	if err := store.ActivateState(context.Background(), "qwen3", version); err == nil {
+		t.Fatalf("ActivateState() succeeded with wrong model")
+	}
+}

--- a/internal/indexdb/sqlite.go
+++ b/internal/indexdb/sqlite.go
@@ -395,7 +395,9 @@ func (s *Store) SearchBySnapshot(ctx context.Context, modelID string, snapshotID
 	if err != nil {
 		return nil, fmt.Errorf("search query: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	results := make([]search.SearchResult, 0, limit)
 	for rows.Next() {
@@ -458,7 +460,9 @@ func (s *Store) ListSymbolsBySnapshot(ctx context.Context, modelID string, snaps
 	if err != nil {
 		return nil, fmt.Errorf("list symbols: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	var results []search.SearchResult
 	for rows.Next() {

--- a/internal/indexdb/sqlite.go
+++ b/internal/indexdb/sqlite.go
@@ -154,6 +154,18 @@ func (s *Store) CurrentSnapshot(ctx context.Context, modelID string) (int64, err
 	return snapshotID, nil
 }
 
+// CurrentSnapshotIfAny returns the active snapshot for one model family when present.
+func (s *Store) CurrentSnapshotIfAny(ctx context.Context, modelID string) (int64, bool, error) {
+	snapshotID, err := s.CurrentSnapshot(ctx, modelID)
+	if err != nil {
+		if errors.Is(err, ErrNoActiveSnapshot) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	return snapshotID, true, nil
+}
+
 // ActivateSnapshot marks one snapshot as the active searchable snapshot for its model family.
 func (s *Store) ActivateSnapshot(ctx context.Context, modelID string, snapshotID int64) error {
 	_, err := s.db.ExecContext(
@@ -252,6 +264,58 @@ func (s *Store) InsertSymbol(ctx context.Context, snapshotID int64, modelID stri
 	return nil
 }
 
+// CopyPathFromSnapshot copies all symbol rows for one path from an existing snapshot into a building snapshot.
+func (s *Store) CopyPathFromSnapshot(ctx context.Context, modelID string, srcSnapshotID, dstSnapshotID int64, path string) (int, error) {
+	result, err := s.db.ExecContext(
+		ctx,
+		`INSERT INTO snapshot_symbols(
+			snapshot_id,
+			model_id,
+			path,
+			line,
+			symbol_id,
+			symbol_kind,
+			symbol_name,
+			symbol_container,
+			qualified_name,
+			signature,
+			documentation,
+			body,
+			embedding_hash
+		)
+		SELECT
+			?,
+			model_id,
+			path,
+			line,
+			symbol_id,
+			symbol_kind,
+			symbol_name,
+			symbol_container,
+			qualified_name,
+			signature,
+			documentation,
+			body,
+			embedding_hash
+		FROM snapshot_symbols
+		WHERE model_id = ?
+		  AND snapshot_id = ?
+		  AND path = ?`,
+		dstSnapshotID,
+		modelID,
+		srcSnapshotID,
+		path,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("copy symbols for %s: %w", path, err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read copied rows for %s: %w", path, err)
+	}
+	return int(rowsAffected), nil
+}
+
 // CleanupInactiveSnapshots removes building or stale snapshots that are not active for any model family.
 func (s *Store) CleanupInactiveSnapshots(ctx context.Context) error {
 	if _, err := s.db.ExecContext(
@@ -331,9 +395,7 @@ func (s *Store) SearchBySnapshot(ctx context.Context, modelID string, snapshotID
 	if err != nil {
 		return nil, fmt.Errorf("search query: %w", err)
 	}
-	defer func() {
-		_ = rows.Close()
-	}()
+	defer rows.Close()
 
 	results := make([]search.SearchResult, 0, limit)
 	for rows.Next() {
@@ -396,9 +458,7 @@ func (s *Store) ListSymbolsBySnapshot(ctx context.Context, modelID string, snaps
 	if err != nil {
 		return nil, fmt.Errorf("list symbols: %w", err)
 	}
-	defer func() {
-		_ = rows.Close()
-	}()
+	defer rows.Close()
 
 	var results []search.SearchResult
 	for rows.Next() {

--- a/internal/indexdb/sqlite_test.go
+++ b/internal/indexdb/sqlite_test.go
@@ -18,9 +18,7 @@ func TestStoreLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open() error: %v", err)
 	}
-	defer func() {
-		_ = store.Close()
-	}()
+	defer store.Close()
 
 	const modelID = "embeddinggemma"
 
@@ -117,9 +115,7 @@ func TestActiveSnapshotIsolationAcrossModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open() error: %v", err)
 	}
-	defer func() {
-		_ = store.Close()
-	}()
+	defer store.Close()
 
 	if err := store.AddEmbedding(ctx, "embeddinggemma", "hash-gemma", []float32{1, 0, 0}); err != nil {
 		t.Fatalf("AddEmbedding(gemma) error: %v", err)
@@ -173,9 +169,7 @@ func TestLogicalHashIgnoresSnapshotOnlyChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open() error: %v", err)
 	}
-	defer func() {
-		_ = store.Close()
-	}()
+	defer store.Close()
 
 	modelID := "embeddinggemma"
 	vec := []float32{1, 0, 0}
@@ -236,9 +230,7 @@ func TestLogicalHashRejectsLegacySchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sql.Open() error: %v", err)
 	}
-	defer func() {
-		_ = db.Close()
-	}()
+	defer db.Close()
 
 	for _, stmt := range []string{
 		`CREATE TABLE comments (
@@ -266,5 +258,57 @@ func TestLogicalHashRejectsLegacySchema(t *testing.T) {
 	_, err = LogicalHash(ctx, dbPath)
 	if err == nil || !errors.Is(err, ErrIncompatibleSchema) {
 		t.Fatalf("LogicalHash() error = %v, want ErrIncompatibleSchema", err)
+	}
+}
+
+func TestCopyPathFromSnapshot(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "index.db")
+
+	store, err := Open(ctx, dbPath, 3)
+	if err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer store.Close()
+
+	modelID := "embeddinggemma"
+	if err := store.AddEmbedding(ctx, modelID, "hash-a", []float32{1, 0, 0}); err != nil {
+		t.Fatalf("AddEmbedding() error: %v", err)
+	}
+
+	srcSnapshot, err := store.BeginSnapshot(ctx, modelID)
+	if err != nil {
+		t.Fatalf("BeginSnapshot(src) error: %v", err)
+	}
+	if err := store.InsertSymbol(ctx, srcSnapshot, modelID, "a.go", indexing.IndexedSymbol{
+		Line:          10,
+		Kind:          "function",
+		Name:          "A",
+		QualifiedName: "A",
+	}, "hash-a"); err != nil {
+		t.Fatalf("InsertSymbol(src) error: %v", err)
+	}
+	if err := store.ActivateSnapshot(ctx, modelID, srcSnapshot); err != nil {
+		t.Fatalf("ActivateSnapshot(src) error: %v", err)
+	}
+
+	dstSnapshot, err := store.BeginSnapshot(ctx, modelID)
+	if err != nil {
+		t.Fatalf("BeginSnapshot(dst) error: %v", err)
+	}
+	copied, err := store.CopyPathFromSnapshot(ctx, modelID, srcSnapshot, dstSnapshot, "a.go")
+	if err != nil {
+		t.Fatalf("CopyPathFromSnapshot() error: %v", err)
+	}
+	if copied != 1 {
+		t.Fatalf("CopyPathFromSnapshot() copied = %d, want 1", copied)
+	}
+
+	listed, err := store.ListSymbolsBySnapshot(ctx, modelID, dstSnapshot)
+	if err != nil {
+		t.Fatalf("ListSymbolsBySnapshot(dst) error: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Path != "a.go" || listed[0].QualifiedName != "A" {
+		t.Fatalf("ListSymbolsBySnapshot(dst) = %+v", listed)
 	}
 }

--- a/internal/indexdb/sqlite_test.go
+++ b/internal/indexdb/sqlite_test.go
@@ -18,7 +18,9 @@ func TestStoreLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open() error: %v", err)
 	}
-	defer store.Close()
+	defer func() {
+		_ = store.Close()
+	}()
 
 	const modelID = "embeddinggemma"
 
@@ -115,7 +117,9 @@ func TestActiveSnapshotIsolationAcrossModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open() error: %v", err)
 	}
-	defer store.Close()
+	defer func() {
+		_ = store.Close()
+	}()
 
 	if err := store.AddEmbedding(ctx, "embeddinggemma", "hash-gemma", []float32{1, 0, 0}); err != nil {
 		t.Fatalf("AddEmbedding(gemma) error: %v", err)
@@ -169,7 +173,9 @@ func TestLogicalHashIgnoresSnapshotOnlyChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open() error: %v", err)
 	}
-	defer store.Close()
+	defer func() {
+		_ = store.Close()
+	}()
 
 	modelID := "embeddinggemma"
 	vec := []float32{1, 0, 0}
@@ -230,7 +236,9 @@ func TestLogicalHashRejectsLegacySchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sql.Open() error: %v", err)
 	}
-	defer db.Close()
+	defer func() {
+		_ = db.Close()
+	}()
 
 	for _, stmt := range []string{
 		`CREATE TABLE comments (
@@ -269,7 +277,9 @@ func TestCopyPathFromSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open() error: %v", err)
 	}
-	defer store.Close()
+	defer func() {
+		_ = store.Close()
+	}()
 
 	modelID := "embeddinggemma"
 	if err := store.AddEmbedding(ctx, modelID, "hash-a", []float32{1, 0, 0}); err != nil {

--- a/internal/indexing/filehash.go
+++ b/internal/indexing/filehash.go
@@ -1,0 +1,41 @@
+package indexing
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+const fileHashFingerprintVersion = "index-input-v1"
+
+func CollectFileHashes(root string, gitignorePath string, extraPatterns []string) (map[string]string, error) {
+	hashes := make(map[string]string)
+	err := walkSourceFiles(root, gitignorePath, extraPatterns, func(_ string, rel string, source []byte) error {
+		hashes[rel] = hashSourceBytes(source)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return hashes, nil
+}
+
+func BuildScannerFingerprint(commentPrefix string, contextPrefix string, excludes []string) string {
+	normalizedExcludes := append([]string(nil), excludes...)
+	sort.Strings(normalizedExcludes)
+
+	payload := strings.Join([]string{
+		fileHashFingerprintVersion,
+		strings.TrimSpace(commentPrefix),
+		strings.TrimSpace(contextPrefix),
+		strings.Join(normalizedExcludes, "\x00"),
+	}, "\x1f")
+
+	return fmt.Sprintf("%s:%016x", fileHashFingerprintVersion, xxhash.Sum64String(payload))
+}
+
+func hashSourceBytes(source []byte) string {
+	return fmt.Sprintf("%016x", xxhash.Sum64(source))
+}

--- a/internal/indexing/scanner.go
+++ b/internal/indexing/scanner.go
@@ -16,18 +16,76 @@ type FileScanner struct {
 	Root string
 }
 
+func (FileScanner) WalkFiles(root string, gitignorePath string, extraPatterns []string, visit func(path string, rel string, source []byte) error) error {
+	return walkSourceFiles(root, gitignorePath, extraPatterns, visit)
+}
+
+func (FileScanner) CollectJob(path string, rel string, source []byte, commentPrefix string, contextPrefix string) (FileJob, bool, error) {
+	symbols, err := extractSymbolsForSource(path, source, commentPrefix, contextPrefix)
+	if err != nil {
+		return FileJob{}, false, fmt.Errorf("extract symbols from %s: %w", path, err)
+	}
+	job := FileJob{
+		Path:       rel,
+		SourcePath: path,
+		Symbols:    symbols,
+	}
+	return job, len(symbols) > 0, nil
+}
+
 // CollectJobs walks the repository, applies ignore rules, extracts symbols from
 // source files, and returns only files that produced indexable output.
 func (FileScanner) CollectJobs(root string, gitignorePath string, extraPatterns []string, commentPrefix string, contextPrefix string) ([]FileJob, int, error) {
-	matcher, err := buildIgnoreMatcher(gitignorePath, extraPatterns)
-	if err != nil {
-		return nil, 0, fmt.Errorf("build ignore matcher: %w", err)
-	}
-
 	var jobs []FileJob
 	totalSymbols := 0
 
-	err = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+	err := walkSourceFiles(root, gitignorePath, extraPatterns, func(path string, rel string, source []byte) error {
+		job, ok, err := FileScanner{}.CollectJob(path, rel, source, commentPrefix, contextPrefix)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+
+		jobs = append(jobs, job)
+		totalSymbols += len(job.Symbols)
+		return nil
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return jobs, totalSymbols, nil
+}
+
+func extractSymbolsForSource(path string, source []byte, commentPrefix string, contextPrefix string) ([]IndexedSymbol, error) {
+	if symbols, ok := extractTreeSitterSymbols(path, source); ok {
+		return symbols, nil
+	}
+
+	return extractLegacySymbols(path, commentPrefix, contextPrefix)
+}
+
+func extractSymbolsForPath(path string, commentPrefix string, contextPrefix string) ([]IndexedSymbol, error) {
+	source, binary, err := readSourceFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if binary {
+		return nil, nil
+	}
+
+	return extractSymbolsForSource(path, source, commentPrefix, contextPrefix)
+}
+
+func walkSourceFiles(root string, gitignorePath string, extraPatterns []string, visit func(path string, rel string, source []byte) error) error {
+	matcher, err := buildIgnoreMatcher(gitignorePath, extraPatterns)
+	if err != nil {
+		return fmt.Errorf("build ignore matcher: %w", err)
+	}
+
+	return filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -60,43 +118,16 @@ func (FileScanner) CollectJobs(root string, gitignorePath string, extraPatterns 
 			return nil
 		}
 
-		symbols, err := extractSymbolsForPath(path, commentPrefix, contextPrefix)
+		source, binary, err := readSourceFile(path)
 		if err != nil {
-			return fmt.Errorf("extract symbols from %s: %w", path, err)
+			return err
 		}
-		if len(symbols) == 0 {
+		if binary {
 			return nil
 		}
 
-		jobs = append(jobs, FileJob{
-			Path:       rel,
-			SourcePath: path,
-			Symbols:    symbols,
-		})
-		totalSymbols += len(symbols)
-		return nil
+		return visit(path, rel, source)
 	})
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return jobs, totalSymbols, nil
-}
-
-func extractSymbolsForPath(path string, commentPrefix string, contextPrefix string) ([]IndexedSymbol, error) {
-	source, binary, err := readSourceFile(path)
-	if err != nil {
-		return nil, err
-	}
-	if binary {
-		return nil, nil
-	}
-
-	if symbols, ok := extractTreeSitterSymbols(path, source); ok {
-		return symbols, nil
-	}
-
-	return extractLegacySymbols(path, commentPrefix, contextPrefix)
 }
 
 func readSourceFile(path string) ([]byte, bool, error) {

--- a/internal/indexing/scanner_io_test.go
+++ b/internal/indexing/scanner_io_test.go
@@ -118,6 +118,77 @@ func TestCollectJobsSkipsNoiseAndRespectsGitignore(t *testing.T) {
 	}
 }
 
+func TestCollectFileHashesSkipsNoiseAndRespectsGitignore(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("ignored.go\n"), 0o644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".semsearch"), 0o755); err != nil {
+		t.Fatalf("mkdir .semsearch: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+
+	files := map[string]string{
+		"keep.go":      "package demo\n\nfunc Keep() {}\n",
+		"ignored.go":   "package demo\n\nfunc Ignored() {}\n",
+		"README.md":    "# ignored readme\n",
+		"notes.txt":    "plain text note\n",
+		".semsearch/a": "ignored local state\n",
+	}
+	for rel, content := range files {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir parent for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	hashes, err := CollectFileHashes(root, filepath.Join(root, ".gitignore"), nil)
+	if err != nil {
+		t.Fatalf("CollectFileHashes() error: %v", err)
+	}
+
+	if _, ok := hashes["ignored.go"]; ok {
+		t.Fatalf("ignored.go should be skipped, got hashes=%#v", hashes)
+	}
+	if _, ok := hashes["README.md"]; ok {
+		t.Fatalf("README.md should be skipped, got hashes=%#v", hashes)
+	}
+	if _, ok := hashes[".semsearch/a"]; ok {
+		t.Fatalf(".semsearch entries should be skipped, got hashes=%#v", hashes)
+	}
+	if hashes["keep.go"] == "" {
+		t.Fatalf("keep.go hash missing: %#v", hashes)
+	}
+	if hashes["notes.txt"] == "" {
+		t.Fatalf("notes.txt hash missing: %#v", hashes)
+	}
+	if hashes[".gitignore"] == "" {
+		t.Fatalf(".gitignore hash missing: %#v", hashes)
+	}
+}
+
+func TestBuildScannerFingerprintStableAcrossExcludeOrder(t *testing.T) {
+	t.Parallel()
+
+	a := BuildScannerFingerprint("@search:", "@filectx:", []string{"dist", "node_modules"})
+	b := BuildScannerFingerprint("@search:", "@filectx:", []string{"node_modules", "dist"})
+	c := BuildScannerFingerprint("@search", "@filectx:", []string{"node_modules", "dist"})
+
+	if a != b {
+		t.Fatalf("fingerprints should match across exclude order: %q != %q", a, b)
+	}
+	if a == c {
+		t.Fatalf("fingerprints should differ when scanner inputs change: %q == %q", a, c)
+	}
+}
+
 func TestLooksLikeBinaryFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/indexing/service.go
+++ b/internal/indexing/service.go
@@ -11,17 +11,24 @@ type Reporter interface {
 }
 
 type Scanner interface {
-	CollectJobs(root string, gitignorePath string, extraPatterns []string, commentPrefix string, contextPrefix string) ([]FileJob, int, error)
+	WalkFiles(root string, gitignorePath string, extraPatterns []string, visit func(path string, rel string, source []byte) error) error
+	CollectJob(path string, rel string, source []byte, commentPrefix string, contextPrefix string) (FileJob, bool, error)
 }
 
 type Repository interface {
 	BeginSnapshot(ctx context.Context, modelID string) (int64, error)
+	CurrentSnapshotIfAny(ctx context.Context, modelID string) (int64, bool, error)
 	ActivateSnapshot(ctx context.Context, modelID string, snapshotID int64) error
 	EmbeddingExists(ctx context.Context, modelID string, embeddingHash string) (bool, error)
 	AddEmbedding(ctx context.Context, modelID string, embeddingHash string, embedding []float32) error
 	InsertSymbol(ctx context.Context, snapshotID int64, modelID string, path string, symbol IndexedSymbol, embeddingHash string) error
+	CopyPathFromSnapshot(ctx context.Context, modelID string, srcSnapshotID, dstSnapshotID int64, path string) (int, error)
 	CleanupInactiveSnapshots(ctx context.Context) error
 	CleanupUnusedEmbeddings(ctx context.Context) error
+}
+
+type FileHashStore interface {
+	InsertFileHash(ctx context.Context, stateVersion int64, path string, contentHash string) error
 }
 
 type Embedder interface {
@@ -30,12 +37,15 @@ type Embedder interface {
 }
 
 type Params struct {
-	Root          string
-	GitignorePath string
-	Excludes      []string
-	ContextPrefix string
-	CommentPrefix string
-	ModelID       string
+	Root                 string
+	GitignorePath        string
+	Excludes             []string
+	ContextPrefix        string
+	CommentPrefix        string
+	ModelID              string
+	CurrentFileHashes    map[string]string
+	NextFileHashes       map[string]string
+	FileHashStateVersion int64
 }
 
 type Result struct {
@@ -48,28 +58,19 @@ type Service struct {
 	Scanner  Scanner
 	Repo     Repository
 	Embedder Embedder
+	Hashes   FileHashStore
 }
 
 // Run scans the repository, embeds extracted symbols, and activates the new index version.
 func (s Service) Run(ctx context.Context, params Params, reporter Reporter) (Result, error) {
-	jobs, totalSymbols, err := s.Scanner.CollectJobs(
-		params.Root,
-		params.GitignorePath,
-		params.Excludes,
-		params.CommentPrefix,
-		params.ContextPrefix,
-	)
-	if err != nil {
-		return Result{}, fmt.Errorf("collect jobs: %w", err)
-	}
-	if reporter != nil {
-		reporter.Logf("files to index=%d", len(jobs))
-		reporter.Logf("symbols to index=%d", totalSymbols)
-	}
-
 	modelID := params.ModelID
 	if modelID == "" {
 		modelID = "embeddinggemma"
+	}
+
+	currentSnapshotID, hasCurrentSnapshot, err := s.Repo.CurrentSnapshotIfAny(ctx, modelID)
+	if err != nil {
+		return Result{}, fmt.Errorf("read current snapshot: %w", err)
 	}
 
 	snapshotID, err := s.Repo.BeginSnapshot(ctx, modelID)
@@ -81,12 +82,61 @@ func (s Service) Run(ctx context.Context, params Params, reporter Reporter) (Res
 		reporter.Logf("snapshot id=%d", snapshotID)
 	}
 
-	processed := 0
-	for _, job := range jobs {
+	totalFiles := len(params.NextFileHashes)
+	if totalFiles == 0 && params.Root != "" {
+		totalFiles = 1
+	}
+
+	reusedFiles := 0
+	reusedSymbols := 0
+	result := Result{Version: snapshotID}
+	processedFiles := 0
+
+	err = s.Scanner.WalkFiles(params.Root, params.GitignorePath, params.Excludes, func(path string, rel string, source []byte) error {
 		select {
 		case <-ctx.Done():
-			return Result{}, ctx.Err()
+			return ctx.Err()
 		default:
+		}
+
+		contentHash, ok := params.NextFileHashes[rel]
+		if !ok {
+			contentHash = hashSourceBytes(source)
+		}
+		if s.Hashes != nil && params.FileHashStateVersion > 0 {
+			if err := s.Hashes.InsertFileHash(ctx, params.FileHashStateVersion, rel, contentHash); err != nil {
+				return fmt.Errorf("insert file hash for %s: %w", rel, err)
+			}
+		}
+
+		if hasCurrentSnapshot && params.CurrentFileHashes[rel] == contentHash {
+			copiedSymbols, err := s.Repo.CopyPathFromSnapshot(ctx, modelID, currentSnapshotID, snapshotID, rel)
+			if err != nil {
+				return fmt.Errorf("copy unchanged file %s: %w", rel, err)
+			}
+			if copiedSymbols > 0 {
+				reusedFiles++
+				reusedSymbols += copiedSymbols
+				result.IndexedFiles++
+				result.IndexedSymbols += copiedSymbols
+			}
+			processedFiles++
+			if reporter != nil {
+				reporter.CountProgress("Indexing", processedFiles, totalFiles)
+			}
+			return nil
+		}
+
+		job, ok, err := s.Scanner.CollectJob(path, rel, source, params.CommentPrefix, params.ContextPrefix)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			processedFiles++
+			if reporter != nil {
+				reporter.CountProgress("Indexing", processedFiles, totalFiles)
+			}
+			return nil
 		}
 
 		for _, symbol := range job.Symbols {
@@ -94,27 +144,33 @@ func (s Service) Run(ctx context.Context, params Params, reporter Reporter) (Res
 
 			exists, err := s.Repo.EmbeddingExists(ctx, modelID, hash)
 			if err != nil {
-				return Result{}, fmt.Errorf("check embedding exists: %w", err)
+				return fmt.Errorf("check embedding exists: %w", err)
 			}
 			if !exists {
 				vec, err := s.Embedder.EmbedIndexedSymbol(job.Path, symbol)
 				if err != nil {
-					return Result{}, fmt.Errorf("embed symbol at %s:%d: %w", job.Path, symbol.Line, err)
+					return fmt.Errorf("embed symbol at %s:%d: %w", job.Path, symbol.Line, err)
 				}
 				if err := s.Repo.AddEmbedding(ctx, modelID, hash, vec); err != nil {
-					return Result{}, fmt.Errorf("store embedding: %w", err)
+					return fmt.Errorf("store embedding: %w", err)
 				}
 			}
 
 			if err := s.Repo.InsertSymbol(ctx, snapshotID, modelID, job.Path, symbol, hash); err != nil {
-				return Result{}, fmt.Errorf("insert symbol: %w", err)
+				return fmt.Errorf("insert symbol: %w", err)
 			}
 		}
 
-		processed += len(job.Symbols)
+		result.IndexedFiles++
+		result.IndexedSymbols += len(job.Symbols)
+		processedFiles++
 		if reporter != nil {
-			reporter.CountProgress("Indexing", processed, totalSymbols)
+			reporter.CountProgress("Indexing", processedFiles, totalFiles)
 		}
+		return nil
+	})
+	if err != nil {
+		return Result{}, err
 	}
 
 	if err := s.Repo.ActivateSnapshot(ctx, modelID, snapshotID); err != nil {
@@ -127,12 +183,10 @@ func (s Service) Run(ctx context.Context, params Params, reporter Reporter) (Res
 		return Result{}, fmt.Errorf("cleanup unused embeddings: %w", err)
 	}
 	if reporter != nil {
+		reporter.Logf("reused files=%d", reusedFiles)
+		reporter.Logf("reused symbols=%d", reusedSymbols)
 		reporter.Logf("indexing completed")
 	}
 
-	return Result{
-		Version:        snapshotID,
-		IndexedFiles:   len(jobs),
-		IndexedSymbols: totalSymbols,
-	}, nil
+	return result, nil
 }

--- a/internal/indexing/service_test.go
+++ b/internal/indexing/service_test.go
@@ -9,27 +9,46 @@ type testScanner struct {
 	jobs []FileJob
 }
 
-func (s testScanner) CollectJobs(root string, gitignorePath string, extraPatterns []string, commentPrefix string, contextPrefix string) ([]FileJob, int, error) {
-	total := 0
+func (s testScanner) WalkFiles(root string, gitignorePath string, extraPatterns []string, visit func(path string, rel string, source []byte) error) error {
 	for _, job := range s.jobs {
-		total += len(job.Symbols)
+		if err := visit(job.SourcePath, job.Path, []byte(job.Path)); err != nil {
+			return err
+		}
 	}
-	return s.jobs, total, nil
+	return nil
+}
+
+func (s testScanner) CollectJob(path string, rel string, source []byte, commentPrefix string, contextPrefix string) (FileJob, bool, error) {
+	for _, job := range s.jobs {
+		if job.Path == rel {
+			return job, len(job.Symbols) > 0, nil
+		}
+	}
+	return FileJob{Path: rel, SourcePath: path}, false, nil
 }
 
 type testRepo struct {
-	snapshotID int64
-	existing   map[string]bool
-	added      []string
-	inserts    []string
-	models     []string
-	activated  int64
-	cleaned    bool
+	snapshotID        int64
+	currentSnapshotID int64
+	existing          map[string]bool
+	copyCounts        map[string]int
+	added             []string
+	inserts           []string
+	copies            []string
+	models            []string
+	activated         int64
+	cleaned           bool
 }
 
 func (r *testRepo) BeginSnapshot(ctx context.Context, modelID string) (int64, error) {
 	r.models = append(r.models, modelID)
 	return r.snapshotID, nil
+}
+func (r *testRepo) CurrentSnapshotIfAny(ctx context.Context, modelID string) (int64, bool, error) {
+	if r.currentSnapshotID == 0 {
+		return 0, false, nil
+	}
+	return r.currentSnapshotID, true, nil
 }
 func (r *testRepo) ActivateSnapshot(ctx context.Context, modelID string, snapshotID int64) error {
 	r.models = append(r.models, modelID)
@@ -47,11 +66,30 @@ func (r *testRepo) InsertSymbol(ctx context.Context, snapshotID int64, modelID s
 	r.inserts = append(r.inserts, path)
 	return nil
 }
+func (r *testRepo) CopyPathFromSnapshot(ctx context.Context, modelID string, srcSnapshotID, dstSnapshotID int64, path string) (int, error) {
+	r.copies = append(r.copies, path)
+	if r.copyCounts != nil {
+		return r.copyCounts[path], nil
+	}
+	return 0, nil
+}
 func (r *testRepo) CleanupInactiveSnapshots(ctx context.Context) error {
 	r.cleaned = true
 	return nil
 }
 func (r *testRepo) CleanupUnusedEmbeddings(ctx context.Context) error { return nil }
+
+type testHashStore struct {
+	inserted map[string]string
+}
+
+func (h *testHashStore) InsertFileHash(ctx context.Context, stateVersion int64, path string, contentHash string) error {
+	if h.inserted == nil {
+		h.inserted = make(map[string]string)
+	}
+	h.inserted[path] = contentHash
+	return nil
+}
 
 type testEmbedder struct {
 	hashCalls  int
@@ -97,14 +135,17 @@ func TestServiceRunIndexesComments(t *testing.T) {
 		Scanner:  scanner,
 		Repo:     repo,
 		Embedder: embedder,
+		Hashes:   &testHashStore{},
 	}
 
 	result, err := service.Run(context.Background(), Params{
-		Root:          "/tmp",
-		GitignorePath: "/tmp/.gitignore",
-		CommentPrefix: "@search:",
-		ContextPrefix: "@filectx:",
-		ModelID:       "qwen3",
+		Root:                 "/tmp",
+		GitignorePath:        "/tmp/.gitignore",
+		CommentPrefix:        "@search:",
+		ContextPrefix:        "@filectx:",
+		ModelID:              "qwen3",
+		NextFileHashes:       map[string]string{"a.go": "a.go"},
+		FileHashStateVersion: 1,
 	}, reporter)
 	if err != nil {
 		t.Fatalf("Service.Run() error: %v", err)
@@ -156,9 +197,73 @@ func TestServiceRunHonorsContextCancellation(t *testing.T) {
 		},
 		Repo:     &testRepo{snapshotID: 1, existing: map[string]bool{}},
 		Embedder: &testEmbedder{},
+		Hashes:   &testHashStore{},
 	}
 
 	if _, err := service.Run(ctx, Params{}, nil); err == nil {
 		t.Fatalf("expected context cancellation error")
+	}
+}
+
+func TestServiceRunCopiesUnchangedFilesFromCurrentSnapshot(t *testing.T) {
+	t.Parallel()
+
+	scanner := testScanner{
+		jobs: []FileJob{
+			{Path: "a.go", SourcePath: "/tmp/a.go", Symbols: []IndexedSymbol{
+				{Line: 1, Kind: "function", Name: "A", QualifiedName: "A"},
+			}},
+			{Path: "b.go", SourcePath: "/tmp/b.go", Symbols: []IndexedSymbol{
+				{Line: 2, Kind: "function", Name: "B", QualifiedName: "B"},
+			}},
+		},
+	}
+	repo := &testRepo{
+		snapshotID:        8,
+		currentSnapshotID: 3,
+		existing:          map[string]bool{"b.go:B": true},
+		copyCounts:        map[string]int{"a.go": 1},
+	}
+	hashes := &testHashStore{}
+	embedder := &testEmbedder{}
+
+	service := Service{
+		Scanner:  scanner,
+		Repo:     repo,
+		Embedder: embedder,
+		Hashes:   hashes,
+	}
+
+	result, err := service.Run(context.Background(), Params{
+		Root:                 "/tmp",
+		GitignorePath:        "/tmp/.gitignore",
+		CommentPrefix:        "@search:",
+		ContextPrefix:        "@filectx:",
+		ModelID:              "embeddinggemma",
+		CurrentFileHashes:    map[string]string{"a.go": "a.go", "b.go": "old"},
+		NextFileHashes:       map[string]string{"a.go": "a.go", "b.go": "b.go"},
+		FileHashStateVersion: 2,
+	}, &testReporter{})
+	if err != nil {
+		t.Fatalf("Service.Run() error: %v", err)
+	}
+
+	if result.Version != 8 {
+		t.Fatalf("Service.Run().Version = %d, want 8", result.Version)
+	}
+	if result.IndexedFiles != 2 || result.IndexedSymbols != 2 {
+		t.Fatalf("Service.Run() result = %+v", result)
+	}
+	if len(repo.copies) != 1 || repo.copies[0] != "a.go" {
+		t.Fatalf("expected a.go to be copied, got %v", repo.copies)
+	}
+	if len(repo.inserts) != 1 || repo.inserts[0] != "b.go" {
+		t.Fatalf("expected only b.go to be reinserted, got %v", repo.inserts)
+	}
+	if embedder.embedCalls != 0 {
+		t.Fatalf("expected embedding reuse for b.go, got %d embed calls", embedder.embedCalls)
+	}
+	if hashes.inserted["a.go"] == "" || hashes.inserted["b.go"] == "" {
+		t.Fatalf("expected per-file hashes to be inserted, got %#v", hashes.inserted)
 	}
 }

--- a/internal/semsearch/paths.go
+++ b/internal/semsearch/paths.go
@@ -11,6 +11,7 @@ import (
 type Paths struct {
 	LocalDir     string
 	ManifestPath string
+	FileHashDB   string
 	ModelsDir    string
 }
 
@@ -34,6 +35,7 @@ func PreparePaths(root string) (Paths, error) {
 	return Paths{
 		LocalDir:     localDir,
 		ManifestPath: ManifestFilePath(localDir),
+		FileHashDB:   filepath.Join(localDir, "filehashes.db"),
 		ModelsDir:    modelsDir,
 	}, nil
 }


### PR DESCRIPTION
## Summary
- add `internal/filehashdb` to persist per-file content hashes in a dedicated local `filehashes.db`
- skip `unch index` entirely when the local inputs and scanner settings are unchanged
- reuse unchanged file symbols from the current snapshot so partial re-indexes only process changed files
- add coverage for `filehashdb`, hash-state matching, snapshot copying, and CLI skip behavior

## Why
Repeated local indexing still rebuilt the snapshot from scratch even when the repo contents were unchanged. That made `unch index` do unnecessary work and reprocess files that already had a valid active snapshot.

## Root Cause
The indexing flow only tracked snapshot/version state and embedding reuse. It did not persist per-file content hashes or a scanner fingerprint, so it had no reliable way to detect identical inputs or carry forward unchanged symbol rows into the next snapshot.

## Implementation
This change introduces `internal/filehashdb` for local file-hash state, wires it into the CLI indexing flow, and teaches the indexing service to reuse symbols from the current snapshot for unchanged files.

## Impact
Local re-index runs can now return early when nothing changed, and incremental runs reuse unchanged files instead of re-embedding or reinserting them. This keeps the active local index behavior the same while reducing needless indexing work.

## Validation
- `go test ./...`
- `GOOS=windows go build ./internal/filehashdb`
- `GOOS=windows go build ./...` still fails on existing tree-sitter package build constraints unrelated to this change
