### PR TITLE
ops: add manual telegram release workflow

### DIFF
--- a/.github/releases/v0.3.8.md
+++ b/.github/releases/v0.3.8.md
@@ -1,0 +1,16 @@
+# unch v0.3.8
+
+`v0.3.8` is a release-confidence patch release. It keeps the `v0.3.7` CLI, runtime, and indexing behavior intact while adding regression coverage around first-run downloads, managed `yzma` installs, and cached model repair flows, and it republishes the current install path under a fresh semver tag for Go module consumers.
+
+## Highlights
+
+- adds direct runtime fetch coverage for the GitHub release lookup, temp-file downloader, tar/zip extraction paths, and the `yzma` archive 404 fallback
+- covers automatic known-model downloads and cached GGUF repair flows in the model cache
+- exercises managed `yzma` install resolution and stdout download progress reporting through local test servers and archive fixtures
+- raises the portable-package CI coverage after the runtime downloader and archive hardening work that landed in `v0.3.7`
+
+## Upgrade notes
+
+- no index rebuild is required when upgrading from `v0.3.7`
+- if you install from source or use `go install`, use `github.com/uchebnick/unch/cmd/unch@v0.3.8`
+- if you previously tried the public Go module path at `v0.3.7`, switch to `v0.3.8`

--- a/.github/workflows/manual-telegram-release.yml
+++ b/.github/workflows/manual-telegram-release.yml
@@ -1,0 +1,75 @@
+name: manual-telegram-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to announce
+        required: true
+        type: string
+      release_url:
+        description: Published GitHub release URL
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  notify:
+    name: notify-telegram
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Render release announcement
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          python3 scripts/render_release_announcement.py \
+            --tag "${{ inputs.tag }}" \
+            --url "${{ inputs.release_url }}" \
+            --notes-file ".github/releases/${{ inputs.tag }}.md" \
+            > dist/release-announcement.txt
+
+      - name: Send Telegram release notification
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+            echo "Telegram secrets are not set; skipping notification"
+            exit 0
+          fi
+          telegram_api="https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}"
+          response_file="$(mktemp)"
+          status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            -X POST "${telegram_api}/getChat" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}")"
+          if [ "${status}" != "200" ]; then
+            cat "${response_file}" >&2
+            rm -f "${response_file}"
+            echo "Telegram chat lookup failed for the configured chat target" >&2
+            exit 1
+          fi
+          rm -f "${response_file}"
+
+          response_file="$(mktemp)"
+          status="$(curl --silent --show-error \
+            --output "${response_file}" \
+            --write-out "%{http_code}" \
+            -X POST "${telegram_api}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text@dist/release-announcement.txt" \
+            --data-urlencode "disable_web_page_preview=true")"
+          if [ "${status}" != "200" ]; then
+            cat "${response_file}" >&2
+            rm -f "${response_file}"
+            exit 1
+          fi
+          cat "${response_file}"
+          rm -f "${response_file}"


### PR DESCRIPTION
## What changed

- adds `v0.3.8` release notes to the repository so the release text exists in-tree
- adds a small `workflow_dispatch` helper for manually re-sending a Telegram release announcement from the repo's existing secrets

## Why

`v0.3.8` was tagged and released before the notes file existed in the tagged commit, so the automated `notify-release` job sent the fallback announcement text.

This follow-up gives us a safe way to resend the `v0.3.8` Telegram announcement with the corrected release notes without retagging or touching the published release assets.

## Validation

- existing branch CI is running on the helper branch
- the workflow only uses the existing `scripts/render_release_announcement.py` path plus the same Telegram secret flow as `release.yml`
