### PR TITLE
fix: restore tagged install smoke and benchmark warmup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.38
 	github.com/ncruces/go-sqlite3 v0.17.1
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
-	github.com/tree-sitter/go-tree-sitter v0.25.0
+	github.com/tree-sitter/go-tree-sitter v0.24.1-0.20250202211042-adc13ffd8b2c
 	github.com/tree-sitter/tree-sitter-go v0.25.0
 	github.com/tree-sitter/tree-sitter-javascript v0.25.0
 	github.com/tree-sitter/tree-sitter-python v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tetratelabs/wazero v1.7.3 h1:PBH5KVahrt3S2AHgEjKu4u+LlDbbk+nsGE3KLucy6Rw=
 github.com/tetratelabs/wazero v1.7.3/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
-github.com/tree-sitter/go-tree-sitter v0.25.0 h1:sx6kcg8raRFCvc9BnXglke6axya12krCJF5xJ2sftRU=
-github.com/tree-sitter/go-tree-sitter v0.25.0/go.mod h1:r77ig7BikoZhHrrsjAnv8RqGti5rtSyvDHPzgTPsUuU=
+github.com/tree-sitter/go-tree-sitter v0.24.1-0.20250202211042-adc13ffd8b2c h1:lZS22CyoY+TOTVp/KjdeQTBJ2vD/GuWskyaA3jx/+1w=
+github.com/tree-sitter/go-tree-sitter v0.24.1-0.20250202211042-adc13ffd8b2c/go.mod h1:r77ig7BikoZhHrrsjAnv8RqGti5rtSyvDHPzgTPsUuU=
 github.com/tree-sitter/tree-sitter-c v0.23.4 h1:nBPH3FV07DzAD7p0GfNvXM+Y7pNIoPenQWBpvM++t4c=
 github.com/tree-sitter/tree-sitter-c v0.23.4/go.mod h1:MkI5dOiIpeN94LNjeCp8ljXN/953JCwAby4bClMr6bw=
 github.com/tree-sitter/tree-sitter-cpp v0.23.4 h1:LaWZsiqQKvR65yHgKmnaqA+uz6tlDJTJFCyFIeZU/8w=

--- a/internal/bench/unch_adapter.go
+++ b/internal/bench/unch_adapter.go
@@ -93,7 +93,7 @@ func (a *UnchAdapter) Prepare(ctx context.Context, env Environment) error {
 	}
 
 	if a.libPath == "" {
-		resolvedLibPath, err := discoverManagedYzmaLibDir(env.WarmupRoot)
+		resolvedLibPath, err := discoverWarmedYzmaLibDir(env.WarmupRoot)
 		if err != nil {
 			return fmt.Errorf("discover warmed yzma libs: %w", err)
 		}
@@ -291,28 +291,56 @@ func gitDescribe(ctx context.Context, repoRoot string) string {
 	return strings.TrimSpace(string(output))
 }
 
-func discoverManagedYzmaLibDir(warmupRoot string) (string, error) {
+func discoverWarmedYzmaLibDir(warmupRoot string) (string, error) {
 	installRoot := filepath.Join(warmupRoot, ".semsearch", "yzma")
 	candidates := []string{
 		installRoot,
 		filepath.Join(installRoot, "lib"),
 	}
+	if loggedPath := discoverLoggedYzmaLibDir(warmupRoot); loggedPath != "" {
+		candidates = append(candidates, loggedPath)
+	}
 
 	requiredFiles := requiredYzmaLibFilesForGOOS(runtime.GOOS)
 	for _, candidate := range candidates {
-		ok := true
-		for _, filename := range requiredFiles {
-			if _, err := os.Stat(filepath.Join(candidate, filename)); err != nil {
-				ok = false
-				break
-			}
-		}
-		if ok {
+		if hasRequiredFiles(candidate, requiredFiles) {
 			return candidate, nil
 		}
 	}
 
 	return "", fmt.Errorf("yzma libs not found under %s", installRoot)
+}
+
+func discoverLoggedYzmaLibDir(warmupRoot string) string {
+	logPath := filepath.Join(warmupRoot, ".semsearch", "logs", "run.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return ""
+	}
+
+	lines := strings.Split(string(data), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		idx := strings.LastIndex(line, "lib=")
+		if idx < 0 {
+			continue
+		}
+		candidate := strings.TrimSpace(line[idx+len("lib="):])
+		if candidate != "" {
+			return candidate
+		}
+	}
+
+	return ""
+}
+
+func hasRequiredFiles(dir string, requiredFiles []string) bool {
+	for _, filename := range requiredFiles {
+		if _, err := os.Stat(filepath.Join(dir, filename)); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func requiredYzmaLibFilesForGOOS(goos string) []string {

--- a/internal/bench/unch_adapter_test.go
+++ b/internal/bench/unch_adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	stdruntime "runtime"
 	"testing"
 )
 
@@ -142,5 +143,58 @@ func TestUnchAdapterBuildBinaryFromCmdUnch(t *testing.T) {
 	}
 	if info.IsDir() {
 		t.Fatalf("built binary path is a directory: %s", adapter.binaryPath)
+	}
+}
+
+func TestDiscoverWarmedYzmaLibDirPrefersManagedInstall(t *testing.T) {
+	t.Parallel()
+
+	warmupRoot := t.TempDir()
+	managedDir := filepath.Join(warmupRoot, ".semsearch", "yzma", "lib")
+	writeRequiredYzmaFiles(t, managedDir)
+
+	got, err := discoverWarmedYzmaLibDir(warmupRoot)
+	if err != nil {
+		t.Fatalf("discoverWarmedYzmaLibDir() error = %v", err)
+	}
+	if got != filepath.Clean(managedDir) {
+		t.Fatalf("discoverWarmedYzmaLibDir() = %q, want %q", got, managedDir)
+	}
+}
+
+func TestDiscoverWarmedYzmaLibDirFallsBackToLoggedPath(t *testing.T) {
+	t.Parallel()
+
+	warmupRoot := t.TempDir()
+	fallbackDir := filepath.Join(t.TempDir(), "fallback-lib")
+	writeRequiredYzmaFiles(t, fallbackDir)
+
+	logPath := filepath.Join(warmupRoot, ".semsearch", "logs", "run.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte("2026/04/06 09:44:10 lib="+fallbackDir+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	got, err := discoverWarmedYzmaLibDir(warmupRoot)
+	if err != nil {
+		t.Fatalf("discoverWarmedYzmaLibDir() error = %v", err)
+	}
+	if got != filepath.Clean(fallbackDir) {
+		t.Fatalf("discoverWarmedYzmaLibDir() = %q, want %q", got, fallbackDir)
+	}
+}
+
+func writeRequiredYzmaFiles(t *testing.T, dir string) {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", dir, err)
+	}
+	for _, name := range requiredYzmaLibFilesForGOOS(stdruntime.GOOS) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("ok"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", name, err)
+		}
 	}
 }

--- a/internal/runtime/fetch.go
+++ b/internal/runtime/fetch.go
@@ -636,15 +636,28 @@ func archivePathHasParentRef(name string) bool {
 }
 
 func materializeArchiveLinks(root string, links []archiveLink) error {
+	linkIndex := make(map[string]archiveLink, len(links))
 	for _, link := range links {
-		if err := materializeArchiveLink(root, link); err != nil {
+		if !pathWithinRoot(root, link.linkPath) {
+			return fmt.Errorf("archive link destination %s escapes destination", link.linkPath)
+		}
+		if _, exists := linkIndex[link.linkPath]; exists {
+			return fmt.Errorf("duplicate archive link destination %s", link.linkPath)
+		}
+		linkIndex[link.linkPath] = link
+	}
+
+	resolvedTargets := make(map[string]string, len(links))
+	resolving := make(map[string]bool, len(links))
+	for _, link := range links {
+		if err := materializeArchiveLink(root, link, linkIndex, resolvedTargets, resolving); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func materializeArchiveLink(root string, link archiveLink) error {
+func materializeArchiveLink(root string, link archiveLink, linkIndex map[string]archiveLink, resolvedTargets map[string]string, resolving map[string]bool) error {
 	parentDir, err := filepath.EvalSymlinks(filepath.Dir(link.linkPath))
 	if err != nil {
 		return fmt.Errorf("resolve archive link parent: %w", err)
@@ -658,7 +671,7 @@ func materializeArchiveLink(root string, link archiveLink) error {
 		return fmt.Errorf("stat archive link destination %s: %w", link.linkPath, err)
 	}
 
-	resolvedTarget, err := resolvedArchiveLinkTarget(parentDir, root, link.targetPath)
+	resolvedTarget, err := resolvedArchiveLinkTarget(parentDir, root, link, linkIndex, resolvedTargets, resolving)
 	if err != nil {
 		return err
 	}
@@ -677,7 +690,54 @@ func materializeArchiveLink(root string, link archiveLink) error {
 	return nil
 }
 
-func resolvedArchiveLinkTarget(parentDir, root, rawTarget string) (string, error) {
+func resolvedArchiveLinkTarget(parentDir, root string, link archiveLink, linkIndex map[string]archiveLink, resolvedTargets map[string]string, resolving map[string]bool) (string, error) {
+	if resolved, ok := resolvedTargets[link.linkPath]; ok {
+		return resolved, nil
+	}
+	if resolving[link.linkPath] {
+		return "", fmt.Errorf("archive link cycle detected at %s", link.linkPath)
+	}
+	resolving[link.linkPath] = true
+	defer delete(resolving, link.linkPath)
+
+	candidateTarget, err := archiveLinkCandidateTarget(parentDir, root, link.targetPath)
+	if err != nil {
+		return "", err
+	}
+
+	if nextLink, ok := linkIndex[candidateTarget]; ok {
+		nextParentDir, err := filepath.EvalSymlinks(filepath.Dir(nextLink.linkPath))
+		if err != nil {
+			return "", fmt.Errorf("resolve archive link parent: %w", err)
+		}
+		if !pathWithinRoot(root, nextParentDir) {
+			return "", fmt.Errorf("archive link parent escapes destination")
+		}
+
+		resolved, err := resolvedArchiveLinkTarget(nextParentDir, root, nextLink, linkIndex, resolvedTargets, resolving)
+		if err != nil {
+			return "", err
+		}
+		resolvedTargets[link.linkPath] = resolved
+		return resolved, nil
+	}
+
+	info, err := os.Stat(candidateTarget)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("archive link target %q not found", link.targetPath)
+		}
+		return "", fmt.Errorf("stat archive link target %s: %w", candidateTarget, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("archive link target %s is a directory", candidateTarget)
+	}
+
+	resolvedTargets[link.linkPath] = candidateTarget
+	return candidateTarget, nil
+}
+
+func archiveLinkCandidateTarget(parentDir, root, rawTarget string) (string, error) {
 	linkTarget := filepath.Clean(filepath.FromSlash(strings.TrimSpace(rawTarget)))
 	if linkTarget == "." || linkTarget == "" || filepath.IsAbs(linkTarget) {
 		return "", fmt.Errorf("invalid archive link target %q", rawTarget)
@@ -687,15 +747,7 @@ func resolvedArchiveLinkTarget(parentDir, root, rawTarget string) (string, error
 	if !pathWithinRoot(root, candidateTarget) {
 		return "", fmt.Errorf("archive link target %q escapes destination", rawTarget)
 	}
-
-	resolvedTarget, err := filepath.EvalSymlinks(candidateTarget)
-	if err != nil {
-		return "", fmt.Errorf("resolve archive link target %q: %w", rawTarget, err)
-	}
-	if !pathWithinRoot(root, resolvedTarget) {
-		return "", fmt.Errorf("archive link target %q escapes destination", rawTarget)
-	}
-	return resolvedTarget, nil
+	return candidateTarget, nil
 }
 
 func copyFile(src, dst string, mode os.FileMode) error {

--- a/internal/runtime/fetch_test.go
+++ b/internal/runtime/fetch_test.go
@@ -54,6 +54,42 @@ func TestExtractTarGzRejectsOverwriteThroughSymlink(t *testing.T) {
 	}
 }
 
+func TestExtractTarGzMaterializesSymlinkChain(t *testing.T) {
+	if stdruntime.GOOS == "windows" {
+		t.Skip("symlink extraction tests are unreliable on Windows CI")
+	}
+
+	destDir := t.TempDir()
+	archivePath := filepath.Join(t.TempDir(), "payload.tar.gz")
+	writeTarGz(t, archivePath,
+		tarEntry{name: "bundle/libggml.dylib", linkname: "libggml.0.dylib", typ: tar.TypeSymlink, mode: 0o777},
+		tarEntry{name: "bundle/libggml.0.dylib", linkname: "libggml.0.9.8.dylib", typ: tar.TypeSymlink, mode: 0o777},
+		tarEntry{name: "bundle/libggml.0.9.8.dylib", body: []byte("payload"), typ: tar.TypeReg, mode: 0o755},
+	)
+
+	if err := extractTarGz(archivePath, destDir); err != nil {
+		t.Fatalf("extractTarGz() error = %v", err)
+	}
+
+	for _, name := range []string{"libggml.dylib", "libggml.0.dylib", "libggml.0.9.8.dylib"} {
+		path := filepath.Join(destDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", path, err)
+		}
+		if got := string(data); got != "payload" {
+			t.Fatalf("ReadFile(%s) = %q, want %q", path, got, "payload")
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			t.Fatalf("Lstat(%s) error = %v", path, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Fatalf("%s should be materialized as a regular file", path)
+		}
+	}
+}
+
 type tarEntry struct {
 	name     string
 	body     []byte


### PR DESCRIPTION
## What changed

- pins `github.com/tree-sitter/go-tree-sitter` to the reachable pseudo-version behind the previously used `v0.25.0` tag so `GOPROXY=direct` installs stop failing on the tagged release path
- keeps the hardened archive extraction logic, but restores support for the real `llama.cpp` runtime archives that ship versioned library symlink chains
- teaches the benchmark warmup path to reuse the resolved `lib=` path from the warmup run log when the runtime falls back to an already installed yzma library directory
- adds regression coverage for symlink-chain extraction and warmed-library discovery

## Root cause

`#52` fixed the original publishable `go install` path, but the follow-up CI runs exposed two more regressions outside that merge:

- the tagged direct-install path still depended on a Tree-sitter version that exists in the module proxy cache but no longer resolves cleanly from GitHub with `GOPROXY=direct`
- the runtime archive hardening became too strict for legitimate `llama.cpp` tarballs, and the benchmark harness only accepted managed `.semsearch/yzma` installs even when the warmup had already resolved a valid fallback library directory

## Validation

- `go test ./...`
- `git diff --check`
