### PR TITLE
feat: send release announcements to telegram

### DIFF
--- a/.github/releases/v0.3.5.md
+++ b/.github/releases/v0.3.5.md
@@ -1,14 +1,16 @@
 # unch v0.3.5
 
-`v0.3.5` is an installer compatibility patch release. It keeps the `v0.3.x` search and indexing behavior intact while tightening script-based install coverage across Linux distributions and Windows.
+`v0.3.5` is an installer compatibility and release automation patch release. It keeps the `v0.3.x` search and indexing behavior intact while tightening script-based install coverage and adding Telegram release announcements.
 
 ## Highlights
 
 - adds script-only installer smoke checks for Ubuntu, Debian, Arch, Windows x86_64, and Windows arm64
 - patches `install.sh` for NixOS-like Linux environments so the installed release binary runs directly after installation
+- adds Telegram release announcements generated from the existing `.github/releases/*.md` notes on tag publish
 - refreshes installer and compatibility docs to match the current platform support story
 
 ## Upgrade notes
 
 - no index rebuild is required when upgrading from `v0.3.4`
 - existing installs can be upgraded through the normal installer path
+- maintainers who want Telegram release notifications should set `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in GitHub Actions secrets before tagging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,12 +187,15 @@ jobs:
           if-no-files-found: error
 
       - name: Send Telegram release notification
-        if: ${{ secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHAT_ID != '' }}
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           set -euo pipefail
+          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+            echo "Telegram secrets are not set; skipping notification"
+            exit 0
+          fi
           curl --fail --silent --show-error \
             -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,45 @@ jobs:
             dist/*.zip
             dist/checksums.txt
 
+  notify-release:
+    name: notify-release
+    needs: release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Render release announcement
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          python3 scripts/render_release_announcement.py \
+            --tag "${GITHUB_REF_NAME}" \
+            --url "https://github.com/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF_NAME}" \
+            --notes-file ".github/releases/${GITHUB_REF_NAME}.md" \
+            > dist/release-announcement.txt
+
+      - name: Upload release announcement
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-announcement
+          path: dist/release-announcement.txt
+          if-no-files-found: error
+
+      - name: Send Telegram release notification
+        if: ${{ secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHAT_ID != '' }}
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text@dist/release-announcement.txt" \
+            --data-urlencode "disable_web_page_preview=true"
+
   publish-homebrew:
     name: publish-homebrew
     needs: release

--- a/scripts/render_release_announcement.py
+++ b/scripts/render_release_announcement.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def strip_markdown(text: str) -> str:
+    return " ".join(text.replace("`", "").split())
+
+
+def extract_title(lines: list[str], tag: str) -> str:
+    for line in lines:
+        if line.startswith("# "):
+            return strip_markdown(line[2:].strip())
+    return f"unch {tag}"
+
+
+def extract_summary(lines: list[str]) -> str:
+    body = lines[:]
+    if body and body[0].startswith("# "):
+        body = body[1:]
+
+    paragraph: list[str] = []
+    for line in body:
+        stripped = line.strip()
+        if not stripped:
+            if paragraph:
+                break
+            continue
+        if stripped.startswith("## "):
+            break
+        paragraph.append(stripped)
+
+    return strip_markdown(" ".join(paragraph))
+
+
+def extract_section_bullets(lines: list[str], heading: str) -> list[str]:
+    target = f"## {heading}"
+    in_section = False
+    bullets: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped == target:
+            in_section = True
+            continue
+        if in_section and stripped.startswith("## "):
+            break
+        if in_section and stripped.startswith("- "):
+            bullets.append(strip_markdown(stripped[2:]))
+
+    return bullets
+
+
+def render_announcement(tag: str, url: str, notes_text: str) -> str:
+    lines = notes_text.splitlines()
+    title = extract_title(lines, tag)
+    summary = extract_summary(lines)
+    highlights = extract_section_bullets(lines, "Highlights")
+    upgrades = extract_section_bullets(lines, "Upgrade notes")
+
+    rendered: list[str] = [title]
+
+    if summary:
+        rendered.extend(["", summary])
+
+    if highlights:
+        rendered.extend(["", "Highlights:"])
+        rendered.extend(f"- {item}" for item in highlights)
+
+    if upgrades:
+        rendered.extend(["", "Upgrade notes:"])
+        rendered.extend(f"- {item}" for item in upgrades)
+
+    rendered.extend(["", f"Release: {url}"])
+    return "\n".join(rendered)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--notes-file")
+    args = parser.parse_args()
+
+    notes_text = ""
+    if args.notes_file:
+        notes_path = Path(args.notes_file)
+        if notes_path.exists():
+            notes_text = notes_path.read_text(encoding="utf-8")
+
+    if not notes_text:
+        notes_text = f"# unch {args.tag}\n"
+
+    print(render_announcement(args.tag, args.url, notes_text))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- adds a `notify-release` job to the release workflow that renders a plain-text release announcement after a tag is published
- sends the rendered announcement to Telegram via the Bot API using repo secrets
- uploads the rendered announcement as a workflow artifact so the exact outgoing text is visible in Actions
- adds a small script to turn the existing `.github/releases/*.md` notes into a short Telegram-friendly message

## Why

We want release announcements to land in the Telegram channel automatically from the same release notes that already drive GitHub releases, without duplicating the text by hand.

## Secrets

This PR expects these Actions secrets on `uchebnick/unch`:

- `TELEGRAM_BOT_TOKEN`
- `TELEGRAM_CHAT_ID`

They are already configured on the repo.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `python3 scripts/render_release_announcement.py --tag v0.3.4 --url https://github.com/uchebnick/unch/releases/tag/v0.3.4 --notes-file .github/releases/v0.3.4.md`

## Preview

The current rendered preview looks like this:

```text
unch v0.3.4

v0.3.4 is a follow-up patch release for v0.3.3. It keeps the v0.3.x search and indexing behavior intact while fixing the benchmark path that runs during tag CI and release validation.

Highlights:
- teaches the benchmark adapter to treat Index already up to date as a successful warm-index result
- preserves the latest indexed symbol and file counts in benchmark summaries when warm runs skip unchanged repositories
- adds regression coverage for the new benchmark summary parsing and snapshot fallback behavior

Upgrade notes:
- no index rebuild is required when upgrading from v0.3.3
- no installer changes are required for existing macOS, Linux, or Windows x86_64 setups

Release: https://github.com/uchebnick/unch/releases/tag/v0.3.4
```

After merge, the next step is to create a new tag and verify that the real release notification arrives in the Telegram channel.
