### PR TITLE
fix: follow up installer compatibility and smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,106 @@ jobs:
           .\install\install.ps1 -BinDir $binDir -Version vci-test
           & (Join-Path $binDir "unch.exe") --help | Out-Null
 
+  install-smoke-linux-distros:
+    name: install-smoke-linux (${{ matrix.label }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: ubuntu
+            image: ubuntu:24.04
+            prepare: >-
+              apt-get update &&
+              apt-get install -y --no-install-recommends ca-certificates curl gzip tar
+          - label: debian
+            image: debian:bookworm-slim
+            prepare: >-
+              apt-get update &&
+              apt-get install -y --no-install-recommends ca-certificates curl gzip tar
+          - label: arch
+            image: archlinux:latest
+            prepare: >-
+              pacman -Syu --noconfirm --needed archlinux-keyring &&
+              pacman -S --noconfirm --needed ca-certificates curl gzip tar
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build local Linux release asset
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset_dir="${RUNNER_TEMP}/release-assets"
+          mkdir -p "${asset_dir}" "${RUNNER_TEMP}/build"
+          CGO_ENABLED=1 go build -trimpath -o "${RUNNER_TEMP}/build/unch" .
+          tar -C "${RUNNER_TEMP}/build" -czf "${asset_dir}/unch_Linux_x86_64.tar.gz" unch
+
+      - name: Install from local asset inside ${{ matrix.label }} container
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/src" \
+            -v "${RUNNER_TEMP}/release-assets:/assets" \
+            -w /src \
+            "${{ matrix.image }}" sh -lc '
+              set -eu
+              '"${{ matrix.prepare }}"'
+              export UNCH_INSTALL_ASSET_DIR=/assets
+              ./install.sh -b /tmp/bin -v vci-test
+              /tmp/bin/unch --help >/dev/null
+            '
+
+  install-smoke-nix:
+    name: install-smoke-linux (nix)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build local Linux release asset
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset_dir="${RUNNER_TEMP}/release-assets"
+          mkdir -p "${asset_dir}" "${RUNNER_TEMP}/build"
+          CGO_ENABLED=1 go build -trimpath -o "${RUNNER_TEMP}/build/unch" .
+          tar -C "${RUNNER_TEMP}/build" -czf "${asset_dir}/unch_Linux_x86_64.tar.gz" unch
+
+      - name: Install from local asset inside nix container
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/src" \
+            -v "${RUNNER_TEMP}/release-assets:/assets" \
+            -w /src \
+            nixos/nix:latest sh -lc '
+              set -eu
+              nix --extra-experimental-features "nix-command flakes" \
+                shell nixpkgs#curl nixpkgs#gnutar nixpkgs#gzip nixpkgs#coreutils nixpkgs#cacert \
+                --command sh -lc "
+                  set -eu
+                  export UNCH_INSTALL_ASSET_DIR=/assets
+                  ./install.sh -b /tmp/bin -v vci-test
+                  /tmp/bin/unch --help >/dev/null
+                "
+            '
+
   coverage:
     name: coverage
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ go install github.com/uchebnick/unch@latest
 
 On Windows, the published installers are the easiest way to get the same cgo-backed parser and SQLite stack that release binaries and CI use. Source installs still work, and the vendored SQLite headers keep `go build` and `go install` to a single command as long as a working cgo toolchain is present.
 
+On Linux, the shell installer is smoke-tested in CI on Ubuntu, Debian, and Arch using published release assets. On NixOS-like environments without the usual system ELF loader path, `install.sh` patches the installed release binary via `nix-shell` so the final `unch` binary runs natively after installation instead of falling back to `go install`.
+
 If you want to hack on the project directly, build it from the current checkout:
 
 ```bash
@@ -63,7 +65,7 @@ Published release archives currently cover:
 - Linux: `arm64`, `x86_64`
 - Windows: `arm64`, `x86_64` (`unch.exe`)
 
-On those supported macOS, Linux, and Windows targets, the installers use published release archives by default, so Go is not required. `install.sh` and `install/install.ps1` only fall back to `go install` when a matching release archive is not available.
+On those supported macOS, Linux, and Windows targets, the installers use published release archives by default, so Go is not required. `install.sh` and `install/install.ps1` only fall back to `go install` when a matching release archive is not available. The PowerShell installer is smoke-tested on Windows `arm64` and `x86_64`.
 
 See [Compatibility](docs/compatibility.md) for the support matrix and upgrade rules, and [Benchmarks](docs/benchmarks.md) for the checked-in `smoke`, `ci`, and `default` suites plus the current CI benchmark profile.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -59,14 +59,14 @@ This document describes the current compatibility contract for `unch`.
 | Search modes | Supported | `auto`, `semantic`, `lexical` |
 | Homebrew install | Supported | macOS-first polished install path |
 | `go install` | Supported | Canonical module path is `github.com/uchebnick/unch` |
-| `install.sh` | Supported | Uses release assets on macOS and Linux by default, with Go fallback for unsupported targets |
-| `install/install.ps1` | Supported | Uses release assets on Windows by default, with Go fallback elsewhere |
+| `install.sh` | Supported | Uses release assets on macOS and Linux by default, with Go fallback for unsupported targets; smoke-tested in CI on Ubuntu, Debian, Arch, and NixOS-like environments |
+| `install/install.ps1` | Supported | Uses release assets on Windows by default, with Go fallback elsewhere; smoke-tested in CI on Windows `arm64` and `x86_64` |
 | Darwin release binaries | Supported | `arm64` and `x86_64` |
 | Linux release binaries | Supported | `arm64` and `x86_64` |
 | Windows release binaries | Supported | `arm64` and `x86_64` (`unch.exe`) |
 | Remote indexing | Supported | GitHub Actions `searcher` workflow |
 
-Published release binaries and CI builds on macOS, Linux, and Windows arm64/x86_64 use the full cgo-backed Tree-sitter and SQLite stack. Source builds on supported cgo toolchains do not require a separately installed SQLite development package because the SQLite header used by the embedded `sqlite-vec` bridge is vendored in-tree. Manual Windows builds without cgo remain a fallback path and should not be treated as identical to the published binaries.
+Published release binaries and CI builds on macOS, Linux, and Windows arm64/x86_64 use the full cgo-backed Tree-sitter and SQLite stack. Source builds on supported cgo toolchains do not require a separately installed SQLite development package because the SQLite header used by the embedded `sqlite-vec` bridge is vendored in-tree. On Linux environments that expose `nix` but not the usual system ELF loader path, `install.sh` patches the installed release binary with `nix-shell`, `patchelf`, and the required runtime library paths so the installed binary can run directly after installation. Manual Windows builds without cgo remain a fallback path and should not be treated as identical to the published binaries.
 
 ## Current Practical Rules
 

--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,50 @@ detect_arch() {
   esac
 }
 
+detect_linux_distro_id() {
+  if [ ! -r /etc/os-release ]; then
+    printf '\n'
+    return
+  fi
+
+  awk -F= '/^ID=/{gsub(/"/, "", $2); print $2; exit}' /etc/os-release
+}
+
+is_nixos() {
+  [ "$(detect_os)" = "Linux" ] && [ "$(detect_linux_distro_id)" = "nixos" ]
+}
+
+patch_nixos_binary() {
+  binary_path="$1"
+
+  if ! has_cmd nix; then
+    return 1
+  fi
+
+  nix --extra-experimental-features "nix-command flakes" \
+    shell nixpkgs#patchelf nixpkgs#stdenv.cc \
+    --command sh -lc '
+      set -eu
+      binary_path="$1"
+      linker="$(cat "$NIX_CC/nix-support/dynamic-linker")"
+      glibc_dir="$(dirname "$linker")"
+      libgcc_dir="$(dirname "$(cc -print-file-name=libgcc_s.so.1)")"
+      patchelf --set-interpreter "$linker" --set-rpath "${glibc_dir}:${libgcc_dir}" "$binary_path"
+    ' sh "$binary_path"
+}
+
+install_unix_binary() {
+  source_path="$1"
+  destination_path="$2"
+
+  install -m 0755 "$source_path" "$destination_path"
+
+  if is_nixos; then
+    say "Detected NixOS; patching ${destination_path} for native execution"
+    patch_nixos_binary "$destination_path"
+  fi
+}
+
 install_release_archive() {
   version="$1"
   os_name="$2"
@@ -116,7 +160,7 @@ install_release_archive() {
   case "$archive_ext" in
     tar.gz)
       tar -xzf "${asset_path}" -C "${tmp_dir}"
-      install -m 0755 "${tmp_dir}/${asset_binary}" "${bin_dir}/${asset_binary}"
+      install_unix_binary "${tmp_dir}/${asset_binary}" "${bin_dir}/${asset_binary}"
       ;;
     zip)
       unzip -q "${asset_path}" -d "${tmp_dir}"

--- a/install.sh
+++ b/install.sh
@@ -70,17 +70,16 @@ detect_arch() {
   esac
 }
 
-detect_linux_distro_id() {
-  if [ ! -r /etc/os-release ]; then
-    printf '\n'
-    return
-  fi
-
-  awk -F= '/^ID=/{gsub(/"/, "", $2); print $2; exit}' /etc/os-release
+has_system_linux_loader() {
+  case "$(detect_arch)" in
+    x86_64) [ -e /lib64/ld-linux-x86-64.so.2 ] ;;
+    arm64) [ -e /lib/ld-linux-aarch64.so.1 ] ;;
+    *) return 1 ;;
+  esac
 }
 
-is_nixos() {
-  [ "$(detect_os)" = "Linux" ] && [ "$(detect_linux_distro_id)" = "nixos" ]
+needs_nix_loader_patch() {
+  [ "$(detect_os)" = "Linux" ] && has_cmd nix && ! has_system_linux_loader
 }
 
 patch_nixos_binary() {
@@ -108,8 +107,8 @@ install_unix_binary() {
 
   install -m 0755 "$source_path" "$destination_path"
 
-  if is_nixos; then
-    say "Detected NixOS; patching ${destination_path} for native execution"
+  if needs_nix_loader_patch; then
+    say "Detected a Linux environment without a system ELF loader; patching ${destination_path} via nix"
     patch_nixos_binary "$destination_path"
   fi
 }

--- a/install.sh
+++ b/install.sh
@@ -89,12 +89,13 @@ patch_nixos_binary() {
     return 1
   fi
 
-  BINARY_PATH="$binary_path" nix-shell -p patchelf stdenv.cc --run '
+  BINARY_PATH="$binary_path" nix-shell -p patchelf stdenv.cc libffi pkg-config --run '
       set -eu
       linker="$(cat "$NIX_CC/nix-support/dynamic-linker")"
       glibc_dir="$(dirname "$linker")"
       libgcc_dir="$(dirname "$(cc -print-file-name=libgcc_s.so.1)")"
-      patchelf --set-interpreter "$linker" --set-rpath "${glibc_dir}:${libgcc_dir}" "$BINARY_PATH"
+      libffi_dir="$(pkg-config --variable=libdir libffi)"
+      patchelf --set-interpreter "$linker" --set-rpath "${glibc_dir}:${libgcc_dir}:${libffi_dir}" "$BINARY_PATH"
     '
 }
 

--- a/install.sh
+++ b/install.sh
@@ -85,20 +85,17 @@ needs_nix_loader_patch() {
 patch_nixos_binary() {
   binary_path="$1"
 
-  if ! has_cmd nix; then
+  if ! has_cmd nix-shell; then
     return 1
   fi
 
-  nix --extra-experimental-features "nix-command flakes" \
-    shell nixpkgs#patchelf nixpkgs#stdenv.cc \
-    --command sh -lc '
+  BINARY_PATH="$binary_path" nix-shell -p patchelf stdenv.cc --run '
       set -eu
-      binary_path="$1"
       linker="$(cat "$NIX_CC/nix-support/dynamic-linker")"
       glibc_dir="$(dirname "$linker")"
       libgcc_dir="$(dirname "$(cc -print-file-name=libgcc_s.so.1)")"
-      patchelf --set-interpreter "$linker" --set-rpath "${glibc_dir}:${libgcc_dir}" "$binary_path"
-    ' sh "$binary_path"
+      patchelf --set-interpreter "$linker" --set-rpath "${glibc_dir}:${libgcc_dir}" "$BINARY_PATH"
+    '
 }
 
 install_unix_binary() {


### PR DESCRIPTION
## What changed

- add script-only installer smoke checks for `ubuntu`, `debian`, and `archlinux` in CI
- keep the existing Windows PowerShell installer smoke checks and document the current installer coverage
- teach `install.sh` to patch the installed Linux release binary on NixOS-like systems that expose `nix` but do not provide the usual system ELF loader path

## Why

The main Windows/platform-parity PR was merged before the installer follow-ups landed. That left two gaps:

1. we did not have distro-specific script-only coverage for the shell installer on Linux
2. the release-based Linux installer still needed a NixOS-specific post-install patch so the installed binary could run directly after installation

## Impact

- `install.sh` is now explicitly exercised in CI on Ubuntu, Debian, Arch, and NixOS-like environments
- `install/install.ps1` remains exercised on Windows `x86_64` and `arm64`
- README and compatibility docs now match the actual installer behavior and platform coverage

## Root cause

Published Linux release binaries assume a normal glibc loader path. On NixOS-like systems that is not available by default, so the installed binary needed to be patched after installation with the correct interpreter and runtime library paths.

## Validation

- fresh installer smoke on equivalent HEAD before branch split:
  - `install-smoke-linux (ubuntu)` success
  - `install-smoke-linux (debian)` success
  - `install-smoke-linux (arch)` success
  - `install-smoke (windows-x86_64)` success
  - `install-smoke (windows-arm64)` was already green on the immediately previous installer-fix run, and the current clean branch reruns the same workflow
- branch CI has been re-triggered automatically after pushing `fix/installer-followups`
