### PR TITLE
docs: restore v0.3.3 release notes in main

### DIFF
--- a/.github/releases/v0.3.3.md
+++ b/.github/releases/v0.3.3.md
@@ -1,0 +1,22 @@
+# unch v0.3.3
+
+> Deprecated release. `v0.3.3` is kept for historical reference and is superseded by `v0.3.4`.
+>
+> Known issue: the tag CI benchmark suite fails for this version because warm index runs can report `Index already up to date`, which was fixed in `v0.3.4`.
+>
+> Recommended upgrade: use `v0.3.4` for installs and automation.
+
+`v0.3.3` is a focused patch release for local indexing performance. It keeps the `v0.3.x` search and install surface stable while making repeated `unch index` runs much cheaper when the repository has not changed.
+
+## Highlights
+
+- skips local indexing entirely when the indexed files and scanner settings are unchanged
+- reuses symbols for unchanged files from the current snapshot instead of rebuilding them
+- adds a local `filehashes.db` sidecar to persist per-file hash state between index runs
+- keeps CI lint-clean with stricter `errcheck` handling in the snapshot store
+
+## Upgrade notes
+
+- no installer changes are required when upgrading from `v0.3.2`
+- existing `.semsearch/index.db` data stays compatible with this release
+- the next local `unch index` run will create `.semsearch/filehashes.db` automatically


### PR DESCRIPTION
## Summary
- restore `.github/releases/v0.3.3.md` in `main`
- keep the file aligned with the current GitHub release state for `v0.3.3`
- preserve the deprecation warning that points users to `v0.3.4`

## Why
`v0.3.3` was restored as a labeled deprecated release on GitHub, but its versioned release notes file is still missing from `main`. This PR brings the repository history back in sync with the published release metadata.

## Validation
- docs-only change
- no code or workflow files changed
