### PR TITLE
docs: add v0.3.6 release notes

### DIFF
--- a/.github/releases/v0.3.6.md
+++ b/.github/releases/v0.3.6.md
@@ -1,0 +1,15 @@
+# unch v0.3.6
+
+`v0.3.6` is a benchmark reporting and release automation patch release. It keeps the `v0.3.x` search and indexing behavior intact while fixing Telegram delivery, tightening cross-platform benchmark comparisons, and polishing the project entry points.
+
+## Highlights
+
+- fixes Telegram release notifications for the configured channel target and surfaces Telegram API errors directly in the release workflow
+- aligns the release benchmark matrix across Linux, macOS, and Windows by adding macOS, using the same `ci` suite on Windows, and collapsing per-platform benchmark details in the summary
+- reports Windows benchmark CPU info more accurately and adds Telegram News and Telegram Chat badges to the README header
+
+## Upgrade notes
+
+- no index rebuild is required when upgrading from `v0.3.5`
+- existing installs can be upgraded through the normal installer path
+- keep `TELEGRAM_CHAT_ID` set to the full Telegram channel id if you use release notifications


### PR DESCRIPTION
## What changed
- adds the checked-in release notes file for `v0.3.6`

## Why
`v0.3.6` was tagged before `.github/releases/v0.3.6.md` existed in `main`, so the published GitHub release and Telegram announcement initially fell back to the minimal autogenerated text.

## Validation
- updated the published GitHub release body for `v0.3.6`
- resent the corrected Telegram announcement after deleting the short fallback message
