### PR TITLE
ci: sync Mintlify docs to unch-docs

### DIFF
--- a/.github/workflows/sync-mintlify-docs.yml
+++ b/.github/workflows/sync-mintlify-docs.yml
@@ -1,0 +1,58 @@
+name: sync-mintlify-docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "mintlify/**"
+      - ".github/workflows/sync-mintlify-docs.yml"
+      - "scripts/sync_mintlify_docs.sh"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-mintlify-docs
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out unch
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Check out unch-docs
+        uses: actions/checkout@v6
+        with:
+          repository: uchebnick/unch-docs
+          token: ${{ secrets.UNCH_DOCS_SYNC_TOKEN }}
+          path: .docs-sync/unch-docs
+          fetch-depth: 0
+
+      - name: Sync Mintlify source into unch-docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/sync_mintlify_docs.sh mintlify .docs-sync/unch-docs
+
+      - name: Commit and push docs mirror
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd .docs-sync/unch-docs
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No unch-docs changes to publish."
+            exit 0
+          fi
+          git commit -m "docs: sync Mintlify source from unch@${GITHUB_SHA}"
+          git push

--- a/scripts/sync_mintlify_docs.sh
+++ b/scripts/sync_mintlify_docs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+src_dir="${1:?source directory is required}"
+dst_dir="${2:?destination directory is required}"
+
+if [[ ! -d "$src_dir" ]]; then
+  echo "source directory not found: $src_dir" >&2
+  exit 1
+fi
+
+if [[ ! -d "$dst_dir" ]]; then
+  echo "destination directory not found: $dst_dir" >&2
+  exit 1
+fi
+
+rsync -a --delete \
+  --exclude '.git' \
+  --exclude 'node_modules' \
+  --exclude '.mint' \
+  --exclude '.DS_Store' \
+  "$src_dir"/ "$dst_dir"/


### PR DESCRIPTION
## What changed
- adds a `sync-mintlify-docs` workflow in `unch`
- adds `scripts/sync_mintlify_docs.sh` to mirror `mintlify/` into `uchebnick/unch-docs`
- uses `UNCH_DOCS_SYNC_TOKEN` to push the docs mirror after merges to `main`

## Why
- contributors should only need to edit `mintlify/` in the main repo
- publishing to `unch-docs` should happen automatically in CI

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sync-mintlify-docs.yml")'`
- `bash -n scripts/sync_mintlify_docs.sh`
- local dry-run sync into `/Users/uchebnick/projects/unch-docs`
