### PR TITLE
feat: add state-dir cli support

### DIFF
--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/uchebnick/unch/internal/indexing"
 	"github.com/uchebnick/unch/internal/runtime"
-	"github.com/uchebnick/unch/internal/semsearch"
 )
 
 const rootHelpWordmark = `
@@ -30,9 +29,9 @@ func runHelp(program string, args []string) error {
 
 	switch args[0] {
 	case "index":
-		return runIndex(context.TODO(), name, []string{"--help"}, semsearch.Paths{}, nil, indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
+		return runIndex(context.TODO(), name, []string{"--help"}, ".", indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
 	case "search":
-		return runSearch(context.TODO(), name, []string{"--help"}, semsearch.Paths{}, nil, indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
+		return runSearch(context.TODO(), name, []string{"--help"}, ".", indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
 	case "init":
 		return runInit(context.TODO(), name, []string{"--help"}, ".")
 	case "create":
@@ -66,7 +65,7 @@ func printRootHelp(w io.Writer, program string) error {
 	if _, err := fmt.Fprintln(w, helpWordmark()); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintln(w, "Local-first semantic code search for real code objects."); err != nil {
+	if _, err := fmt.Fprintln(w, "Semantic code search for code symbols and docs."); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintln(w); err != nil {
@@ -136,7 +135,7 @@ func printRootHelp(w io.Writer, program string) error {
 func printCreateHelp(w io.Writer, program string) error {
 	_, err := fmt.Fprintf(
 		w,
-		"Usage:\n  %s create ci [flags]\n\nTargets:\n  ci  Create .github/workflows/searcher.yml in the target repository\n\nUse `%s create ci --help` for flags.\n",
+		"Usage:\n  %s create ci [flags]\n\nTargets:\n  ci  Create the remote index workflow file (.github/workflows/searcher.yml) in the target repository\n\nUse `%s create ci --help` for flags.\n",
 		program,
 		program,
 	)
@@ -146,7 +145,7 @@ func printCreateHelp(w io.Writer, program string) error {
 func printBindHelp(w io.Writer, program string) error {
 	_, err := fmt.Fprintf(
 		w,
-		"Usage:\n  %s bind ci [flags] <github-repo-or-workflow-url>\n\nTargets:\n  ci  Bind the local manifest to a remote GitHub repository or searcher workflow\n\nUse `%s bind ci --help` for flags.\n",
+		"Usage:\n  %s bind ci [flags] <github-repo-or-workflow-url>\n\nTargets:\n  ci  Bind the local manifest to a remote GitHub repository or remote index workflow\n\nUse `%s bind ci --help` for flags.\n",
 		program,
 		program,
 	)

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/uchebnick/unch/internal/embed/llama"
 	"github.com/uchebnick/unch/internal/filehashdb"
@@ -17,18 +18,18 @@ import (
 	"github.com/uchebnick/unch/internal/termui"
 )
 
-func runIndex(ctx context.Context, program string, args []string, paths semsearch.Paths, s *termui.Session, scanner indexing.FileScanner, runtimes runtime.YzmaResolver, models runtime.ModelCache) error {
+func runIndex(ctx context.Context, program string, args []string, cwd string, scanner indexing.FileScanner, runtimes runtime.YzmaResolver, models runtime.ModelCache) (err error) {
 	var excludes stringListFlag
 
-	defaultDBPath := filepath.Join(paths.LocalDir, "index.db")
-	defaultModelPath := runtime.DefaultModelPath(paths.ModelsDir)
+	defaultModelPath := defaultModelFlagValue()
 
 	fs := flag.NewFlagSet(program+" index", flag.ContinueOnError)
 	fs.SetOutput(nil)
 	fs.Usage = func() {}
 
 	root := fs.String("root", ".", "root directory to index")
-	dbPath := fs.String("db", defaultDBPath, "path to sqlite db")
+	stateDir := fs.String("state-dir", "", "path to .semsearch directory; defaults to <root>/.semsearch")
+	dbPath := fs.String("db", "", "deprecated: path to .semsearch/index.db, or to a .semsearch directory")
 	modelPath := fs.String("model", defaultModelPath, "path to GGUF embedding model, or a known model id such as embeddinggemma or qwen3")
 	libPath := fs.String("lib", "", "path to yzma library directory, or to one of its shared library files")
 	contextPrefix := fs.String("context-prefix", "@filectx:", "legacy file context prefix used only by fallback indexers")
@@ -57,14 +58,19 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 					"Known model ids today: embeddinggemma and qwen3.",
 					"Changing --model changes the embedding space; rebuild the index before searching with the new model.",
 					"--comment-prefix and --context-prefix are legacy fallback knobs for unsupported files or parser failures.",
+					"Use --state-dir to keep index artifacts in a custom .semsearch directory.",
 				},
 			)
 		}
 		return err
 	}
 
+	stateDirWasExplicit := false
 	dbWasExplicit := false
 	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "state-dir" {
+			stateDirWasExplicit = true
+		}
 		if f.Name == "db" {
 			dbWasExplicit = true
 		}
@@ -75,10 +81,26 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 		return fmt.Errorf("resolve root: %w", err)
 	}
 
-	targetPaths, err := semsearch.PreparePaths(rootAbs)
+	targetPaths, resolvedDBPath, stateDirOwnsDB, err := resolveStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
 	if err != nil {
 		return err
 	}
+
+	s, err := termui.NewSession(targetPaths.LocalDir)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			s.Logf("fatal error: %v", err)
+		}
+		_ = s.Close()
+	}()
+	s.Logf("program=%s", program)
+	s.Logf("args=%q", args)
+	s.Logf("cwd=%s", cwd)
+	s.Logf("command=index")
+
 	if _, err := semsearch.EnsureFileWeights(targetPaths.LocalDir); err != nil {
 		return err
 	}
@@ -99,12 +121,13 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 		}
 	}
 
-	resolvedDBPath := *dbPath
-	if !dbWasExplicit {
-		resolvedDBPath = filepath.Join(targetPaths.LocalDir, "index.db")
+	resolvedDefaultModelPath := runtime.DefaultModelPath(targetPaths.ModelsDir)
+	requestedModelPath := strings.TrimSpace(*modelPath)
+	if requestedModelPath == "" {
+		requestedModelPath = resolvedDefaultModelPath
 	}
 
-	modelID, err := runtime.CanonicalModelID(*modelPath, defaultModelPath)
+	modelID, err := runtime.CanonicalModelID(requestedModelPath, resolvedDefaultModelPath)
 	if err != nil {
 		return fmt.Errorf("resolve model id: %w", err)
 	}
@@ -135,12 +158,12 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 		ctx,
 		targetPaths,
 		resolvedDBPath,
-		dbWasExplicit,
 		currentManifest,
 		hashStore,
 		modelID,
 		scannerFingerprint,
 		fileHashes,
+		stateDirOwnsDB,
 		s,
 	)
 	if err != nil {
@@ -170,7 +193,7 @@ func runIndex(ctx context.Context, program string, args []string, paths semsearc
 		s.Logf("%s", libNote)
 	}
 
-	resolvedModelPath, modelNote, err := models.ResolveOrInstallModelPath(ctx, *modelPath, defaultModelPath, true, s)
+	resolvedModelPath, modelNote, err := models.ResolveOrInstallModelPath(ctx, requestedModelPath, resolvedDefaultModelPath, true, s)
 	if err != nil {
 		return err
 	}
@@ -265,16 +288,15 @@ func maybeSkipUnchangedIndex(
 	ctx context.Context,
 	paths semsearch.Paths,
 	resolvedDBPath string,
-	dbWasExplicit bool,
 	currentManifest semsearch.Manifest,
 	hashStore *filehashdb.Store,
 	modelID string,
 	scannerFingerprint string,
 	fileHashes map[string]string,
+	stateDirOwnsDB bool,
 	s *termui.Session,
 ) (bool, error) {
-	defaultDBPath := filepath.Join(paths.LocalDir, "index.db")
-	if dbWasExplicit || resolvedDBPath != defaultDBPath {
+	if !stateDirOwnsDB || resolvedDBPath != filepath.Join(paths.LocalDir, "index.db") {
 		return false, nil
 	}
 	if currentManifest.Version <= 0 || semsearch.HasRemoteBinding(currentManifest) {

--- a/internal/cli/index_skip_test.go
+++ b/internal/cli/index_skip_test.go
@@ -40,12 +40,12 @@ func TestMaybeSkipUnchangedIndexSkipsMatchingLocalState(t *testing.T) {
 		context.Background(),
 		semsearch.Paths{LocalDir: localDir},
 		dbPath,
-		false,
 		semsearch.Manifest{Version: 7, Source: "local"},
 		store,
 		"embeddinggemma",
 		"scan-v1",
 		files,
+		true,
 		nil,
 	)
 	if err != nil {
@@ -85,12 +85,12 @@ func TestMaybeSkipUnchangedIndexDoesNotSkipMismatchedState(t *testing.T) {
 		context.Background(),
 		semsearch.Paths{LocalDir: localDir},
 		dbPath,
-		false,
 		semsearch.Manifest{Version: 7, Source: "local"},
 		store,
 		"embeddinggemma",
 		"scan-v1",
 		map[string]string{"a.go": "bbb"},
+		true,
 		nil,
 	)
 	if err != nil {
@@ -128,32 +128,26 @@ func TestMaybeSkipUnchangedIndexDoesNotSkipExplicitOrRemoteDB(t *testing.T) {
 	}
 
 	cases := []struct {
-		name          string
-		resolvedDB    string
-		dbWasExplicit bool
-		manifest      semsearch.Manifest
+		name           string
+		resolvedDB     string
+		stateDirOwnsDB bool
+		manifest       semsearch.Manifest
 	}{
 		{
-			name:          "explicit db",
-			resolvedDB:    defaultDBPath,
-			dbWasExplicit: true,
-			manifest:      semsearch.Manifest{Version: 7, Source: "local"},
+			name:           "legacy custom db path",
+			resolvedDB:     filepath.Join(localDir, "custom.db"),
+			stateDirOwnsDB: false,
+			manifest:       semsearch.Manifest{Version: 7, Source: "local"},
 		},
 		{
-			name:          "remote binding",
-			resolvedDB:    defaultDBPath,
-			dbWasExplicit: false,
+			name:           "remote binding",
+			resolvedDB:     defaultDBPath,
+			stateDirOwnsDB: true,
 			manifest: semsearch.Manifest{
 				Version: 7,
 				Source:  "remote",
 				Remote:  &semsearch.Remote{CIURL: "https://github.com/acme/widgets/actions/workflows/searcher.yml"},
 			},
-		},
-		{
-			name:          "custom db path",
-			resolvedDB:    filepath.Join(localDir, "custom.db"),
-			dbWasExplicit: false,
-			manifest:      semsearch.Manifest{Version: 7, Source: "local"},
 		},
 	}
 
@@ -168,12 +162,12 @@ func TestMaybeSkipUnchangedIndexDoesNotSkipExplicitOrRemoteDB(t *testing.T) {
 				context.Background(),
 				semsearch.Paths{LocalDir: localDir},
 				tc.resolvedDB,
-				tc.dbWasExplicit,
 				tc.manifest,
 				store,
 				"embeddinggemma",
 				"scan-v1",
 				files,
+				tc.stateDirOwnsDB,
 				nil,
 			)
 			if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/uchebnick/unch/internal/indexing"
 	"github.com/uchebnick/unch/internal/runtime"
-	"github.com/uchebnick/unch/internal/semsearch"
-	"github.com/uchebnick/unch/internal/termui"
 )
 
 // Run initializes the CLI runtime and dispatches to the selected subcommand.
@@ -43,35 +41,15 @@ func Run(program string, args []string) (err error) {
 		return runRemote(ctx, program, commandArgs, cwd)
 	}
 
-	paths, err := semsearch.PreparePaths(cwd)
-	if err != nil {
-		return err
-	}
-
-	s, err := termui.NewSession(paths.LocalDir)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err != nil {
-			s.Logf("fatal error: %v", err)
-		}
-		_ = s.Close()
-	}()
-	s.Logf("program=%s", program)
-	s.Logf("args=%q", args)
-	s.Logf("cwd=%s", cwd)
-
 	scanner := indexing.FileScanner{}
 	models := runtime.ModelCache{}
 	runtimes := runtime.YzmaResolver{}
-	s.Logf("command=%s", command)
 
 	switch command {
 	case "search":
-		return runSearch(ctx, program, commandArgs, paths, s, scanner, runtimes, models)
+		return runSearch(ctx, program, commandArgs, cwd, scanner, runtimes, models)
 	default:
-		return runIndex(ctx, program, commandArgs, paths, s, scanner, runtimes, models)
+		return runIndex(ctx, program, commandArgs, cwd, scanner, runtimes, models)
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hybridgroup/yzma/pkg/llama"
 	"github.com/uchebnick/unch/internal/indexing"
 	"github.com/uchebnick/unch/internal/runtime"
-	"github.com/uchebnick/unch/internal/semsearch"
 )
 
 func captureStdout(t *testing.T, fn func()) string {
@@ -225,7 +224,7 @@ func TestRunRootHelp(t *testing.T) {
 		}
 	})
 
-	if !strings.Contains(output, "Local-first semantic code search for real code objects.") {
+	if !strings.Contains(output, "Semantic code search for code symbols and docs.") {
 		t.Fatalf("Run(--help) output = %q, want root summary", output)
 	}
 	if !strings.Contains(output, "Model selection:") {
@@ -272,7 +271,7 @@ func TestRunRemoteHelp(t *testing.T) {
 func TestRunSearchRequiresQuery(t *testing.T) {
 	t.Parallel()
 
-	err := runSearch(context.Background(), "unch", nil, semsearch.Paths{}, nil, indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
+	err := runSearch(context.Background(), "unch", nil, ".", indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
 	if err == nil || !strings.Contains(err.Error(), "empty search query") {
 		t.Fatalf("runSearch() error = %v, want empty search query", err)
 	}
@@ -281,7 +280,7 @@ func TestRunSearchRequiresQuery(t *testing.T) {
 func TestRunSearchRejectsInvalidMode(t *testing.T) {
 	t.Parallel()
 
-	err := runSearch(context.Background(), "unch", []string{"--mode", "weird", "--query", "abc"}, semsearch.Paths{}, nil, indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
+	err := runSearch(context.Background(), "unch", []string{"--mode", "weird", "--query", "abc"}, ".", indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
 	if err == nil || !strings.Contains(err.Error(), "unknown search mode") {
 		t.Fatalf("runSearch() error = %v, want unknown search mode", err)
 	}
@@ -289,7 +288,7 @@ func TestRunSearchRejectsInvalidMode(t *testing.T) {
 
 func TestRunIndexRejectsUnknownFlag(t *testing.T) {
 	stderr := captureStderr(t, func() {
-		err := runIndex(context.Background(), "unch", []string{"--wat"}, semsearch.Paths{}, nil, indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
+		err := runIndex(context.Background(), "unch", []string{"--wat"}, ".", indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
 		if err == nil {
 			t.Fatalf("expected runIndex() to reject unknown flag")
 		}

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -18,16 +18,16 @@ import (
 	"github.com/uchebnick/unch/internal/termui"
 )
 
-func runSearch(ctx context.Context, program string, args []string, paths semsearch.Paths, s *termui.Session, _ indexing.FileScanner, runtimes runtime.YzmaResolver, models runtime.ModelCache) error {
-	defaultDBPath := filepath.Join(paths.LocalDir, "index.db")
-	defaultModelPath := runtime.DefaultModelPath(paths.ModelsDir)
+func runSearch(ctx context.Context, program string, args []string, cwd string, _ indexing.FileScanner, runtimes runtime.YzmaResolver, models runtime.ModelCache) (err error) {
+	defaultModelPath := defaultModelFlagValue()
 
 	fs := flag.NewFlagSet(program+" search", flag.ContinueOnError)
 	fs.SetOutput(nil)
 	fs.Usage = func() {}
 
 	root := fs.String("root", ".", "root directory used to format result paths")
-	dbPath := fs.String("db", defaultDBPath, "path to sqlite db")
+	stateDir := fs.String("state-dir", "", "path to .semsearch directory; defaults to <root>/.semsearch")
+	dbPath := fs.String("db", "", "deprecated: path to .semsearch/index.db, or to a .semsearch directory")
 	modelPath := fs.String("model", defaultModelPath, "path to GGUF embedding model, or a known model id such as embeddinggemma or qwen3")
 	libPath := fs.String("lib", "", "path to yzma library directory, or to one of its shared library files")
 	queryFlag := fs.String("query", "", "search query; if empty, remaining args are joined")
@@ -60,6 +60,7 @@ func runSearch(ctx context.Context, program string, args []string, paths semsear
 					"Known model ids today: embeddinggemma and qwen3.",
 					"Use the same embedding model for both index and search, otherwise ranking quality will be wrong.",
 					"Switching models requires rebuilding the index with `unch index` first.",
+					"Use --state-dir to search an external .semsearch directory and keep remote sync bound to that state.",
 				},
 			)
 		}
@@ -79,8 +80,12 @@ func runSearch(ctx context.Context, program string, args []string, paths semsear
 		return err
 	}
 
+	stateDirWasExplicit := false
 	dbWasExplicit := false
 	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "state-dir" {
+			stateDirWasExplicit = true
+		}
 		if f.Name == "db" {
 			dbWasExplicit = true
 		}
@@ -91,25 +96,38 @@ func runSearch(ctx context.Context, program string, args []string, paths semsear
 		return fmt.Errorf("resolve root: %w", err)
 	}
 
-	targetPaths, err := semsearch.PreparePaths(rootAbs)
+	targetPaths, resolvedDBPath, shouldSyncRemote, err := resolveStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
 	if err != nil {
 		return err
 	}
-	if _, err := semsearch.EnsureFileWeights(targetPaths.LocalDir); err != nil {
+
+	s, err := termui.NewSession(targetPaths.LocalDir)
+	if err != nil {
 		return err
 	}
+	defer func() {
+		if err != nil {
+			s.Logf("fatal error: %v", err)
+		}
+		_ = s.Close()
+	}()
+	s.Logf("program=%s", program)
+	s.Logf("args=%q", args)
+	s.Logf("cwd=%s", cwd)
+	s.Logf("command=search")
 
-	remoteSync, err := semsearch.SyncRemoteIndex(ctx, targetPaths.LocalDir)
-	if err != nil {
-		return fmt.Errorf("sync remote index: %w", err)
-	}
-	if remoteSync.Checked && remoteSync.Note != "" {
-		printSessionLine(s, "%s", remoteSync.Note)
-	}
+	if shouldSyncRemote {
+		if _, err := semsearch.EnsureFileWeights(targetPaths.LocalDir); err != nil {
+			return err
+		}
 
-	resolvedDBPath := *dbPath
-	if !dbWasExplicit {
-		resolvedDBPath = filepath.Join(targetPaths.LocalDir, "index.db")
+		remoteSync, err := semsearch.SyncRemoteIndex(ctx, targetPaths.LocalDir)
+		if err != nil {
+			return fmt.Errorf("sync remote index: %w", err)
+		}
+		if remoteSync.Checked && remoteSync.Note != "" {
+			printSessionLine(s, "%s", remoteSync.Note)
+		}
 	}
 
 	resolvedLibPath, libNote, err := runtimes.ResolveOrInstallYzmaLibPath(ctx, *libPath, targetPaths.LocalDir, s)
@@ -120,14 +138,20 @@ func runSearch(ctx context.Context, program string, args []string, paths semsear
 		s.Logf("%s", libNote)
 	}
 
-	resolvedModelPath, modelNote, err := models.ResolveOrInstallModelPath(ctx, *modelPath, defaultModelPath, true, s)
+	resolvedDefaultModelPath := runtime.DefaultModelPath(targetPaths.ModelsDir)
+	requestedModelPath := strings.TrimSpace(*modelPath)
+	if requestedModelPath == "" {
+		requestedModelPath = resolvedDefaultModelPath
+	}
+
+	resolvedModelPath, modelNote, err := models.ResolveOrInstallModelPath(ctx, requestedModelPath, resolvedDefaultModelPath, true, s)
 	if err != nil {
 		return err
 	}
 	if modelNote != "" {
 		s.Logf("%s", modelNote)
 	}
-	modelID, err := runtime.CanonicalModelID(*modelPath, defaultModelPath)
+	modelID, err := runtime.CanonicalModelID(requestedModelPath, resolvedDefaultModelPath)
 	if err != nil {
 		return fmt.Errorf("resolve model id: %w", err)
 	}
@@ -141,6 +165,7 @@ func runSearch(ctx context.Context, program string, args []string, paths semsear
 	}
 
 	s.Logf("db=%s", resolvedDBPath)
+	s.Logf("state_dir=%s", targetPaths.LocalDir)
 	s.Logf("lib=%s", resolvedLibPath)
 	s.Logf("model=%s", resolvedModelPath)
 	s.Logf("model_id=%s", modelID)

--- a/internal/cli/search_test.go
+++ b/internal/cli/search_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveStateTargetDefaultRepoLocalState(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	paths, dbPath, stateDirOwnsDB, err := resolveStateTarget(root, "", false, "", false)
+	if err != nil {
+		t.Fatalf("resolveStateTarget() error: %v", err)
+	}
+	if !stateDirOwnsDB {
+		t.Fatalf("stateDirOwnsDB = false, want true")
+	}
+	if paths.LocalDir != filepath.Join(root, ".semsearch") {
+		t.Fatalf("paths.LocalDir = %q", paths.LocalDir)
+	}
+	if dbPath != filepath.Join(root, ".semsearch", "index.db") {
+		t.Fatalf("dbPath = %q", dbPath)
+	}
+}
+
+func TestResolveStateTargetExplicitStateDirKeepsStateDirSemantics(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	stateDir := filepath.Join(t.TempDir(), ".semsearch")
+
+	paths, dbPath, stateDirOwnsDB, err := resolveStateTarget(root, stateDir, true, "", false)
+	if err != nil {
+		t.Fatalf("resolveStateTarget() error: %v", err)
+	}
+	if !stateDirOwnsDB {
+		t.Fatalf("stateDirOwnsDB = false, want true")
+	}
+	if paths.LocalDir != stateDir {
+		t.Fatalf("paths.LocalDir = %q, want %q", paths.LocalDir, stateDir)
+	}
+	if dbPath != filepath.Join(stateDir, "index.db") {
+		t.Fatalf("dbPath = %q", dbPath)
+	}
+}
+
+func TestResolveStateTargetExplicitIndexDBKeepsStateDirSemantics(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), ".semsearch", "index.db")
+
+	paths, resolvedDBPath, stateDirOwnsDB, err := resolveStateTarget(root, "", false, dbPath, true)
+	if err != nil {
+		t.Fatalf("resolveStateTarget() error: %v", err)
+	}
+	if !stateDirOwnsDB {
+		t.Fatalf("stateDirOwnsDB = false, want true")
+	}
+	if paths.LocalDir != filepath.Dir(dbPath) {
+		t.Fatalf("paths.LocalDir = %q, want %q", paths.LocalDir, filepath.Dir(dbPath))
+	}
+	if resolvedDBPath != dbPath {
+		t.Fatalf("resolvedDBPath = %q, want %q", resolvedDBPath, dbPath)
+	}
+}
+
+func TestResolveStateTargetExplicitCustomDBSkipsStateDirSemantics(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "custom", "search.db")
+
+	paths, resolvedDBPath, stateDirOwnsDB, err := resolveStateTarget(root, "", false, dbPath, true)
+	if err != nil {
+		t.Fatalf("resolveStateTarget() error: %v", err)
+	}
+	if stateDirOwnsDB {
+		t.Fatalf("stateDirOwnsDB = true, want false")
+	}
+	if paths.LocalDir != filepath.Dir(dbPath) {
+		t.Fatalf("paths.LocalDir = %q, want %q", paths.LocalDir, filepath.Dir(dbPath))
+	}
+	if resolvedDBPath != dbPath {
+		t.Fatalf("resolvedDBPath = %q, want %q", resolvedDBPath, dbPath)
+	}
+}
+
+func TestResolveStateTargetRejectsStateDirAndDBTogether(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, err := resolveStateTarget(t.TempDir(), "/tmp/.semsearch", true, "/tmp/.semsearch/index.db", true)
+	if err == nil || err.Error() != "use either --state-dir or --db, not both" {
+		t.Fatalf("resolveStateTarget() error = %v", err)
+	}
+}

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/uchebnick/unch/internal/runtime"
+	"github.com/uchebnick/unch/internal/semsearch"
+)
+
+func defaultModelFlagValue() string {
+	modelsDir, err := semsearch.DefaultModelsDir()
+	if err != nil {
+		return ""
+	}
+	return runtime.DefaultModelPath(modelsDir)
+}
+
+func resolveStateTarget(rootAbs string, stateDirInput string, stateDirWasExplicit bool, dbInput string, dbWasExplicit bool) (semsearch.Paths, string, bool, error) {
+	if stateDirWasExplicit && dbWasExplicit {
+		return semsearch.Paths{}, "", false, fmt.Errorf("use either --state-dir or --db, not both")
+	}
+	if stateDirWasExplicit {
+		return resolveExplicitStateDirTarget(stateDirInput)
+	}
+	if dbWasExplicit {
+		return resolveLegacyDBTarget(dbInput)
+	}
+
+	paths, err := semsearch.PreparePaths(rootAbs)
+	if err != nil {
+		return semsearch.Paths{}, "", false, err
+	}
+	return paths, filepath.Join(paths.LocalDir, "index.db"), true, nil
+}
+
+func resolveExplicitStateDirTarget(stateDirInput string) (semsearch.Paths, string, bool, error) {
+	resolvedStateDir, err := filepath.Abs(strings.TrimSpace(stateDirInput))
+	if err != nil {
+		return semsearch.Paths{}, "", false, fmt.Errorf("resolve state dir: %w", err)
+	}
+
+	paths, err := semsearch.PathsForLocalDir(resolvedStateDir)
+	if err != nil {
+		return semsearch.Paths{}, "", false, err
+	}
+	return paths, filepath.Join(paths.LocalDir, "index.db"), true, nil
+}
+
+func resolveLegacyDBTarget(dbInput string) (semsearch.Paths, string, bool, error) {
+	resolvedInput, err := filepath.Abs(strings.TrimSpace(dbInput))
+	if err != nil {
+		return semsearch.Paths{}, "", false, fmt.Errorf("resolve db path: %w", err)
+	}
+
+	info, statErr := os.Stat(resolvedInput)
+	localDir := ""
+	resolvedDBPath := resolvedInput
+	stateDirOwnsDB := false
+
+	switch {
+	case statErr == nil && info.IsDir():
+		localDir = resolvedInput
+		resolvedDBPath = filepath.Join(localDir, "index.db")
+		stateDirOwnsDB = true
+	case statErr == nil:
+		localDir = filepath.Dir(resolvedInput)
+		stateDirOwnsDB = strings.EqualFold(filepath.Base(resolvedInput), "index.db")
+	case os.IsNotExist(statErr) && strings.EqualFold(filepath.Base(resolvedInput), ".semsearch"):
+		localDir = resolvedInput
+		resolvedDBPath = filepath.Join(localDir, "index.db")
+		stateDirOwnsDB = true
+	case os.IsNotExist(statErr):
+		localDir = filepath.Dir(resolvedInput)
+		stateDirOwnsDB = strings.EqualFold(filepath.Base(resolvedInput), "index.db")
+	default:
+		return semsearch.Paths{}, "", false, fmt.Errorf("stat db path: %w", statErr)
+	}
+
+	paths, err := semsearch.PathsForLocalDir(localDir)
+	if err != nil {
+		return semsearch.Paths{}, "", false, err
+	}
+	return paths, resolvedDBPath, stateDirOwnsDB, nil
+}

--- a/internal/semsearch/paths.go
+++ b/internal/semsearch/paths.go
@@ -15,15 +15,22 @@ type Paths struct {
 	ModelsDir    string
 }
 
-// PreparePaths creates the local and global directories used by unch for
-// repository state, manifests, and shared model storage.
-func PreparePaths(root string) (Paths, error) {
-	localDir := filepath.Join(root, ".semsearch")
+// DefaultModelsDir resolves the shared model cache directory used by unch.
+func DefaultModelsDir() (string, error) {
 	globalDir, err := globalSemsearchDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(globalDir, "models"), nil
+}
+
+// PathsForLocalDir creates the local and global directories used by unch for
+// repository state, manifests, and shared model storage.
+func PathsForLocalDir(localDir string) (Paths, error) {
+	modelsDir, err := DefaultModelsDir()
 	if err != nil {
 		return Paths{}, err
 	}
-	modelsDir := filepath.Join(globalDir, "models")
 
 	if err := os.MkdirAll(localDir, 0o755); err != nil {
 		return Paths{}, fmt.Errorf("create local dir: %w", err)
@@ -38,6 +45,12 @@ func PreparePaths(root string) (Paths, error) {
 		FileHashDB:   filepath.Join(localDir, "filehashes.db"),
 		ModelsDir:    modelsDir,
 	}, nil
+}
+
+// PreparePaths creates the local and global directories used by unch for
+// repository state, manifests, and shared model storage.
+func PreparePaths(root string) (Paths, error) {
+	return PathsForLocalDir(filepath.Join(root, ".semsearch"))
 }
 
 func globalSemsearchDir() (string, error) {


### PR DESCRIPTION
## What Changed
- adds `--state-dir` to `unch index` and `unch search`
- keeps `--db` as a deprecated compatibility alias
- resolves session logs, manifests, file hash cache, and remote sync from the selected state directory instead of always touching `cwd/.semsearch`
- adds coverage for explicit state-dir and legacy db resolution paths

## Why
The current `--db` flag only exposes a single sqlite file, but the real CLI state lives in the whole `.semsearch` directory. That led to confusing behavior where an explicit external db path could still sync or mutate the repository-local remote cache.

## Impact
- external `.semsearch` directories behave predictably for both `index` and `search`
- `SyncRemoteIndex` now follows the explicit state directory when one is provided
- legacy `--db` usage still works while the CLI shifts toward the more honest state-dir model

## Validation
- `go test ./internal/cli ./internal/semsearch -count=1`
