### PR TITLE
docs: add v0.3.7 release notes

### DIFF
--- a/.github/releases/v0.3.7.md
+++ b/.github/releases/v0.3.7.md
@@ -1,0 +1,15 @@
+# unch v0.3.7
+
+`v0.3.7` is a CLI, remote indexing, and documentation update release. It makes `--state-dir` a first-class interface, hardens remote state reuse, aligns source installs around `cmd/unch`, and adds the new Mintlify docs site.
+
+## Highlights
+
+- adds first-class `--state-dir` support for `index` and `search`, while keeping `--db` only as a legacy alias
+- hardens remote indexing state by improving sync and download behavior and carrying `filehashes.db` through CI and remote restore for warmer reindex flows
+- aligns source installs and release workflows around `github.com/uchebnick/unch/cmd/unch`, and publishes the first Mintlify docs site with refreshed README links
+
+## Upgrade notes
+
+- no local index rebuild is required when upgrading from `v0.3.6`
+- if you use remote indexing, rerun `.github/workflows/unch-index.yml` so published state includes the current remote contract and warm file-hash cache
+- if you install from source, use `go install github.com/uchebnick/unch/cmd/unch@latest`


### PR DESCRIPTION
## What changed

- adds the checked-in release notes file for `v0.3.7`
- keeps the release notes history in `main` aligned with the published tag

## Why

`v0.3.7` was tagged before `.github/releases/v0.3.7.md` existed in the repository, so the release would otherwise fall back to autogenerated minimal notes.

## Validation

- reviewed the notes file against the shipped `v0.3.7` diff
