### PR TITLE
[codex] ci: retry MSYS2 package installs on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,13 @@ jobs:
           release: ${{ matrix.msys_release }}
           update: ${{ matrix.msys_update }}
           cache: ${{ matrix.msys_cache }}
-          install: ${{ matrix.msys_pkg }}
+
+      - name: Install MSYS2 toolchain package
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          bash ./scripts/install_msys2_package.sh "${{ matrix.msys_pkg }}"
 
       - name: Restore benchmark cache
         uses: actions/cache@v5
@@ -247,7 +253,13 @@ jobs:
           release: ${{ matrix.msys_release }}
           update: ${{ matrix.msys_update }}
           cache: ${{ matrix.msys_cache }}
-          install: ${{ matrix.msys_pkg }}
+
+      - name: Install MSYS2 toolchain package
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          bash ./scripts/install_msys2_package.sh "${{ matrix.msys_pkg }}"
 
       - name: Build all packages
         if: runner.os != 'Windows'
@@ -329,7 +341,13 @@ jobs:
           release: ${{ matrix.msys_release }}
           update: ${{ matrix.msys_update }}
           cache: ${{ matrix.msys_cache }}
-          install: ${{ matrix.msys_pkg }}
+
+      - name: Install MSYS2 toolchain package
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          bash ./scripts/install_msys2_package.sh "${{ matrix.msys_pkg }}"
 
       - name: Build local Unix release asset
         if: runner.os != 'Windows'

--- a/scripts/install_msys2_package.sh
+++ b/scripts/install_msys2_package.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+pkg="${1:?usage: install_msys2_package.sh <package>}"
+attempts="${MSYS2_PACMAN_ATTEMPTS:-3}"
+base_delay="${MSYS2_PACMAN_RETRY_DELAY_SECONDS:-5}"
+
+attempt=1
+while [ "$attempt" -le "$attempts" ]; do
+  if pacman --noconfirm -S --needed --overwrite '*' "$pkg"; then
+    exit 0
+  fi
+
+  if [ "$attempt" -eq "$attempts" ]; then
+    echo "pacman install failed for ${pkg} after ${attempts} attempts" >&2
+    exit 1
+  fi
+
+  echo "Retrying pacman install for ${pkg} (attempt $((attempt + 1))/${attempts})" >&2
+  pacman -Scc --noconfirm || true
+  sleep $((base_delay * attempt))
+  attempt=$((attempt + 1))
+done


### PR DESCRIPTION
## What changed

This moves Windows MSYS2 package installation out of `msys2/setup-msys2` and into an explicit retrying step.

## Root cause

The failing `install-smoke (windows-arm64)` job was not broken by the docs diff itself. It failed while `msys2/setup-msys2` was downloading toolchain packages via `pacman`, with a mirror timeout on `mingw-w64-clang-aarch64-zlib`.

## Fix

- stop using the built-in `install:` path in `msys2/setup-msys2`
- add `scripts/install_msys2_package.sh`
- retry `pacman -S --needed` installs for Windows benchmark, test, and install-smoke jobs

## Validation

- `bash -n scripts/install_msys2_package.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
