### PR TITLE
fix: harden remote sync and scanner guards

### DIFF
--- a/.github/workflows/searcher-reusable.yml
+++ b/.github/workflows/searcher-reusable.yml
@@ -179,6 +179,7 @@ jobs:
           name: semsearch-index
           path: |
             .semsearch/index.db
+            .semsearch/filehashes.db
             .semsearch/manifest.json
             .semsearch/logs/
           if-no-files-found: warn
@@ -218,6 +219,11 @@ jobs:
           fi
           mkdir -p "$publish_dir/semsearch"
           cp "$artifact_dir/index.db" "$publish_dir/semsearch/index.db"
+          if [ -f "$artifact_dir/filehashes.db" ]; then
+            cp "$artifact_dir/filehashes.db" "$publish_dir/semsearch/filehashes.db"
+          else
+            rm -f "$publish_dir/semsearch/filehashes.db"
+          fi
           cp "$artifact_dir/manifest.json" "$publish_dir/semsearch/manifest.json"
           echo "::group::Publish payload"
           find "$publish_dir/semsearch" -maxdepth 1 -type f | sort
@@ -226,7 +232,7 @@ jobs:
             cd "$publish_dir"
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add semsearch/index.db semsearch/manifest.json
+            git add -A semsearch/index.db semsearch/filehashes.db semsearch/manifest.json
             if git diff --cached --quiet; then
               echo "No gh-pages changes to publish."
             else

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -156,7 +156,7 @@ func printBindHelp(w io.Writer, program string) error {
 func printRemoteHelp(w io.Writer, program string) error {
 	_, err := fmt.Fprintf(
 		w,
-		"Usage:\n  %s remote <subcommand> [flags]\n\nSubcommands:\n  sync      Refresh the local index from a bound remote workflow\n  download  Download the published artifact for a specific commit without binding the repo\n  bind      Alias for `bind ci`\n\nUse `%s remote sync --help` or `%s remote download --help` for flags.\n",
+		"Usage:\n  %s remote <subcommand> [flags]\n\nSubcommands:\n  sync      Refresh bound .semsearch state from the latest published remote workflow\n  download  Download one published artifact for a specific commit into local-only state\n  bind      Alias for `bind ci`\n\nUse `%s remote sync --help` or `%s remote download --help` for flags.\n",
 		program,
 		program,
 		program,

--- a/internal/cli/remote.go
+++ b/internal/cli/remote.go
@@ -47,13 +47,15 @@ func runRemoteSync(ctx context.Context, program string, args []string) error {
 				os.Stdout,
 				fs,
 				cliName(program)+" remote sync [flags] [root]",
-				"Refresh the local index from a bound remote GitHub Actions workflow.",
+				"Refresh the local .semsearch state from the latest published remote workflow.",
 				[]string{
 					cliName(program) + " remote sync",
 					cliName(program) + " remote sync --root ../repo --allow-missing",
 				},
 				[]string{
 					"If the manifest is not bound, this command reports that and exits cleanly.",
+					"Use sync for the normal remote-backed flow when the repository should follow the latest published state.",
+					"When available, sync restores index.db, manifest.json, and filehashes.db together.",
 					"Use --allow-missing in CI bootstrap flows so older or unpublished remote indexes do not fail the run.",
 				},
 			)
@@ -80,11 +82,11 @@ func runRemoteSync(ctx context.Context, program string, args []string) error {
 	if err != nil {
 		if *allowMissing {
 			if errors.Is(err, semsearch.ErrRemoteIndexNotPublished) {
-				_, _ = fmt.Fprintln(os.Stdout, "Remote index is not published yet; run the searcher GitHub Actions workflow once to publish it")
+				_, _ = fmt.Fprintln(os.Stdout, "Remote index is not published yet; run the remote index workflow once to publish it")
 				return nil
 			}
 			if errors.Is(err, semsearch.ErrRemoteIndexIncompatible) {
-				_, _ = fmt.Fprintln(os.Stdout, "Remote index uses an older schema; continuing without restore so the searcher workflow can rebuild and republish it")
+				_, _ = fmt.Fprintln(os.Stdout, "Remote index uses an older schema; continuing without restore so the remote index workflow can rebuild and republish it")
 				return nil
 			}
 		}
@@ -115,13 +117,15 @@ func runRemoteDownload(ctx context.Context, program string, args []string) error
 				os.Stdout,
 				fs,
 				cliName(program)+" remote download [flags] --commit <sha> <github-repo-or-workflow-url>",
-				"Download a published search artifact for a specific commit without binding the repository to remote sync.",
+				"Download one published search artifact for a specific commit into local-only .semsearch state.",
 				[]string{
 					cliName(program) + " remote download --commit abc123 https://github.com/uchebnick/unch",
 					cliName(program) + " remote download --commit abc123 https://github.com/uchebnick/unch/actions/workflows/searcher.yml",
 				},
 				[]string{
+					"Use download for debugging, benchmarking, or reproducing one commit without binding to the latest remote state.",
 					"The downloaded manifest is activated as local-only state, so future searches do not auto-sync to latest remote by accident.",
+					"When present, the downloaded artifact also restores filehashes.db for faster warm reindex runs.",
 				},
 			)
 		}
@@ -155,6 +159,6 @@ func runRemoteDownload(ctx context.Context, program string, args []string) error
 	if result.Note != "" {
 		_, _ = fmt.Fprintln(os.Stdout, result.Note)
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "Activated local search index at %s\n", filepath.Join(paths.LocalDir, "index.db"))
+	_, _ = fmt.Fprintf(os.Stdout, "Activated local search state at %s\n", paths.LocalDir)
 	return nil
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -267,6 +267,9 @@ func TestRunRemoteHelp(t *testing.T) {
 	if !strings.Contains(output, "remote download") {
 		t.Fatalf("Run(remote --help) output = %q, want download subcommand", output)
 	}
+	if !strings.Contains(output, "specific commit") {
+		t.Fatalf("Run(remote --help) output = %q, want commit-oriented download guidance", output)
+	}
 }
 
 func TestRunSearchRequiresQuery(t *testing.T) {

--- a/internal/indexing/scanner.go
+++ b/internal/indexing/scanner.go
@@ -200,7 +200,7 @@ func shouldSkipIndexedPath(rel string) bool {
 	}
 
 	base := strings.ToLower(strings.TrimSpace(filepath.Base(rel)))
-	if strings.HasPrefix(base, "readme") {
+	if base == "readme" || strings.HasPrefix(base, "readme.") {
 		return true
 	}
 

--- a/internal/indexing/scanner_test.go
+++ b/internal/indexing/scanner_test.go
@@ -16,6 +16,9 @@ func TestShouldSkipIndexedPath(t *testing.T) {
 		{path: "README.md", want: true},
 		{path: "docs/README.dev.md", want: true},
 		{path: "guides/readme.txt", want: true},
+		{path: "internal/READMEParser.go", want: false},
+		{path: "pkg/readme_utils.py", want: false},
+		{path: "web/ReadmeClient.ts", want: false},
 	}
 
 	for _, tt := range tests {

--- a/internal/semsearch/ci.go
+++ b/internal/semsearch/ci.go
@@ -283,6 +283,7 @@ jobs:
           name: semsearch-index
           path: |
             .semsearch/index.db
+            .semsearch/filehashes.db
             .semsearch/manifest.json
             .semsearch/logs/
           if-no-files-found: warn
@@ -322,6 +323,11 @@ jobs:
           fi
           mkdir -p "$publish_dir/semsearch"
           cp "$artifact_dir/index.db" "$publish_dir/semsearch/index.db"
+          if [ -f "$artifact_dir/filehashes.db" ]; then
+            cp "$artifact_dir/filehashes.db" "$publish_dir/semsearch/filehashes.db"
+          else
+            rm -f "$publish_dir/semsearch/filehashes.db"
+          fi
           cp "$artifact_dir/manifest.json" "$publish_dir/semsearch/manifest.json"
           echo "::group::Publish payload"
           find "$publish_dir/semsearch" -maxdepth 1 -type f | sort
@@ -330,7 +336,7 @@ jobs:
             cd "$publish_dir"
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add semsearch/index.db semsearch/manifest.json
+            git add -A semsearch/index.db semsearch/filehashes.db semsearch/manifest.json
             if git diff --cached --quiet; then
               echo "No gh-pages changes to publish."
             else

--- a/internal/semsearch/remote.go
+++ b/internal/semsearch/remote.go
@@ -179,6 +179,11 @@ func (w GitHubWorkflowRef) PublishedIndexURL() (string, error) {
 	return joinURLPath(gitHubContentBaseURL, w.Owner, w.Repo, gitHubPagesBranch, gitHubPagesSemsearchDir, "index.db")
 }
 
+// PublishedFileHashDBURL returns the raw gh-pages file hash cache URL for this workflow.
+func (w GitHubWorkflowRef) PublishedFileHashDBURL() (string, error) {
+	return joinURLPath(gitHubContentBaseURL, w.Owner, w.Repo, gitHubPagesBranch, gitHubPagesSemsearchDir, "filehashes.db")
+}
+
 // SyncRemoteIndex refreshes the local index from the published remote CI artifacts when needed.
 func SyncRemoteIndex(ctx context.Context, localDir string) (RemoteSyncResult, error) {
 	manifest, err := ReadManifest(localDir)
@@ -206,12 +211,14 @@ func SyncRemoteIndex(ctx context.Context, localDir string) (RemoteSyncResult, er
 	remoteManifest = normalizePublishedManifest(remoteManifest, manifest.Remote.CIURL)
 
 	dbPath := filepath.Join(localDir, "index.db")
+	fileHashDBPath := filepath.Join(localDir, "filehashes.db")
 	dbExists := fileExists(dbPath)
 	needsDownload := !dbExists ||
 		manifest.Version != remoteManifest.Version ||
 		manifest.IndexingHash != remoteManifest.IndexingHash
 
 	if !needsDownload {
+		_ = downloadPublishedFileHashDB(ctx, workflow, fileHashDBPath)
 		if !manifestsEqual(manifest, remoteManifest) {
 			if err := WriteManifest(localDir, remoteManifest); err != nil {
 				return RemoteSyncResult{}, fmt.Errorf("write refreshed manifest: %w", err)
@@ -239,6 +246,7 @@ func SyncRemoteIndex(ctx context.Context, localDir string) (RemoteSyncResult, er
 		}
 		return RemoteSyncResult{}, fmt.Errorf("download remote index: %w", err)
 	}
+	_ = downloadPublishedFileHashDB(ctx, workflow, fileHashDBPath)
 	if err := WriteManifest(localDir, remoteManifest); err != nil {
 		return RemoteSyncResult{}, fmt.Errorf("write downloaded manifest: %w", err)
 	}
@@ -277,7 +285,7 @@ func DownloadIndexArtifactForCommit(ctx context.Context, localDir string, ciTarg
 		return ArtifactDownloadResult{}, err
 	}
 
-	downloadedManifest, indexBytes, err := extractIndexArtifactPayload(artifactZip)
+	downloadedManifest, indexBytes, fileHashDBBytes, err := extractIndexArtifactPayload(artifactZip)
 	if err != nil {
 		return ArtifactDownloadResult{}, err
 	}
@@ -286,6 +294,12 @@ func DownloadIndexArtifactForCommit(ctx context.Context, localDir string, ciTarg
 	dbPath := filepath.Join(localDir, "index.db")
 	if err := writeDownloadedIndex(dbPath, indexBytes, downloadedManifest.IndexingHash); err != nil {
 		return ArtifactDownloadResult{}, fmt.Errorf("activate artifact index: %w", err)
+	}
+	if len(fileHashDBBytes) > 0 {
+		fileHashDBPath := filepath.Join(localDir, "filehashes.db")
+		if err := writeDownloadedFile(fileHashDBPath, fileHashDBBytes); err != nil {
+			return ArtifactDownloadResult{}, fmt.Errorf("activate artifact file hash cache: %w", err)
+		}
 	}
 	if err := WriteManifest(localDir, localManifest); err != nil {
 		return ArtifactDownloadResult{}, fmt.Errorf("write downloaded manifest: %w", err)
@@ -376,6 +390,22 @@ func writeDownloadedIndex(destPath string, data []byte, expectedHash string) err
 	return activateDownloadedIndex(context.Background(), tmpPath, destPath, expectedHash)
 }
 
+func writeDownloadedFile(destPath string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(destPath), err)
+	}
+
+	tmpPath := destPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", tmpPath, err)
+	}
+	if err := replaceFile(tmpPath, destPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("activate %s: %w", destPath, err)
+	}
+	return nil
+}
+
 func activateDownloadedIndex(ctx context.Context, tmpPath string, destPath string, expectedHash string) error {
 	if strings.TrimSpace(expectedHash) != "" {
 		gotHash, err := indexdb.LogicalHash(ctx, tmpPath)
@@ -397,6 +427,20 @@ func activateDownloadedIndex(ctx context.Context, tmpPath string, destPath strin
 		return fmt.Errorf("activate %s: %w", destPath, err)
 	}
 	return nil
+}
+
+func downloadPublishedFileHashDB(ctx context.Context, workflow GitHubWorkflowRef, destPath string) error {
+	fileHashURL, err := workflow.PublishedFileHashDBURL()
+	if err != nil {
+		return err
+	}
+
+	data, err := fetchRemoteBytes(ctx, fileHashURL)
+	if err != nil {
+		return nil
+	}
+
+	return writeDownloadedFile(destPath, data)
 }
 
 type gitHubWorkflowRunsResponse struct {
@@ -520,44 +564,47 @@ func downloadArtifactArchive(ctx context.Context, workflow GitHubWorkflowRef, ar
 	return data, nil
 }
 
-func extractIndexArtifactPayload(archive []byte) (Manifest, []byte, error) {
+func extractIndexArtifactPayload(archive []byte) (Manifest, []byte, []byte, error) {
 	reader, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
 	if err != nil {
-		return Manifest{}, nil, fmt.Errorf("open artifact archive: %w", err)
+		return Manifest{}, nil, nil, fmt.Errorf("open artifact archive: %w", err)
 	}
 
 	var manifestBytes []byte
 	var indexBytes []byte
+	var fileHashDBBytes []byte
 	for _, file := range reader.File {
 		switch path.Base(file.Name) {
 		case "manifest.json":
 			manifestBytes, err = readZipFile(file)
 		case "index.db":
 			indexBytes, err = readZipFile(file)
+		case "filehashes.db":
+			fileHashDBBytes, err = readZipFile(file)
 		default:
 			continue
 		}
 		if err != nil {
-			return Manifest{}, nil, err
+			return Manifest{}, nil, nil, err
 		}
 	}
 
 	if len(manifestBytes) == 0 {
-		return Manifest{}, nil, fmt.Errorf("artifact archive does not include manifest.json")
+		return Manifest{}, nil, nil, fmt.Errorf("artifact archive does not include manifest.json")
 	}
 	if len(indexBytes) == 0 {
-		return Manifest{}, nil, fmt.Errorf("artifact archive does not include index.db")
+		return Manifest{}, nil, nil, fmt.Errorf("artifact archive does not include index.db")
 	}
 
 	var manifest Manifest
 	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-		return Manifest{}, nil, fmt.Errorf("decode artifact manifest: %w", err)
+		return Manifest{}, nil, nil, fmt.Errorf("decode artifact manifest: %w", err)
 	}
 	manifest = manifest.Normalize()
 	if err := manifest.Validate(); err != nil {
-		return Manifest{}, nil, fmt.Errorf("validate artifact manifest: %w", err)
+		return Manifest{}, nil, nil, fmt.Errorf("validate artifact manifest: %w", err)
 	}
-	return manifest, indexBytes, nil
+	return manifest, indexBytes, fileHashDBBytes, nil
 }
 
 func readZipFile(file *zip.File) ([]byte, error) {

--- a/internal/semsearch/remote.go
+++ b/internal/semsearch/remote.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -31,8 +32,8 @@ const (
 )
 
 var (
-	ErrRemoteIndexNotPublished = errors.New("remote index is not published yet; run the searcher GitHub Actions workflow once to publish it")
-	ErrRemoteIndexIncompatible = errors.New("remote index uses an incompatible schema; rerun the searcher GitHub Actions workflow to publish a compatible index")
+	ErrRemoteIndexNotPublished = errors.New("remote index is not published yet; run the remote index workflow once to publish it")
+	ErrRemoteIndexIncompatible = errors.New("remote index uses an incompatible schema; rerun the remote index workflow to publish a compatible index")
 	gitHubAPIBaseURL           = defaultGitHubAPIBaseURL
 	gitHubContentBaseURL       = defaultGitHubContentBaseURL
 	remoteManifestHTTPClient   = &http.Client{Timeout: 20 * time.Second}
@@ -229,7 +230,7 @@ func SyncRemoteIndex(ctx context.Context, localDir string) (RemoteSyncResult, er
 				return RemoteSyncResult{
 					Checked:  true,
 					Manifest: manifest,
-					Note:     "Published remote index uses an older schema; using the local cache until the searcher workflow republishes it",
+					Note:     "Published remote index uses an older schema; using the local cache until the remote index workflow republishes it",
 				}, nil
 			}
 			if err := WriteManifest(localDir, remoteManifest); err != nil {
@@ -391,7 +392,7 @@ func activateDownloadedIndex(ctx context.Context, tmpPath string, destPath strin
 		}
 	}
 
-	if err := os.Rename(tmpPath, destPath); err != nil {
+	if err := replaceFile(tmpPath, destPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("activate %s: %w", destPath, err)
 	}
@@ -401,6 +402,8 @@ func activateDownloadedIndex(ctx context.Context, tmpPath string, destPath strin
 type gitHubWorkflowRunsResponse struct {
 	WorkflowRuns []gitHubWorkflowRun `json:"workflow_runs"`
 }
+
+const gitHubAPIPerPage = 100
 
 type gitHubWorkflowRun struct {
 	ID         int64  `json:"id"`
@@ -446,24 +449,32 @@ func findSearchArtifactForCommit(ctx context.Context, workflow GitHubWorkflowRef
 }
 
 func listWorkflowRuns(ctx context.Context, workflow GitHubWorkflowRef, commitSHA string) ([]gitHubWorkflowRun, error) {
-	runsURL, err := workflowRunsAPIURL(workflow, commitSHA)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := fetchRemoteBytes(ctx, runsURL)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("%w for commit %s", ErrRemoteIndexNotPublished, shortenCommitSHA(commitSHA))
+	allRuns := make([]gitHubWorkflowRun, 0, gitHubAPIPerPage)
+	for page := 1; ; page++ {
+		runsURL, err := workflowRunsAPIURL(workflow, commitSHA, page)
+		if err != nil {
+			return nil, err
 		}
-		return nil, fmt.Errorf("list workflow runs: %w", err)
+
+		data, err := fetchRemoteBytes(ctx, runsURL)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("%w for commit %s", ErrRemoteIndexNotPublished, shortenCommitSHA(commitSHA))
+			}
+			return nil, fmt.Errorf("list workflow runs: %w", err)
+		}
+
+		var payload gitHubWorkflowRunsResponse
+		if err := json.Unmarshal(data, &payload); err != nil {
+			return nil, fmt.Errorf("decode workflow runs: %w", err)
+		}
+		allRuns = append(allRuns, payload.WorkflowRuns...)
+		if len(payload.WorkflowRuns) < gitHubAPIPerPage {
+			break
+		}
 	}
 
-	var payload gitHubWorkflowRunsResponse
-	if err := json.Unmarshal(data, &payload); err != nil {
-		return nil, fmt.Errorf("decode workflow runs: %w", err)
-	}
-	return payload.WorkflowRuns, nil
+	return allRuns, nil
 }
 
 func findRunArtifact(ctx context.Context, workflow GitHubWorkflowRef, runID int64) (int64, bool, error) {
@@ -610,7 +621,7 @@ func handleRemoteManifestFetchError(fetchErr error, localDir string, manifest Ma
 			return RemoteSyncResult{
 				Checked:  true,
 				Manifest: manifest,
-				Note:     "Remote index is not published yet; using the local cache until the searcher workflow publishes it",
+				Note:     "Remote index is not published yet; using the local cache until the remote index workflow publishes it",
 			}, nil
 		}
 		return RemoteSyncResult{}, ErrRemoteIndexNotPublished
@@ -703,7 +714,7 @@ func joinURLPath(base string, elems ...string) (string, error) {
 	return parsed.String(), nil
 }
 
-func workflowRunsAPIURL(workflow GitHubWorkflowRef, commitSHA string) (string, error) {
+func workflowRunsAPIURL(workflow GitHubWorkflowRef, commitSHA string, page int) (string, error) {
 	base, err := joinURLPath(gitHubAPIBaseURL, "repos", workflow.Owner, workflow.Repo, "actions", "workflows", workflow.WorkflowFile, "runs")
 	if err != nil {
 		return "", err
@@ -714,9 +725,28 @@ func workflowRunsAPIURL(workflow GitHubWorkflowRef, commitSHA string) (string, e
 	}
 	query := parsed.Query()
 	query.Set("head_sha", strings.TrimSpace(commitSHA))
-	query.Set("per_page", "100")
+	query.Set("per_page", fmt.Sprintf("%d", gitHubAPIPerPage))
+	query.Set("page", fmt.Sprintf("%d", page))
 	parsed.RawQuery = query.Encode()
 	return parsed.String(), nil
+}
+
+func replaceFile(srcPath string, destPath string) error {
+	if err := os.Rename(srcPath, destPath); err == nil {
+		return nil
+	}
+
+	if runtime.GOOS != "windows" {
+		return os.Rename(srcPath, destPath)
+	}
+
+	if removeErr := os.Remove(destPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return fmt.Errorf("remove existing destination: %w", removeErr)
+	}
+	if err := os.Rename(srcPath, destPath); err != nil {
+		return err
+	}
+	return nil
 }
 
 func runArtifactsAPIURL(workflow GitHubWorkflowRef, runID int64) (string, error) {

--- a/internal/semsearch/remote_test.go
+++ b/internal/semsearch/remote_test.go
@@ -80,6 +80,7 @@ func TestSyncRemoteIndexDownloadsNewVersion(t *testing.T) {
 	remoteDBPath := filepath.Join(t.TempDir(), "remote-index.db")
 	remoteHash := writeTestIndexDB(t, remoteDBPath, 2, "/tmp/remote.go", 20, "hash2", []float32{3, 2, 1})
 	remoteDB := readTestIndexDBBytes(t, remoteDBPath)
+	fileHashDBBytes := []byte("file-hash-cache")
 	remoteManifest := Manifest{
 		SchemaVersion: ManifestSchemaVersion,
 		Version:       2,
@@ -95,6 +96,8 @@ func TestSyncRemoteIndexDownloadsNewVersion(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(remoteManifest)
 		case "/acme/widgets/gh-pages/semsearch/index.db":
 			_, _ = w.Write(remoteDB)
+		case "/acme/widgets/gh-pages/semsearch/filehashes.db":
+			_, _ = w.Write(fileHashDBBytes)
 		default:
 			http.NotFound(w, r)
 		}
@@ -127,6 +130,13 @@ func TestSyncRemoteIndexDownloadsNewVersion(t *testing.T) {
 	}
 	if string(gotDB) != string(remoteDB) {
 		t.Fatalf("synced db = %q, want %q", string(gotDB), string(remoteDB))
+	}
+	gotFileHashDB, err := os.ReadFile(filepath.Join(localDir, "filehashes.db"))
+	if err != nil {
+		t.Fatalf("read synced file hash db: %v", err)
+	}
+	if string(gotFileHashDB) != string(fileHashDBBytes) {
+		t.Fatalf("synced file hash db = %q, want %q", string(gotFileHashDB), string(fileHashDBBytes))
 	}
 
 	reloaded, err := ReadManifest(localDir)
@@ -299,6 +309,7 @@ func TestDownloadIndexArtifactForCommit(t *testing.T) {
 	remoteDBPath := filepath.Join(t.TempDir(), "artifact-index.db")
 	remoteHash := writeTestIndexDB(t, remoteDBPath, 9, "internal/search/service.go", 42, "hash9", []float32{9, 4, 2})
 	remoteDB := readTestIndexDBBytes(t, remoteDBPath)
+	fileHashDBBytes := []byte("artifact-file-hash-cache")
 	artifactManifest := Manifest{
 		SchemaVersion: ManifestSchemaVersion,
 		Version:       9,
@@ -306,7 +317,9 @@ func TestDownloadIndexArtifactForCommit(t *testing.T) {
 		Source:        "remote",
 		Remote:        &Remote{CIURL: ciURL},
 	}
-	artifactZip := buildArtifactArchive(t, artifactManifest, remoteDB)
+	artifactZip := buildArtifactArchiveWithExtraFiles(t, artifactManifest, remoteDB, map[string][]byte{
+		"filehashes.db": fileHashDBBytes,
+	})
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -377,6 +390,13 @@ func TestDownloadIndexArtifactForCommit(t *testing.T) {
 	}
 	if string(gotDB) != string(remoteDB) {
 		t.Fatalf("downloaded db != artifact db")
+	}
+	gotFileHashDB, err := os.ReadFile(filepath.Join(localDir, "filehashes.db"))
+	if err != nil {
+		t.Fatalf("os.ReadFile(filehashes.db) error: %v", err)
+	}
+	if string(gotFileHashDB) != string(fileHashDBBytes) {
+		t.Fatalf("downloaded file hash db != artifact file hash db")
 	}
 
 	reloaded, err := ReadManifest(localDir)
@@ -601,6 +621,11 @@ func TestWriteDownloadedIndexReplacesExistingDestination(t *testing.T) {
 
 func buildArtifactArchive(t *testing.T, manifest Manifest, indexBytes []byte) []byte {
 	t.Helper()
+	return buildArtifactArchiveWithExtraFiles(t, manifest, indexBytes, nil)
+}
+
+func buildArtifactArchiveWithExtraFiles(t *testing.T, manifest Manifest, indexBytes []byte, extraFiles map[string][]byte) []byte {
+	t.Helper()
 
 	var buf bytes.Buffer
 	writer := zip.NewWriter(&buf)
@@ -611,11 +636,16 @@ func buildArtifactArchive(t *testing.T, manifest Manifest, indexBytes []byte) []
 	}
 	manifestData = append(manifestData, '\n')
 
-	for name, data := range map[string][]byte{
+	files := map[string][]byte{
 		"manifest.json": manifestData,
 		"index.db":      indexBytes,
 		"logs/run.log":  []byte("ok\n"),
-	} {
+	}
+	for name, data := range extraFiles {
+		files[name] = data
+	}
+
+	for name, data := range files {
 		entry, err := writer.Create(name)
 		if err != nil {
 			t.Fatalf("writer.Create(%s) error: %v", name, err)

--- a/internal/semsearch/remote_test.go
+++ b/internal/semsearch/remote_test.go
@@ -489,6 +489,116 @@ func TestDownloadIndexArtifactForCommitRejectsIncompatibleIndex(t *testing.T) {
 	}
 }
 
+func TestDownloadIndexArtifactForCommitPaginatesWorkflowRuns(t *testing.T) {
+	localDir := t.TempDir()
+	commitSHA := "11223344556677889900aabbccddeeff00112233"
+	ciURL := "https://github.com/acme/widgets/actions/workflows/searcher.yml"
+
+	remoteDBPath := filepath.Join(t.TempDir(), "artifact-index.db")
+	remoteHash := writeTestIndexDB(t, remoteDBPath, 10, "internal/search/service.go", 7, "hash10", []float32{1, 0, 1})
+	remoteDB := readTestIndexDBBytes(t, remoteDBPath)
+	artifactManifest := Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Version:       10,
+		IndexingHash:  remoteHash,
+		Source:        "remote",
+		Remote:        &Remote{CIURL: ciURL},
+	}
+	artifactZip := buildArtifactArchive(t, artifactManifest, remoteDB)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/acme/widgets/actions/workflows/searcher.yml/runs":
+			page := r.URL.Query().Get("page")
+			w.Header().Set("Content-Type", "application/json")
+			switch page {
+			case "1":
+				runs := make([]map[string]any, 0, gitHubAPIPerPage)
+				for i := 0; i < gitHubAPIPerPage; i++ {
+					runs = append(runs, map[string]any{
+						"id":         i + 1,
+						"head_sha":   "ffffffffffffffffffffffffffffffffffffffff",
+						"status":     "completed",
+						"conclusion": "success",
+					})
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"workflow_runs": runs})
+			case "2":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"workflow_runs": []map[string]any{
+						{
+							"id":         999,
+							"head_sha":   commitSHA,
+							"status":     "completed",
+							"conclusion": "success",
+						},
+					},
+				})
+			default:
+				_ = json.NewEncoder(w).Encode(map[string]any{"workflow_runs": []map[string]any{}})
+			}
+		case "/repos/acme/widgets/actions/runs/999/artifacts":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"artifacts": []map[string]any{
+					{
+						"id":      456,
+						"name":    searchIndexArtifactName,
+						"expired": false,
+					},
+				},
+			})
+		case "/repos/acme/widgets/actions/artifacts/456/zip":
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(artifactZip)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	originalAPIBaseURL := gitHubAPIBaseURL
+	originalClient := remoteManifestHTTPClient
+	gitHubAPIBaseURL = server.URL
+	remoteManifestHTTPClient = server.Client()
+	t.Cleanup(func() {
+		gitHubAPIBaseURL = originalAPIBaseURL
+		remoteManifestHTTPClient = originalClient
+	})
+
+	result, err := DownloadIndexArtifactForCommit(context.Background(), localDir, "https://github.com/acme/widgets", commitSHA)
+	if err != nil {
+		t.Fatalf("DownloadIndexArtifactForCommit() error: %v", err)
+	}
+	if !result.Downloaded {
+		t.Fatalf("result.Downloaded = false, want true")
+	}
+}
+
+func TestWriteDownloadedIndexReplacesExistingDestination(t *testing.T) {
+	localDir := t.TempDir()
+	destPath := filepath.Join(localDir, "index.db")
+	if err := os.WriteFile(destPath, []byte("old-index"), 0o644); err != nil {
+		t.Fatalf("write old destination: %v", err)
+	}
+
+	remoteDBPath := filepath.Join(t.TempDir(), "replacement-index.db")
+	remoteHash := writeTestIndexDB(t, remoteDBPath, 3, "internal/search/service.go", 8, "hash3", []float32{3, 3, 3})
+	remoteDB := readTestIndexDBBytes(t, remoteDBPath)
+
+	if err := writeDownloadedIndex(destPath, remoteDB, remoteHash); err != nil {
+		t.Fatalf("writeDownloadedIndex() error: %v", err)
+	}
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("read replaced destination: %v", err)
+	}
+	if string(got) != string(remoteDB) {
+		t.Fatalf("replaced destination does not match downloaded db")
+	}
+}
+
 func buildArtifactArchive(t *testing.T, manifest Manifest, indexBytes []byte) []byte {
 	t.Helper()
 


### PR DESCRIPTION
## What Changed
- replaces downloaded `index.db` safely when a destination file already exists, including on Windows
- publishes and restores `.semsearch/filehashes.db` as part of the remote CI state so warm reindex scenarios can reuse the file hash cache
- paginates GitHub workflow runs for `remote download --commit` instead of stopping at the first 100 runs
- narrows the README skip filter so source files like `READMEParser.go` and `readme_utils.py` are not silently skipped
- adds focused regression tests for remote artifact paging, destination replacement, README false positives, and file hash cache restore

## Why
A few small edge cases could currently fail in quiet or misleading ways: Windows rename semantics break replacement of an existing downloaded index, older commits can disappear once a repository has more than 100 workflow runs, the broad README filter can skip real code files, and remote CI restores were not carrying the file hash cache needed for faster warm indexing.

## Impact
- remote download and remote sync are more reliable on Windows
- commit-pinned artifact download scales past the first page of workflow runs
- remote CI warm reindex runs can reuse published file hash state
- indexing no longer drops non-document source files just because their basename starts with `readme`

## Validation
- `go test ./internal/semsearch ./internal/indexing -count=1`
- `go test ./internal/cli ./internal/semsearch -count=1`
