### PR TITLE
docs: add telegram badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![Homebrew Tap](https://img.shields.io/badge/Homebrew-uchebnick%2Ftap-FBB040?logo=homebrew&logoColor=white)](https://github.com/uchebnick/homebrew-tap)
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/uchebnick/unch/gh-pages/coverage/coverage-badge.json)](https://github.com/uchebnick/unch/actions/workflows/ci.yml)
 [![Go 1.25+](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white)](https://github.com/uchebnick/unch)
+[![Telegram News](https://img.shields.io/badge/Telegram-News-26A5E4?logo=telegram&logoColor=white)](https://t.me/unchnews)
+[![Telegram Chat](https://img.shields.io/badge/Telegram-Chat-26A5E4?logo=telegram&logoColor=white)](https://t.me/unchchat)
 
 **Local-first semantic code search for real code objects.**
 


### PR DESCRIPTION
## What changed
- adds Telegram News and Telegram Chat badges to the README header

## Why
The Telegram channel and chat are now part of the normal project entry points, so they should be visible alongside the other top-level badges.

## Validation
- README-only change
- checked rendered diff locally
