### PR TITLE
fix: align benchmark matrix across platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         include:
           - os: ubuntu-latest
             label: linux
+          - os: macos-14
+            label: macos
           - os: windows-latest
             label: windows-x86_64
             msystem: UCRT64
@@ -79,7 +81,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.UNCH_BENCH_ROOT }}/cache
-          key: benchmark-${{ runner.os }}-${{ matrix.label }}-${{ hashFiles('benchmarks/suites/smoke.json', 'go.mod') }}
+          key: benchmark-${{ runner.os }}-${{ matrix.label }}-${{ hashFiles('benchmarks/suites/ci.json', 'go.mod') }}
           restore-keys: |
             benchmark-${{ runner.os }}-${{ matrix.label }}-
 
@@ -106,7 +108,7 @@ jobs:
           set -euo pipefail
           workspace_dir="$(cygpath -u "$GITHUB_WORKSPACE")"
           results_dir="${workspace_dir}/benchmarks/results"
-          suite_path="${workspace_dir}/benchmarks/suites/smoke.json"
+          suite_path="${workspace_dir}/${BENCHMARK_SUITE}"
           json_path="${results_dir}/ci-benchmark.json"
           log_path="${results_dir}/ci-benchmark.log"
           export CGO_ENABLED=1

--- a/internal/bench/env.go
+++ b/internal/bench/env.go
@@ -78,6 +78,33 @@ func detectCPUInfo() string {
 				}
 			}
 		}
+	case "windows":
+		cpuName := runBestEffortCommand(
+			"powershell.exe",
+			"-NoProfile",
+			"-Command",
+			"(Get-CimInstance Win32_Processor | Select-Object -First 1 -ExpandProperty Name)",
+		)
+		systemType := runBestEffortCommand(
+			"powershell.exe",
+			"-NoProfile",
+			"-Command",
+			"(Get-CimInstance Win32_ComputerSystem | Select-Object -ExpandProperty SystemType)",
+		)
+		switch {
+		case cpuName != "" && systemType != "":
+			return fmt.Sprintf("%s (%s)", cpuName, systemType)
+		case cpuName != "":
+			return cpuName
+		case systemType != "":
+			return systemType
+		}
+		if arch := strings.TrimSpace(os.Getenv("PROCESSOR_ARCHITEW6432")); arch != "" {
+			return arch
+		}
+		if arch := strings.TrimSpace(os.Getenv("PROCESSOR_ARCHITECTURE")); arch != "" {
+			return arch
+		}
 	}
 
 	return strings.TrimSpace(runBestEffortCommand("uname", "-m"))

--- a/scripts/render_benchmark_matrix_summary.py
+++ b/scripts/render_benchmark_matrix_summary.py
@@ -80,6 +80,19 @@ def render_repository_table(report: dict) -> list[str]:
     return lines
 
 
+def render_platform_summary(report: dict) -> str:
+    env = report["environment"]
+    timing = report["timing"]
+    metrics = report["metrics"]
+    return (
+        f"<code>{env['os']}/{env['arch']}</code> • "
+        f"{env.get('cpu_info') or 'unknown CPU'} • "
+        f"cold {format_duration_ms(timing['cold_index_mean_ms'])} • "
+        f"warm {format_duration_ms(timing['warm_search_mean_ms'])} • "
+        f"score {metrics['quality_score']}/100"
+    )
+
+
 def render_matrix_summary(reports: list[dict]) -> str:
     lines: list[str] = ["## Benchmark Matrix", ""]
 
@@ -125,7 +138,8 @@ def render_matrix_summary(reports: list[dict]) -> str:
         timing = report["timing"]
         metrics = report["metrics"]
         lines.append("")
-        lines.append(f"### `{env['os']}/{env['arch']}`")
+        lines.append("<details>")
+        lines.append(f"<summary>{render_platform_summary(report)}</summary>")
         lines.append("")
         lines.append(f"- Tool: `{report['tool']}` (`{env['tool_version']}`)")
         lines.append(f"- CPU: `{env.get('cpu_info') or 'unknown CPU'}` • `{env['num_cpu']}` cores")
@@ -140,6 +154,8 @@ def render_matrix_summary(reports: list[dict]) -> str:
         )
         lines.append("")
         lines.extend(render_repository_table(report))
+        lines.append("")
+        lines.append("</details>")
 
     lines.append("")
     return "\n".join(lines)


### PR DESCRIPTION
## What changed
- adds macOS to the release-tag benchmark matrix
- runs the same `benchmarks/suites/ci.json` suite on Windows that Linux already uses
- renders per-platform benchmark sections as collapsed `<details>` blocks in the summary
- reports Windows benchmark CPU info via PowerShell instead of the misleading MSYS `uname -m` fallback

## Why
The current benchmark summary mixes `ci` and `smoke` data, omits macOS entirely, and labels `windows/arm64` benchmark results with `x86_64`, which makes the cross-platform comparison misleading.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `python3 -m py_compile scripts/render_benchmark_matrix_summary.py scripts/render_benchmark_summary.py`
- `go test ./internal/bench -count=1`
- `GOOS=windows GOARCH=arm64 go build ./cmd/bench`
- `GOOS=darwin GOARCH=arm64 go build ./cmd/bench`
