### PR TITLE
[codex] docs: add docs site badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Homebrew Tap](https://img.shields.io/badge/Homebrew-uchebnick%2Ftap-FBB040?logo=homebrew&logoColor=white)](https://github.com/uchebnick/homebrew-tap)
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/uchebnick/unch/gh-pages/coverage/coverage-badge.json)](https://github.com/uchebnick/unch/actions/workflows/ci.yml)
 [![Go 1.25+](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white)](https://github.com/uchebnick/unch)
+[![Docs](https://img.shields.io/badge/Docs-unch.mintlify.app-0F172A)](https://unch.mintlify.app/)
 [![Telegram News](https://img.shields.io/badge/Telegram-News-26A5E4?logo=telegram&logoColor=white)](https://t.me/unchnews)
 [![Telegram Chat](https://img.shields.io/badge/Telegram-Chat-26A5E4?logo=telegram&logoColor=white)](https://t.me/unchchat)
 


### PR DESCRIPTION
## What changed

- adds a docs badge to the README header
- links directly to `https://unch.mintlify.app/`

## Why

The docs site now exists as a real destination, so it should be discoverable from the main repository page.

## Validation

- `git diff --check -- README.md`
