### PR TITLE
release: v0.3.4

### DIFF
--- a/.github/releases/v0.3.4.md
+++ b/.github/releases/v0.3.4.md
@@ -1,0 +1,14 @@
+# unch v0.3.4
+
+`v0.3.4` is a follow-up patch release for `v0.3.3`. It keeps the `v0.3.x` search and indexing behavior intact while fixing the benchmark path that runs during tag CI and release validation.
+
+## Highlights
+
+- teaches the benchmark adapter to treat `Index already up to date` as a successful warm-index result
+- preserves the latest indexed symbol and file counts in benchmark summaries when warm runs skip unchanged repositories
+- adds regression coverage for the new benchmark summary parsing and snapshot fallback behavior
+
+## Upgrade notes
+
+- no index rebuild is required when upgrading from `v0.3.3`
+- no installer changes are required for existing macOS, Linux, or Windows x86_64 setups

--- a/internal/bench/runner.go
+++ b/internal/bench/runner.go
@@ -166,7 +166,7 @@ func benchmarkRepository(ctx context.Context, adapter Adapter, repo CheckedOutRe
 		QueryCount: len(repo.Case.Queries),
 		ModeCounts: RepositoryModeCounts(repo.Case.Queries),
 	}
-	if latestIndexRun, ok := LatestIndexRun(report); ok {
+	if latestIndexRun, ok := LatestIndexedSnapshot(report); ok {
 		report.Stats.LastIndexedSymbols = latestIndexRun.IndexedSymbols
 		report.Stats.LastIndexedFiles = latestIndexRun.IndexedFiles
 	}

--- a/internal/bench/stats.go
+++ b/internal/bench/stats.go
@@ -68,6 +68,22 @@ func LatestIndexRun(report RepositoryReport) (IndexRunReport, bool) {
 	return IndexRunReport{}, false
 }
 
+func LatestIndexedSnapshot(report RepositoryReport) (IndexRunReport, bool) {
+	for i := len(report.WarmIndexRuns) - 1; i >= 0; i-- {
+		run := report.WarmIndexRuns[i]
+		if run.IndexedSymbols > 0 || run.IndexedFiles > 0 {
+			return run, true
+		}
+	}
+	for i := len(report.ColdIndexRuns) - 1; i >= 0; i-- {
+		run := report.ColdIndexRuns[i]
+		if run.IndexedSymbols > 0 || run.IndexedFiles > 0 {
+			return run, true
+		}
+	}
+	return LatestIndexRun(report)
+}
+
 func FormatModeCounts(counts map[string]int) string {
 	if len(counts) == 0 {
 		return "none"

--- a/internal/bench/stats_test.go
+++ b/internal/bench/stats_test.go
@@ -1,0 +1,24 @@
+package bench
+
+import "testing"
+
+func TestLatestIndexedSnapshotFallsBackToLastCountedRun(t *testing.T) {
+	t.Parallel()
+
+	report := RepositoryReport{
+		ColdIndexRuns: []IndexRunReport{
+			{Summary: "Indexed 278 symbols in 16 files", IndexedSymbols: 278, IndexedFiles: 16},
+		},
+		WarmIndexRuns: []IndexRunReport{
+			{Summary: indexUpToDateSummary},
+		},
+	}
+
+	latest, ok := LatestIndexedSnapshot(report)
+	if !ok {
+		t.Fatal("LatestIndexedSnapshot() ok = false")
+	}
+	if latest.IndexedSymbols != 278 || latest.IndexedFiles != 16 {
+		t.Fatalf("LatestIndexedSnapshot() = %+v", latest)
+	}
+}

--- a/internal/bench/unch_adapter.go
+++ b/internal/bench/unch_adapter.go
@@ -21,6 +21,8 @@ var (
 	indexSummaryPattern = regexp.MustCompile(`Indexed\s+(\d+)\s+symbols\s+in\s+(\d+)\s+files`)
 )
 
+const indexUpToDateSummary = "Index already up to date"
+
 type UnchAdapter struct {
 	binaryPath string
 	version    string
@@ -246,20 +248,24 @@ func parseSearchHits(stdout string, combined string) ([]SearchHit, error) {
 
 func parseIndexSummary(output string) (string, int, int, error) {
 	match := indexSummaryPattern.FindStringSubmatch(output)
-	if len(match) != 3 {
-		return "", 0, 0, fmt.Errorf("indexed summary not found in output")
+	if len(match) == 3 {
+		indexedSymbols, err := strconv.Atoi(match[1])
+		if err != nil {
+			return "", 0, 0, fmt.Errorf("parse indexed symbols %q: %w", match[1], err)
+		}
+		indexedFiles, err := strconv.Atoi(match[2])
+		if err != nil {
+			return "", 0, 0, fmt.Errorf("parse indexed files %q: %w", match[2], err)
+		}
+
+		return match[0], indexedSymbols, indexedFiles, nil
 	}
 
-	indexedSymbols, err := strconv.Atoi(match[1])
-	if err != nil {
-		return "", 0, 0, fmt.Errorf("parse indexed symbols %q: %w", match[1], err)
-	}
-	indexedFiles, err := strconv.Atoi(match[2])
-	if err != nil {
-		return "", 0, 0, fmt.Errorf("parse indexed files %q: %w", match[2], err)
+	if strings.Contains(output, indexUpToDateSummary) {
+		return indexUpToDateSummary, 0, 0, nil
 	}
 
-	return match[0], indexedSymbols, indexedFiles, nil
+	return "", 0, 0, fmt.Errorf("indexed summary not found in output")
 }
 
 func writeWarmupProgram(root string) error {

--- a/internal/bench/unch_adapter_test.go
+++ b/internal/bench/unch_adapter_test.go
@@ -44,3 +44,18 @@ func TestParseIndexSummary(t *testing.T) {
 		t.Fatalf("parseIndexSummary() = (%d, %d)", indexedSymbols, indexedFiles)
 	}
 }
+
+func TestParseIndexSummaryUpToDate(t *testing.T) {
+	t.Parallel()
+
+	summary, indexedSymbols, indexedFiles, err := parseIndexSummary("Loaded model dim=768\nIndex already up to date\n")
+	if err != nil {
+		t.Fatalf("parseIndexSummary() error: %v", err)
+	}
+	if summary != indexUpToDateSummary {
+		t.Fatalf("parseIndexSummary() summary = %q", summary)
+	}
+	if indexedSymbols != 0 || indexedFiles != 0 {
+		t.Fatalf("parseIndexSummary() = (%d, %d)", indexedSymbols, indexedFiles)
+	}
+}


### PR DESCRIPTION
## Summary
- include the benchmark CI fix for warm index runs that report "Index already up to date"
- preserve the latest indexed symbol/file counts in benchmark summaries when warm runs skip unchanged repositories
- add v0.3.4 release notes for the follow-up patch release

## Verification
- go test ./...
- smoke benchmark path already re-run locally on the same fix commit before cutting this release branch