### PR TITLE
[codex] docs: enrich Mintlify docs UX

### DIFF
--- a/mintlify/ci/github-actions.mdx
+++ b/mintlify/ci/github-actions.mdx
@@ -3,52 +3,52 @@ title: GitHub Actions
 description: Step-by-step guide to setting up the unch remote index workflow in your repository.
 ---
 
-## Setup
+<Steps>
+  <Step title="Create the workflow file">
+    ```bash
+    unch create ci
+    ```
 
-### 1. Create the workflow file
+    This writes `.github/workflows/unch-index.yml`.
 
-```bash
-unch create ci
-```
+    To scaffold into another repository:
 
-This writes `.github/workflows/unch-index.yml`.
+    ```bash
+    unch create ci --root ../other-repo
+    ```
+  </Step>
 
-To scaffold into another repository:
+  <Step title="Commit the workflow">
+    ```bash
+    git add .github/workflows/unch-index.yml
+    git commit -m "Add unch remote index workflow"
+    ```
+  </Step>
 
-```bash
-unch create ci --root ../other-repo
-```
+  <Step title="Bind the local manifest">
+    ```bash
+    unch bind ci https://github.com/owner/repo
+    ```
 
-### 2. Commit the workflow
+    You can also bind directly to a workflow URL:
 
-```bash
-git add .github/workflows/unch-index.yml
-git commit -m "Add unch remote index workflow"
-```
+    ```bash
+    unch bind ci https://github.com/owner/repo/actions/workflows/unch-index.yml
+    ```
+  </Step>
 
-### 3. Bind the local manifest
+  <Step title="Push and verify">
+    Push the commit and confirm that the workflow succeeds in the repository Actions tab.
+  </Step>
 
-```bash
-unch bind ci https://github.com/owner/repo
-```
+  <Step title="Force sync if needed">
+    ```bash
+    unch remote sync
+    ```
 
-You can also bind directly to a workflow URL:
-
-```bash
-unch bind ci https://github.com/owner/repo/actions/workflows/unch-index.yml
-```
-
-### 4. Push and verify
-
-Push the commit and confirm that the workflow succeeds in the repository Actions tab.
-
-### 5. Force sync if needed
-
-```bash
-unch remote sync
-```
-
-After the first successful publish, `unch search` can auto-refresh from remote when a newer version exists.
+    After the first successful publish, `unch search` can auto-refresh from remote when a newer version exists.
+  </Step>
+</Steps>
 
 ## Workflow inputs
 
@@ -59,6 +59,19 @@ The generated workflow supports manual `workflow_dispatch` inputs:
 - `skip_publish`
 
 These are useful for bootstrap flows, debugging, and controlled republish runs.
+
+<Tabs>
+  <Tab title="Repository URL bind">
+    ```bash
+    unch bind ci https://github.com/owner/repo
+    ```
+  </Tab>
+  <Tab title="Workflow URL bind">
+    ```bash
+    unch bind ci https://github.com/owner/repo/actions/workflows/unch-index.yml
+    ```
+  </Tab>
+</Tabs>
 
 ## Bootstrap flows
 
@@ -77,3 +90,19 @@ When a release changes indexing or storage compatibility:
 1. rerun the repository’s `unch-index.yml` workflow
 2. let CI republish a compatible `index.db`, `manifest.json`, and `filehashes.db`
 3. run `unch remote sync` or just search again locally
+
+<AccordionGroup>
+  <Accordion title="What does the workflow publish?">
+    The generated workflow publishes `index.db`, `manifest.json`, and `filehashes.db`.
+
+    That gives later restores both the active index and the warm file-hash cache.
+  </Accordion>
+  <Accordion title="What if no remote artifact exists yet?">
+    Use `unch remote sync --allow-missing` during bootstrap or first-run CI flows.
+
+    That way a missing artifact does not fail the entire flow before the first publish exists.
+  </Accordion>
+  <Accordion title="What should I rerun after an incompatible release?">
+    Rerun `.github/workflows/unch-index.yml` so the repository republishes state compatible with the upgraded binary.
+  </Accordion>
+</AccordionGroup>

--- a/mintlify/ci/overview.mdx
+++ b/mintlify/ci/overview.mdx
@@ -5,6 +5,18 @@ description: Publish a shared search index via GitHub Actions so your team alway
 
 By default, `unch` is entirely local. Remote indexing through GitHub Actions is an optional layer on top.
 
+<CardGroup cols={3}>
+  <Card title="Stay local by default" icon="laptop">
+    You only need CI when you want a shared published state for the repository.
+  </Card>
+  <Card title="Warm restores" icon="arrows-rotate">
+    Published remote state includes `filehashes.db`, so warm reindex paths can reuse the same file-hash cache.
+  </Card>
+  <Card title="Latest compatible state" icon="cloud-arrow-down">
+    `unch search` and `unch remote sync` restore only state that matches the local binary schema.
+  </Card>
+</CardGroup>
+
 ## When remote indexing helps
 
 - Multiple people search the same repository
@@ -13,10 +25,20 @@ By default, `unch` is entirely local. Remote indexing through GitHub Actions is 
 
 ## How the workflow works
 
-1. `unch create ci` writes `.github/workflows/unch-index.yml`
-2. `unch bind ci <github-repo-url>` records the remote workflow in the local manifest
-3. GitHub Actions builds and publishes the search state
-4. `unch search` and `unch remote sync` restore the latest compatible published state when needed
+<Steps>
+  <Step title="Generate the workflow">
+    `unch create ci` writes `.github/workflows/unch-index.yml`.
+  </Step>
+  <Step title="Bind the checkout">
+    `unch bind ci <github-repo-url>` records the remote workflow in the local manifest.
+  </Step>
+  <Step title="Publish shared state">
+    GitHub Actions builds and publishes the search state for the repository.
+  </Step>
+  <Step title="Restore when needed">
+    `unch search` and `unch remote sync` restore the latest compatible published state when needed.
+  </Step>
+</Steps>
 
 ## What gets published
 
@@ -33,3 +55,7 @@ That lets warm restore and warm reindex paths reuse the same file-hash cache ins
 Running `unch index` locally on a repository that is bound to remote CI detaches the manifest from remote mode and switches it back to local-only state.
 
 After a local reindex, run `unch bind ci <github-repo-url>` again if you want that checkout to follow remote updates.
+
+<Tip>
+  Use remote indexing for shared state, not as a requirement for basic local search. The normal `unch` flow still works fully without CI.
+</Tip>

--- a/mintlify/commands.mdx
+++ b/mintlify/commands.mdx
@@ -21,6 +21,10 @@ description: Overview of the main unch CLI commands.
   </Card>
 </CardGroup>
 
+<Tip>
+  `--state-dir` is the preferred way to point `unch` at external or shared local state. `--db` is kept only as a legacy alias.
+</Tip>
+
 ## Typical local flow
 
 ```bash

--- a/mintlify/commands/index.mdx
+++ b/mintlify/commands/index.mdx
@@ -9,6 +9,36 @@ description: Build or refresh the local search index for a repository.
 unch index [flags]
 ```
 
+<CardGroup cols={3}>
+  <Card title="Default state" icon="folder-tree">
+    `unch index --root .` builds or refreshes `./.semsearch`.
+  </Card>
+  <Card title="Custom state dir" icon="folder-open">
+    Use `--state-dir` when you want the index somewhere other than `<root>/.semsearch`.
+  </Card>
+  <Card title="Model-aware snapshots" icon="brain">
+    Each embedding model keeps its own active snapshot.
+  </Card>
+</CardGroup>
+
+## Common flow
+
+<Steps>
+  <Step title="Pick a repository root">
+    ```bash
+    unch index --root .
+    ```
+  </Step>
+  <Step title="Optionally pick a model or external state dir">
+    ```bash
+    unch index --model qwen3 --state-dir /tmp/project.semsearch
+    ```
+  </Step>
+  <Step title="Reuse warm state when possible">
+    Unchanged files reuse the existing file-hash cache and indexed snapshot data instead of rebuilding everything from scratch.
+  </Step>
+</Steps>
+
 ## Flags
 
 ### `--root`
@@ -73,8 +103,44 @@ unch index --model ~/.semsearch/models/Qwen3-Embedding-0.6B-Q8_0.gguf
 unch index --state-dir /tmp/project.semsearch
 ```
 
+<Tabs>
+  <Tab title="Default repo-local state">
+    ```bash
+    unch index --root .
+    ```
+  </Tab>
+  <Tab title="Custom state directory">
+    ```bash
+    unch index --root . --state-dir /tmp/project.semsearch
+    ```
+  </Tab>
+  <Tab title="Different model">
+    ```bash
+    unch index --root . --model qwen3
+    ```
+  </Tab>
+</Tabs>
+
 ## Notes
 
 - The first run may download the default embedding model and local `yzma` runtime libraries.
 - If the repository is currently bound to remote CI, a local reindex detaches that binding and returns the manifest to local mode.
 - Use the same model family for `index` and `search`, otherwise ranking quality will be wrong.
+
+<AccordionGroup>
+  <Accordion title="Why is --db deprecated?">
+    `unch` state is no longer just one database file.
+
+    The full `.semsearch` directory contains `index.db`, `manifest.json`, `filehashes.db`, and related runtime state, so `--state-dir` is the more honest interface.
+  </Accordion>
+  <Accordion title="When do legacy prefix flags matter?">
+    `--comment-prefix` and `--context-prefix` only matter in fallback indexing paths for unsupported files or parser failures.
+
+    They are not part of the normal Tree-sitter-based flow for supported languages.
+  </Accordion>
+  <Accordion title="What happens to remote binding after a local reindex?">
+    A local reindex switches the manifest back to local-only mode.
+
+    Rebind with `unch bind ci ...` afterwards if you want that checkout to follow remote updates again.
+  </Accordion>
+</AccordionGroup>

--- a/mintlify/commands/remote.mdx
+++ b/mintlify/commands/remote.mdx
@@ -7,12 +7,45 @@ Remote indexing is optional. Use it when you want GitHub Actions to build and pu
 
 The generated workflow file is `.github/workflows/unch-index.yml`.
 
+<CardGroup cols={2}>
+  <Card title="Create CI scaffold" icon="wand-magic-sparkles" href="#unch-create-ci">
+    Generate the workflow file for remote indexing.
+  </Card>
+  <Card title="Bind local state" icon="link" href="#unch-bind-ci">
+    Connect the current checkout to a repo or workflow URL.
+  </Card>
+  <Card title="Sync latest remote state" icon="arrows-rotate" href="#unch-remote-sync">
+    Restore the newest published index into your local `.semsearch`.
+  </Card>
+  <Card title="Download by commit" icon="download" href="#unch-remote-download">
+    Fetch a specific published artifact without rebinding to latest.
+  </Card>
+</CardGroup>
+
 ## Typical setup flow
 
 1. Run `unch create ci`.
 2. Run `unch bind ci <github-repo-or-workflow-url>`.
 3. Commit and push the workflow.
 4. After the workflow succeeds once, `unch search` and `unch remote sync` can restore the published state.
+
+<Tabs>
+  <Tab title="Bootstrap shared search">
+    ```bash
+    unch create ci
+    unch bind ci https://github.com/owner/repo
+    git add .github/workflows/unch-index.yml
+    git commit -m "ci: add unch remote indexing"
+    git push
+    ```
+  </Tab>
+  <Tab title="Pin to one commit">
+    ```bash
+    unch remote download --commit abc123 https://github.com/owner/repo
+    unch search --state-dir .semsearch "router middleware"
+    ```
+  </Tab>
+</Tabs>
 
 ## `unch create ci`
 
@@ -55,3 +88,7 @@ unch remote download --commit abc123 https://github.com/uchebnick/unch/actions/w
 ```
 
 The downloaded manifest is activated as local-only state so future searches do not auto-sync to the latest remote artifact by accident.
+
+<Tip>
+  Published remote state includes `index.db`, `manifest.json`, and `filehashes.db`, so warm reindex flows can reuse the file hash cache too.
+</Tip>

--- a/mintlify/commands/search.mdx
+++ b/mintlify/commands/search.mdx
@@ -11,6 +11,43 @@ unch search [flags] <query>
 
 The query can be passed positionally or with `--query`. When both are present, `--query` wins.
 
+<CardGroup cols={3}>
+  <Card title="Auto mode" icon="sparkles">
+    Best default for natural-language queries about behavior.
+  </Card>
+  <Card title="Semantic mode" icon="brain">
+    Force embedding-only retrieval when you want conceptual matches.
+  </Card>
+  <Card title="Lexical mode" icon="binary">
+    Force exact-term retrieval when you already know the identifier or string.
+  </Card>
+</CardGroup>
+
+## Common search patterns
+
+<Tabs>
+  <Tab title="Behavior query">
+    ```bash
+    unch search "create a new router"
+    ```
+  </Tab>
+  <Tab title="Exact symbol">
+    ```bash
+    unch search --mode lexical "ParseQuery"
+    ```
+  </Tab>
+  <Tab title="Detailed inspection">
+    ```bash
+    unch search --details "get path variables from a request"
+    ```
+  </Tab>
+  <Tab title="External state dir">
+    ```bash
+    unch search --state-dir /tmp/project.semsearch "router middleware"
+    ```
+  </Tab>
+</Tabs>
+
 ## Flags
 
 ### `--query`
@@ -84,3 +121,17 @@ unch search --state-dir /tmp/project.semsearch "router middleware"
 - `auto` stays semantic-first for natural-language queries.
 - If the manifest is bound to remote CI, `unch search` can refresh from remote automatically before running the query.
 - If no active snapshot exists for the requested model, `unch` tells you to run `unch index --model <model>` first.
+
+<AccordionGroup>
+  <Accordion title="When should I force lexical mode?">
+    Force lexical mode when you already know the identifier, string literal, or exact term you want to match.
+  </Accordion>
+  <Accordion title="When should I force semantic mode?">
+    Force semantic mode when the query is about behavior or intent and exact string overlap is weak.
+  </Accordion>
+  <Accordion title="Why should index and search use the same model?">
+    Ranking quality depends on query and document embeddings living in the same model space.
+
+    If you indexed with one model and search with another, the results may degrade or fail entirely.
+  </Accordion>
+</AccordionGroup>

--- a/mintlify/index.mdx
+++ b/mintlify/index.mdx
@@ -3,24 +3,82 @@ title: unch
 description: Local-first semantic code search for code symbols and docs.
 ---
 
-`unch` indexes functions, methods, types, classes, interfaces, and attached docs with Tree-sitter, then lets you search them from the terminal.
+`unch` lets you find functions, methods, types, classes, interfaces, and attached docs by describing what the code does, not by remembering the exact name or file path.
 
-It is useful when you know what the code does, but not the symbol name or file path. Local indexing is the default. Remote publishing is optional.
+Everything stays local by default. Remote publishing is optional.
+
+<Tip>
+  If you only want the docs site in Mintlify, connect `unch-docs` rather than the main `unch` code repository.
+</Tip>
 
 <CardGroup cols={2}>
-  <Card title="Install unch" icon="download" href="/installation">
-    Pick Homebrew, shell installer, PowerShell, or source install.
+  <Card title="Installation" icon="download" href="/installation">
+    Install via Homebrew, shell installer, PowerShell, or `go install`.
   </Card>
   <Card title="Quick Start" icon="rocket" href="/quickstart">
-    Index a repository and run your first semantic search.
+    Index a repo and run your first search in under a minute.
   </Card>
   <Card title="Commands" icon="terminal" href="/commands">
-    See the main CLI flows for local indexing, search, and remote sync.
+    Full reference for `index`, `search`, and `remote`.
   </Card>
-  <Card title="CI & Remote Indexing" icon="github" href="/ci/overview">
+  <Card title="CI & Remote" icon="cloud-arrow-down" href="/ci/overview">
     Publish and reuse indexes through GitHub Actions when you need shared state.
   </Card>
 </CardGroup>
+
+## Pick a workflow
+
+<Tabs>
+  <Tab title="Local-first">
+    ```bash
+    unch index --root .
+    unch search "create a new router"
+    unch search --details "get path variables from a request"
+    ```
+  </Tab>
+  <Tab title="Shared via CI">
+    ```bash
+    unch create ci
+    unch bind ci https://github.com/owner/repo
+    unch remote sync
+    unch search "create a new router"
+    ```
+  </Tab>
+</Tabs>
+
+## What you get
+
+<CardGroup cols={2}>
+  <Card title="Symbol-aware indexing" icon="brackets-curly">
+    Index top-level API objects and attached docs instead of raw lines only.
+  </Card>
+  <Card title="Local-first by default" icon="laptop">
+    Keep indexing and search on your machine unless you explicitly publish remote state.
+  </Card>
+  <Card title="Semantic and lexical retrieval" icon="magnifying-glass">
+    Use `auto`, `semantic`, or `lexical` mode depending on how specific the query is.
+  </Card>
+  <Card title="Optional remote reuse" icon="github">
+    Publish through `.github/workflows/unch-index.yml` when you want a shared cache.
+  </Card>
+</CardGroup>
+
+## Typical flow
+
+<Steps>
+  <Step title="Install unch">
+    Start with [Installation](/installation).
+  </Step>
+  <Step title="Index a repository">
+    Run `unch index --root .` inside the project you want to search.
+  </Step>
+  <Step title="Search by behavior">
+    Describe what the code does instead of typing the exact symbol name.
+  </Step>
+  <Step title="Inspect details when needed">
+    Add `--details` to show kind, signature, docs, and body context.
+  </Step>
+</Steps>
 
 ## Start here
 
@@ -28,21 +86,3 @@ It is useful when you know what the code does, but not the symbol name or file p
 - [Quick Start](/quickstart)
 - [Commands](/commands)
 - [CI & Remote Indexing](/ci/overview)
-
-## What you get
-
-- Local-first search over top-level API objects and attached docs
-- Tree-sitter extraction for Go, TypeScript, JavaScript, and Python
-- `auto`, `semantic`, and `lexical` search modes
-- Optional GitHub Actions publishing through `.github/workflows/unch-index.yml`
-
-## Typical flow
-
-1. Install `unch`.
-2. Run `unch index --root .` in a repository.
-3. Run `unch search "create a new router"`.
-4. Add `--details` when you want signatures and docs in the output.
-
-<Tip>
-  If you only want the docs repo in Mintlify, connect `unch-docs` rather than the main `unch` code repository.
-</Tip>

--- a/mintlify/installation.mdx
+++ b/mintlify/installation.mdx
@@ -3,6 +3,18 @@ title: Installation
 description: Install unch with Homebrew, shell installer, PowerShell, go install, or build from source.
 ---
 
+<CardGroup cols={3}>
+  <Card title="Fastest path" icon="bolt">
+    Use Homebrew on macOS or the shell and PowerShell installers on release-supported targets.
+  </Card>
+  <Card title="Most flexible" icon="sliders">
+    Use `go install` or build from source when you want a local checkout or custom toolchain flow.
+  </Card>
+  <Card title="Release coverage" icon="box-archive">
+    Published archives cover macOS, Linux, and Windows on both `arm64` and `x86_64`.
+  </Card>
+</CardGroup>
+
 ## Requirements
 
 On supported release targets, the installers use published archives by default, so Go is not required.
@@ -99,18 +111,6 @@ On Windows source builds, that means an MSYS2 or MinGW-style toolchain, or an eq
   </Tab>
 </Tabs>
 
-<CardGroup cols={3}>
-  <Card title="Fastest path" icon="bolt">
-    Use Homebrew on macOS or the shell/PowerShell installer on release-supported targets.
-  </Card>
-  <Card title="Most flexible" icon="sliders">
-    Use `go install` or build from source when you want a local checkout or custom toolchain flow.
-  </Card>
-  <Card title="No Go required" icon="box-archive">
-    Published release archives cover macOS, Linux, and Windows on both `arm64` and `x86_64`.
-  </Card>
-</CardGroup>
-
 ## Published release archives
 
 | Platform | Architectures | Status |
@@ -125,6 +125,22 @@ On Windows source builds, that means an MSYS2 or MinGW-style toolchain, or an eq
 unch --help
 ```
 
+<AccordionGroup>
+  <Accordion title="When should I prefer release installers?">
+    Prefer the release installers when your platform has a matching published archive and you just want a working binary quickly.
+
+    That path does not require Go and is the one covered by install smoke checks in CI.
+  </Accordion>
+  <Accordion title="When should I use go install or build from source?">
+    Use source-based install when you want to work from a checkout, pin your own toolchain, or run on a target without a matching release archive.
+  </Accordion>
+  <Accordion title="What is special about Windows source builds?">
+    Windows source builds need a working C toolchain.
+
+    In practice that means MSYS2, MinGW, or an equivalent environment that can build the Tree-sitter and SQLite dependencies.
+  </Accordion>
+</AccordionGroup>
+
 <Tip>
-  If Mintlify is connected to the separate docs repository, keep product docs changes in `unch-docs` so deploys stay isolated from code changes.
+  If `unch` is installed but not found, make sure the installer destination is on your `PATH`.
 </Tip>

--- a/mintlify/quickstart.mdx
+++ b/mintlify/quickstart.mdx
@@ -3,47 +3,75 @@ title: Quick Start
 description: Index a repository and run your first search in under a minute.
 ---
 
-## Index a repository
+<Steps>
+  <Step title="Index a repository">
+    ```bash
+    cd path/to/repo
+    unch index --root .
+    ```
 
-```bash
-cd path/to/repo
-unch index --root .
-```
+    Real output from indexing [`gorilla/mux`](https://github.com/gorilla/mux):
 
-Real output from indexing [`gorilla/mux`](https://github.com/gorilla/mux):
+    ```text
+    $ unch index --root .
+    Loaded model       dim=768
+    Indexed 278 symbols in 16 files
+    ```
+  </Step>
 
-```text
-$ unch index --root .
-Loaded model       dim=768
-Indexed 278 symbols in 16 files
-```
+  <Step title="Run your first search">
+    ```bash
+    unch search "create a new router"
+    ```
 
-## Run your first search
+    ```text
+    $ unch search "create a new router"
+    1. mux.go:32  0.7747
+    2. mux.go:314 0.8135
+    ```
+  </Step>
 
-```bash
-unch search "create a new router"
-```
+  <Step title="Add details when you want richer output">
+    ```bash
+    unch search --details "get path variables from a request"
+    ```
 
-```text
-$ unch search "create a new router"
-1. mux.go:32  0.7747
-2. mux.go:314 0.8135
-```
+    ```text
+    $ unch search --details "get path variables from a request"
+    1. mux.go:466  0.7991
+       kind: function
+       name: Vars
+       signature: func Vars(r *http.Request) map[string]string
+       docs: Vars returns the route variables for the current request, if any.
+    ```
+  </Step>
+</Steps>
 
-Add `--details` for richer output:
+## Search modes in practice
 
-```bash
-unch search --details "get path variables from a request"
-```
+<Tabs>
+  <Tab title="Auto">
+    Best default for natural-language queries.
 
-```text
-$ unch search --details "get path variables from a request"
-1. mux.go:466  0.7991
-   kind: function
-   name: Vars
-   signature: func Vars(r *http.Request) map[string]string
-   docs: Vars returns the route variables for the current request, if any.
-```
+    ```bash
+    unch search "create a new router"
+    ```
+  </Tab>
+  <Tab title="Semantic">
+    Use when you want embedding-driven matches only.
+
+    ```bash
+    unch search --mode semantic "parse query parameters"
+    ```
+  </Tab>
+  <Tab title="Lexical">
+    Use when you already know the exact identifier or string.
+
+    ```bash
+    unch search --mode lexical "ParseQuery"
+    ```
+  </Tab>
+</Tabs>
 
 ## What happens on first run
 
@@ -54,6 +82,10 @@ The first `unch index` may:
 - create `./.semsearch/`
 
 Each model keeps its own active index snapshot. Rebuilding `qwen3` does not replace the active `embeddinggemma` snapshot until the new run finishes successfully.
+
+<Tip>
+  If you want to keep state somewhere other than `./.semsearch`, use `--state-dir`.
+</Tip>
 
 ## Next steps
 

--- a/mintlify/reference/compatibility.mdx
+++ b/mintlify/reference/compatibility.mdx
@@ -56,6 +56,29 @@ description: Support matrix, upgrade rules, and versioning contract for unch.
 
 Published release binaries and CI builds on macOS, Linux, and Windows arm64/x86_64 use the full cgo-backed Tree-sitter and SQLite stack. Manual Windows builds without cgo remain a fallback path and should not be treated as identical to the published binaries.
 
+<AccordionGroup>
+  <Accordion title="CLI stability">
+    Existing commands and flags are expected to stay stable across patch releases.
+
+    Breaking CLI changes should only happen in minor releases, and new flags should be additive.
+  </Accordion>
+  <Accordion title="Manifest and index state">
+    Local repository state lives in `.semsearch/manifest.json`.
+
+    `schema_version` governs manifest compatibility, while `index.db` remains a rebuildable cache artifact rather than a durable user database.
+  </Accordion>
+  <Accordion title="Remote and CI state">
+    Remote sync only trusts published state when it is compatible with the local binary.
+
+    If a published remote index uses an older incompatible schema, local search should keep using a compatible local cache when available.
+  </Accordion>
+  <Accordion title="Practical upgrade rule">
+    If `unch` upgrades and local search breaks, rerun `unch index`.
+
+    If remote sync reports an incompatible published schema, rerun `.github/workflows/unch-index.yml`.
+  </Accordion>
+</AccordionGroup>
+
 ## Practical upgrade rules
 
 - If `unch` upgrades and local search breaks, rerun `unch index`

--- a/mintlify/reference/troubleshooting.mdx
+++ b/mintlify/reference/troubleshooting.mdx
@@ -3,89 +3,91 @@ title: Troubleshooting
 description: Solutions to common issues with unch.
 ---
 
-## "No active index for model X; run unch index --model X first"
+<AccordionGroup>
+  <Accordion title='No active index for model X; run `unch index --model X` first'>
+    Cause:
 
-Cause:
+    - you searched with a different model than the one used for indexing
 
-- you searched with a different model than the one used for indexing
+    Fix:
 
-Fix:
+    ```bash
+    unch index --model <model-name>
+    unch search --model <model-name> "query"
+    ```
+  </Accordion>
 
-```bash
-unch index --model <model-name>
-unch search --model <model-name> "query"
-```
+  <Accordion title="Search returns no results or poor results">
+    Try:
 
-## Search returns no results or poor results
+    - `--mode semantic`
+    - `--mode lexical`
+    - rephrasing the query in terms of behavior
+    - confirming that `index` and `search` use the same model
 
-Try:
+    ```bash
+    unch search --mode semantic "parse query parameters"
+    unch search --mode lexical "ParseQuery"
+    ```
+  </Accordion>
 
-- `--mode semantic`
-- `--mode lexical`
-- rephrasing the query in terms of behavior
-- confirming that `index` and `search` use the same model
+  <Accordion title="First run is slow">
+    That is usually expected. The first run may download:
 
-```bash
-unch search --mode semantic "parse query parameters"
-unch search --mode lexical "ParseQuery"
-```
+    - the GGUF embedding model
+    - the local `yzma` runtime libraries
 
-## First run is slow
+    Later runs reuse those caches.
+  </Accordion>
 
-That is usually expected. The first run may download:
+  <Accordion title="Remote sync fails with an incompatible schema error">
+    Rerun the repository remote index workflow so it republishes compatible state:
 
-- the GGUF embedding model
-- the local `yzma` runtime libraries
+    - `index.db`
+    - `manifest.json`
+    - `filehashes.db`
 
-Later runs reuse those caches.
+    Then run:
 
-## Remote sync fails with an incompatible schema error
+    ```bash
+    unch remote sync
+    ```
+  </Accordion>
 
-Rerun the repository remote index workflow so it republishes compatible state:
+  <Accordion title="Local search breaks after upgrading unch">
+    Rebuild the local index:
 
-- `index.db`
-- `manifest.json`
-- `filehashes.db`
+    ```bash
+    unch index
+    ```
+  </Accordion>
 
-Then run:
+  <Accordion title="Mintlify site does not refresh after a docs push">
+    Confirm that Mintlify is connected to the `unch-docs` repository and not the main `unch` code repository.
+  </Accordion>
 
-```bash
-unch remote sync
-```
+  <Accordion title="bind ci requires exactly one GitHub repository or workflow URL">
+    Pass exactly one URL:
 
-## Local search breaks after upgrading unch
+    ```bash
+    unch bind ci https://github.com/owner/repo
+    unch bind ci https://github.com/owner/repo/actions/workflows/unch-index.yml
+    ```
+  </Accordion>
 
-Rebuild the local index:
+  <Accordion title="Local reindex canceled; remote CI binding preserved">
+    You tried to run `unch index` on a checkout bound to remote CI and declined the detach prompt.
 
-```bash
-unch index
-```
+    If you want a local rebuild:
 
-## Mintlify site does not refresh after a docs push
+    1. run `unch index` again
+    2. confirm the prompt
+    3. rebind afterwards if you still want remote sync for that checkout
 
-Confirm that Mintlify is connected to the `unch-docs` repository and not the main `unch` code repository.
+    If you only want the latest published state instead:
 
-## bind ci requires exactly one GitHub repository or workflow URL
-
-Pass exactly one URL:
-
-```bash
-unch bind ci https://github.com/owner/repo
-unch bind ci https://github.com/owner/repo/actions/workflows/unch-index.yml
-```
-
-## local reindex canceled; remote CI binding preserved
-
-You tried to run `unch index` on a checkout bound to remote CI and declined the detach prompt.
-
-If you want a local rebuild:
-
-1. run `unch index` again
-2. confirm the prompt
-3. rebind afterwards if you still want remote sync for that checkout
-
-If you only want the latest published state instead:
-
-```bash
-unch remote sync
-```
+    ```bash
+    unch remote sync
+    ```
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
## What changed

This refreshes the Mintlify docs to use more of the MDX and Mintlify UI surface instead of mostly plain prose.

## Highlights

- upgrades the homepage with card-style entry points, workflow tabs, and step-based onboarding
- adds richer Mintlify components across installation, quick start, command reference, CI, compatibility, and troubleshooting pages
- makes the docs feel more like a product site instead of a straight markdown port

## Impact

- better first-run docs UX on the Mintlify site
- clearer navigation for installation, commands, and remote CI flows
- no product code changes

## Validation

- `mint broken-links`
