### PR TITLE
test: cover runtime download flows

### DIFF
--- a/internal/runtime/fetch_test.go
+++ b/internal/runtime/fetch_test.go
@@ -2,14 +2,114 @@ package runtime
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	stdruntime "runtime"
 	"strings"
 	"testing"
 )
+
+func TestFetchLatestLlamaVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/hybridgroup/llama-cpp-builder/releases/latest" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Fatalf("Accept header = %q", got)
+		}
+		_, _ = io.WriteString(w, `{"tag_name":"b9999"}`)
+	}))
+	defer server.Close()
+
+	rewriteDefaultTransportToServer(t, server)
+
+	got, err := fetchLatestLlamaVersion()
+	if err != nil {
+		t.Fatalf("fetchLatestLlamaVersion() error = %v", err)
+	}
+	if got != "b9999" {
+		t.Fatalf("fetchLatestLlamaVersion() = %q, want %q", got, "b9999")
+	}
+}
+
+func TestDownloadToTempFileUsesProgressTracker(t *testing.T) {
+	const body = "GGUFpayload"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "11")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+
+	tracker := &recordingProgressTracker{}
+	path, err := downloadToTempFile(context.Background(), server.URL+"/model.gguf", t.TempDir(), "model-*.gguf", tracker)
+	if err != nil {
+		t.Fatalf("downloadToTempFile() error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	if got := string(data); got != body {
+		t.Fatalf("downloaded body = %q, want %q", got, body)
+	}
+	if tracker.src != server.URL+"/model.gguf" {
+		t.Fatalf("progress src = %q, want %q", tracker.src, server.URL+"/model.gguf")
+	}
+	if tracker.totalSize != int64(len(body)) {
+		t.Fatalf("progress total = %d, want %d", tracker.totalSize, len(body))
+	}
+}
+
+func TestDownloadAndExtractArchiveTarGz(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, ".tar.gz") {
+			t.Fatalf("unexpected archive path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(tarGzBytes(t,
+			tarEntry{name: "bundle/libllama.so", body: []byte("payload"), typ: tar.TypeReg, mode: 0o755},
+		))
+	}))
+	defer server.Close()
+
+	destDir := t.TempDir()
+	if err := downloadAndExtractArchive(context.Background(), server.URL+"/runtime.tar.gz", destDir, nil); err != nil {
+		t.Fatalf("downloadAndExtractArchive() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(destDir, "libllama.so"))
+	if err != nil {
+		t.Fatalf("ReadFile(extracted) error = %v", err)
+	}
+	if got := string(data); got != "payload" {
+		t.Fatalf("extracted body = %q, want %q", got, "payload")
+	}
+}
+
+func TestDownloadYzmaArchiveReturnsNotFoundError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	rewriteDefaultTransportToServer(t, server)
+
+	err := downloadYzmaArchive(context.Background(), "amd64", "linux", processorCPU, "b1234", t.TempDir(), nil)
+	if !errors.Is(err, errYzmaArchiveNotFound) {
+		t.Fatalf("downloadYzmaArchive() error = %v, want errYzmaArchiveNotFound", err)
+	}
+}
 
 func TestExtractTarGzRejectsEscapingSymlink(t *testing.T) {
 	if stdruntime.GOOS == "windows" {
@@ -90,6 +190,37 @@ func TestExtractTarGzMaterializesSymlinkChain(t *testing.T) {
 	}
 }
 
+func TestExtractZIPMaterializesSymlinkChain(t *testing.T) {
+	destDir := t.TempDir()
+	archivePath := filepath.Join(t.TempDir(), "payload.zip")
+	writeZIP(t, archivePath,
+		zipEntry{name: "bundle/libggml-link", linkTarget: "libggml-real", mode: os.ModeSymlink | 0o777},
+		zipEntry{name: "bundle/libggml-real", body: []byte("payload"), mode: 0o755},
+	)
+
+	if err := extractZIP(archivePath, destDir); err != nil {
+		t.Fatalf("extractZIP() error = %v", err)
+	}
+
+	for _, name := range []string{"libggml-link", "libggml-real"} {
+		path := filepath.Join(destDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", path, err)
+		}
+		if got := string(data); got != "payload" {
+			t.Fatalf("ReadFile(%s) = %q, want %q", path, got, "payload")
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			t.Fatalf("Lstat(%s) error = %v", path, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Fatalf("%s should be materialized as a regular file", path)
+		}
+	}
+}
+
 type tarEntry struct {
 	name     string
 	body     []byte
@@ -99,6 +230,14 @@ type tarEntry struct {
 }
 
 func writeTarGz(t *testing.T, archivePath string, entries ...tarEntry) {
+	t.Helper()
+
+	if err := os.WriteFile(archivePath, tarGzBytes(t, entries...), 0o644); err != nil {
+		t.Fatalf("write archive file: %v", err)
+	}
+}
+
+func tarGzBytes(t *testing.T, entries ...tarEntry) []byte {
 	t.Helper()
 
 	var buf bytes.Buffer
@@ -135,7 +274,93 @@ func writeTarGz(t *testing.T, archivePath string, entries ...tarEntry) {
 	if err := gzw.Close(); err != nil {
 		t.Fatalf("close gzip writer: %v", err)
 	}
-	if err := os.WriteFile(archivePath, buf.Bytes(), 0o644); err != nil {
-		t.Fatalf("write archive file: %v", err)
+	return buf.Bytes()
+}
+
+type zipEntry struct {
+	name       string
+	body       []byte
+	linkTarget string
+	mode       os.FileMode
+}
+
+func writeZIP(t *testing.T, archivePath string, entries ...zipEntry) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	for _, entry := range entries {
+		header := &zip.FileHeader{
+			Name:   entry.name,
+			Method: zip.Deflate,
+		}
+		header.SetMode(entry.mode)
+
+		writer, err := zw.CreateHeader(header)
+		if err != nil {
+			t.Fatalf("create zip header %s: %v", entry.name, err)
+		}
+
+		payload := entry.body
+		if entry.mode&os.ModeSymlink != 0 {
+			payload = []byte(entry.linkTarget)
+		}
+		if len(payload) > 0 {
+			if _, err := writer.Write(payload); err != nil {
+				t.Fatalf("write zip payload %s: %v", entry.name, err)
+			}
+		}
 	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip writer: %v", err)
+	}
+	if err := os.WriteFile(archivePath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write zip archive: %v", err)
+	}
+}
+
+type recordingProgressTracker struct {
+	src         string
+	currentSize int64
+	totalSize   int64
+}
+
+func (r *recordingProgressTracker) TrackProgress(src string, currentSize, totalSize int64, stream io.ReadCloser) io.ReadCloser {
+	r.src = src
+	r.currentSize = currentSize
+	r.totalSize = totalSize
+	return stream
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func rewriteDefaultTransportToServer(t *testing.T, server *httptest.Server) {
+	t.Helper()
+
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+
+	previous := http.DefaultTransport
+	baseTransport, ok := previous.(*http.Transport)
+	if !ok {
+		t.Fatalf("http.DefaultTransport has unexpected type %T", previous)
+	}
+	cloned := baseTransport.Clone()
+	http.DefaultTransport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		rewritten := req.Clone(req.Context())
+		rewritten.URL.Scheme = target.Scheme
+		rewritten.URL.Host = target.Host
+		return cloned.RoundTrip(rewritten)
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = previous
+	})
 }

--- a/internal/runtime/model_cache_test.go
+++ b/internal/runtime/model_cache_test.go
@@ -2,6 +2,9 @@ package runtime
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -136,6 +139,65 @@ func TestResolveOrInstallModelPathUsesExistingFilesAndNestedGGUF(t *testing.T) {
 
 	if _, _, err := cache.ResolveOrInstallModelPath(context.Background(), filepath.Join(dir, "missing.gguf"), modelPath, false, nil); err == nil {
 		t.Fatalf("expected error for missing explicit model path")
+	}
+}
+
+func TestResolveOrInstallModelPathAutoDownloadsKnownModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "GGUFpayload")
+	}))
+	defer server.Close()
+
+	t.Setenv("SEMSEARCH_MODEL_URL", server.URL+"/embeddinggemma.gguf")
+
+	cache := ModelCache{}
+	defaultPath := DefaultModelPath(t.TempDir())
+
+	got, note, err := cache.ResolveOrInstallModelPath(context.Background(), "", defaultPath, true, nil)
+	if err != nil {
+		t.Fatalf("ResolveOrInstallModelPath(auto-download) error = %v", err)
+	}
+	if got != defaultPath {
+		t.Fatalf("ResolveOrInstallModelPath(auto-download) path = %q, want %q", got, defaultPath)
+	}
+	if !strings.Contains(note, "downloaded embeddinggemma-300m model") {
+		t.Fatalf("ResolveOrInstallModelPath(auto-download) note = %q", note)
+	}
+
+	data, err := os.ReadFile(defaultPath)
+	if err != nil {
+		t.Fatalf("ReadFile(downloaded model) error = %v", err)
+	}
+	if got := string(data); got != "GGUFpayload" {
+		t.Fatalf("downloaded model contents = %q, want %q", got, "GGUFpayload")
+	}
+}
+
+func TestRepairInstalledModelRepairsNestedGGUF(t *testing.T) {
+	destPath := filepath.Join(t.TempDir(), "embeddinggemma-300m.gguf")
+	if err := os.MkdirAll(destPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(model dir) error = %v", err)
+	}
+
+	nested := filepath.Join(destPath, "nested.gguf")
+	if err := os.WriteFile(nested, []byte("GGUFpayload"), 0o644); err != nil {
+		t.Fatalf("WriteFile(nested model) error = %v", err)
+	}
+
+	note, err := repairInstalledModel(destPath, nil)
+	if err != nil {
+		t.Fatalf("repairInstalledModel() error = %v", err)
+	}
+	if !strings.Contains(note, "repaired cached model") {
+		t.Fatalf("repairInstalledModel() note = %q", note)
+	}
+
+	info, err := os.Stat(destPath)
+	if err != nil {
+		t.Fatalf("Stat(repaired path) error = %v", err)
+	}
+	if info.IsDir() {
+		t.Fatalf("repairInstalledModel() left %s as a directory", destPath)
 	}
 }
 

--- a/internal/runtime/progress_test.go
+++ b/internal/runtime/progress_test.go
@@ -1,0 +1,75 @@
+package runtime
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestStdoutProgressTrackerReportsReadAndClose(t *testing.T) {
+	restoreStdout, readOutput := captureStdout(t)
+
+	reader := (&stdoutProgressTracker{}).TrackProgress(
+		"https://example.com/models/file.gguf",
+		0,
+		int64(len("payload")),
+		io.NopCloser(strings.NewReader("payload")),
+	)
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if got := string(data); got != "payload" {
+		t.Fatalf("ReadAll() = %q, want %q", got, "payload")
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	restoreStdout()
+	output := readOutput()
+	if !strings.Contains(output, "downloading file.gguf... 100% (7 B/7 B)") {
+		t.Fatalf("progress output = %q", output)
+	}
+}
+
+func TestProgressFormattingHelpers(t *testing.T) {
+	if got := formatDownloadProgress("", 2048, 0); got != "downloading file... 2 KiB" {
+		t.Fatalf("formatDownloadProgress(unknown total) = %q", got)
+	}
+
+	if got := formatDownloadProgress("https://example.com/archive.tar.gz", 2048, 1024); got != "downloading archive.tar.gz... 100% (2 KiB/2 KiB)" {
+		t.Fatalf("formatDownloadProgress(clamped total) = %q", got)
+	}
+
+	if got := humanDownloadBytes(3 << 20); got != "3.0 MiB" {
+		t.Fatalf("humanDownloadBytes(3 MiB) = %q", got)
+	}
+}
+
+func captureStdout(t *testing.T) (func(), func() string) {
+	t.Helper()
+
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stdout = writer
+
+	restore := func() {
+		_ = writer.Close()
+		os.Stdout = original
+	}
+	readOutput := func() string {
+		data, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatalf("ReadAll(stdout pipe) error = %v", err)
+		}
+		return string(data)
+	}
+
+	return restore, readOutput
+}

--- a/internal/runtime/yzma_test.go
+++ b/internal/runtime/yzma_test.go
@@ -3,6 +3,8 @@ package runtime
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -91,6 +93,44 @@ func TestResolveYzmaLibPath(t *testing.T) {
 	}
 	if got != filepath.Clean(fallback) || !strings.Contains(note, "using YZMA_LIB=") {
 		t.Fatalf("ResolveYzmaLibPath(fallback) = (%q, %q)", got, note)
+	}
+}
+
+func TestResolveOrInstallYzmaLibPathDownloadsManagedRuntime(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, ".tar.gz"):
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(tarGzBytes(t, yzmaArchiveEntries()...))
+		case strings.HasSuffix(r.URL.Path, ".zip"):
+			archivePath := filepath.Join(t.TempDir(), "runtime.zip")
+			writeZIP(t, archivePath, yzmaZipEntries()...)
+			data, err := os.ReadFile(archivePath)
+			if err != nil {
+				t.Fatalf("ReadFile(zip archive) error = %v", err)
+			}
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(data)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	rewriteDefaultTransportToServer(t, server)
+	t.Setenv("SEMSEARCH_YZMA_VERSION", "b1234")
+	t.Setenv("SEMSEARCH_YZMA_PROCESSOR", processorCPU)
+
+	localDir := t.TempDir()
+	got, note, err := (YzmaResolver{}).ResolveOrInstallYzmaLibPath(context.Background(), "", localDir, nil)
+	if err != nil {
+		t.Fatalf("ResolveOrInstallYzmaLibPath() error = %v", err)
+	}
+	if !strings.Contains(note, "downloaded yzma libs to") {
+		t.Fatalf("ResolveOrInstallYzmaLibPath() note = %q", note)
+	}
+	if resolved, ok := validateYzmaLibDir(got); !ok || resolved != got {
+		t.Fatalf("ResolveOrInstallYzmaLibPath() returned invalid lib dir %q", got)
 	}
 }
 
@@ -216,4 +256,29 @@ func TestDefaultYzmaProcessorUsesPinnedProcessor(t *testing.T) {
 	if got := defaultYzmaProcessor(); got != "cpu" {
 		t.Fatalf("defaultYzmaProcessor() = %q, want %q", got, "cpu")
 	}
+}
+
+func yzmaArchiveEntries() []tarEntry {
+	entries := make([]tarEntry, 0, len(requiredYzmaLibFiles()))
+	for _, name := range requiredYzmaLibFiles() {
+		entries = append(entries, tarEntry{
+			name: "bundle/" + name,
+			body: []byte("stub"),
+			typ:  0,
+			mode: 0o755,
+		})
+	}
+	return entries
+}
+
+func yzmaZipEntries() []zipEntry {
+	entries := make([]zipEntry, 0, len(requiredYzmaLibFiles()))
+	for _, name := range requiredYzmaLibFiles() {
+		entries = append(entries, zipEntry{
+			name: "bundle/" + name,
+			body: []byte("stub"),
+			mode: 0o755,
+		})
+	}
+	return entries
 }


### PR DESCRIPTION
## What changed

- adds runtime fetch tests for the GitHub release lookup, temp-file downloader, tarball extraction path, ZIP extraction path, and the `yzma` archive 404 fallback
- adds model-cache coverage for automatic known-model downloads and cached GGUF repair flows
- adds managed `yzma` install coverage so the resolver is exercised through a local test server instead of only through lower-level helpers
- adds progress tracker tests for the stdout progress reader and download-formatting helpers
- raises the CI-shaped portable-package coverage back up by covering the runtime download code that landed in the last packaging/runtime work

## Why

The runtime downloader and extraction layer added a lot of new behavior in `internal/runtime`, but most of it was only exercised indirectly. That left the coverage job lower than it should have been even though the shipped paths were now much more important to first-run installs.

This change locks in the user-facing download flows with local test servers and archive fixtures, and it gives the coverage job a better signal when we touch the runtime installer again.

## Validation

- `go test ./...`
- `go test -covermode=atomic -coverprofile=coverage/coverage.out ./internal/bench ./internal/indexing ./internal/runtime ./internal/search ./internal/termui`
- `go tool cover -func=coverage/coverage.out | tail -n 1`
