### PR TITLE
refactor: split model catalog from embedding runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Useful flags:
 
 - `--exclude` to skip generated, vendor, or irrelevant paths
 - `--model` to use `embeddinggemma`, `qwen3`, or a custom `.gguf` path
+- `--ctx-size` to override the selected model context size; `0` uses the model default
 - `--lib` to use an existing `yzma` runtime directory
 - `--state-dir` to keep index state in a custom `.semsearch` directory
 
@@ -148,6 +149,7 @@ Useful flags:
 - `--limit` to control result count
 - `--max-distance` to narrow semantic matches
 - `--model` to search with `embeddinggemma`, `qwen3`, or a custom `.gguf` path
+- `--ctx-size` to override the selected model context size; `0` uses the model default
 - `--state-dir` to search against a custom `.semsearch` directory
 - `--details` to print symbol metadata, signature, docs, and body context for each match
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -102,7 +102,7 @@ func printRootHelp(w io.Writer, program string) error {
 		"  - Pass --model embeddinggemma or --model qwen3 to auto-select and auto-download a known GGUF model.",
 		"  - Pass --model /path/to/model.gguf to use a custom GGUF embedding model.",
 		"  - Known profiles today: embeddinggemma (mean pooling) and Qwen3-Embedding (last-token pooling).",
-		"  - --ctx-size and --batch-size default to the selected model profile when left at 0.",
+		"  - --ctx-size defaults to the selected model profile when left at 0.",
 		"  - Rebuild the index after changing models, and use the same model family for both index and search.",
 	}
 	for _, line := range modelNotes {

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -213,7 +213,3 @@ func defaultPooling(modelPath string) llama.PoolingType {
 func defaultContextSize(modelPath string) int {
 	return llamaembed.DefaultContextSizeForModelPath(modelPath)
 }
-
-func defaultBatchSize(modelPath string) int {
-	return llamaembed.DefaultBatchSizeForModelPath(modelPath)
-}

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -36,7 +36,6 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 	commentPrefix := fs.String("comment-prefix", "@search:", "legacy comment prefix used only by fallback indexers")
 	gitignorePath := fs.String("gitignore", "", "optional path to .gitignore; default is <root>/.gitignore")
 	contextSize := fs.Int("ctx-size", 0, "llama context size; 0 uses the selected model default")
-	batchSize := fs.Int("batch-size", 0, "llama batch size; 0 uses the selected model default")
 	verbose := fs.Bool("verbose", false, "enable yzma verbose logging")
 	fs.Var(&excludes, "exclude", "exclude pattern; can be used multiple times")
 
@@ -182,10 +181,6 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 	if resolvedContextSize <= 0 {
 		resolvedContextSize = defaultContextSize(resolvedModelPath)
 	}
-	resolvedBatchSize := *batchSize
-	if resolvedBatchSize <= 0 {
-		resolvedBatchSize = defaultBatchSize(resolvedModelPath)
-	}
 
 	s.Logf("state_dir=%s", targetPaths.LocalDir)
 	s.Logf("index_db=%s", resolvedIndexPath)
@@ -193,14 +188,12 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 	s.Logf("model=%s", resolvedModelPath)
 	s.Logf("model_id=%s", modelID)
 	s.Logf("ctx_size=%d", resolvedContextSize)
-	s.Logf("batch_size=%d", resolvedBatchSize)
 	s.Logf("root=%s", rootAbs)
 
 	embedder, err := loadEmbedderWithSpinner(ctx, s, llamaembed.Config{
 		ModelPath:   resolvedModelPath,
 		LibPath:     resolvedLibPath,
 		ContextSize: resolvedContextSize,
-		BatchSize:   resolvedBatchSize,
 		Verbose:     *verbose,
 		Pooling:     defaultPooling(resolvedModelPath),
 	})

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -32,7 +32,6 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 	libPath := fs.String("lib", "", "path to yzma library directory, or to one of its shared library files")
 	queryFlag := fs.String("query", "", "search query; if empty, remaining args are joined")
 	contextSize := fs.Int("ctx-size", 0, "llama context size; 0 uses the selected model default")
-	batchSize := fs.Int("batch-size", 0, "llama batch size; 0 uses the selected model default")
 	limit := fs.Int("limit", 10, "max number of search results")
 	mode := fs.String("mode", "auto", "search mode: auto, semantic, lexical")
 	maxDistance := fs.Float64("max-distance", 0.85, "maximum semantic distance kept in auto and semantic modes; <= 0 disables filtering")
@@ -157,10 +156,6 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 	if resolvedContextSize <= 0 {
 		resolvedContextSize = defaultContextSize(resolvedModelPath)
 	}
-	resolvedBatchSize := *batchSize
-	if resolvedBatchSize <= 0 {
-		resolvedBatchSize = defaultBatchSize(resolvedModelPath)
-	}
 
 	s.Logf("index_db=%s", resolvedIndexPath)
 	s.Logf("state_dir=%s", targetPaths.LocalDir)
@@ -168,7 +163,6 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 	s.Logf("model=%s", resolvedModelPath)
 	s.Logf("model_id=%s", modelID)
 	s.Logf("ctx_size=%d", resolvedContextSize)
-	s.Logf("batch_size=%d", resolvedBatchSize)
 	s.Logf("root=%s", rootAbs)
 	s.Logf("query=%q", queryText)
 	s.Logf("limit=%d", *limit)
@@ -179,7 +173,6 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 		ModelPath:   resolvedModelPath,
 		LibPath:     resolvedLibPath,
 		ContextSize: resolvedContextSize,
-		BatchSize:   resolvedBatchSize,
 		Verbose:     *verbose,
 		Pooling:     defaultPooling(resolvedModelPath),
 	})

--- a/internal/embed/llama/embedder.go
+++ b/internal/embed/llama/embedder.go
@@ -22,7 +22,6 @@ type Config struct {
 	ModelPath   string
 	LibPath     string
 	ContextSize int
-	BatchSize   int
 	Verbose     bool
 	Pooling     llama.PoolingType
 }
@@ -33,7 +32,7 @@ type Embedder struct {
 	ctx     llama.Context
 	vocab   llama.Vocab
 	dim     int
-	profile embeddingModel
+	profile embeddingBehavior
 }
 
 var (
@@ -50,7 +49,7 @@ func New(cfg Config) (*Embedder, error) {
 		return nil, err
 	}
 
-	profile := modelForPath(cfg.ModelPath)
+	profile := behaviorForPath(cfg.ModelPath)
 
 	resolvedLibPath, _, err := unchruntime.ResolveYzmaLibPath(cfg.LibPath)
 	if err != nil {
@@ -62,8 +61,8 @@ func New(cfg Config) (*Embedder, error) {
 		return nil, fmt.Errorf("prepare dynamic library lookup path: %w", err)
 	}
 
-	if cfg.BatchSize <= 0 {
-		cfg.BatchSize = 2048
+	if cfg.ContextSize <= 0 {
+		cfg.ContextSize = profileForPath(cfg.ModelPath).DefaultContextSize
 	}
 	if cfg.Pooling == 0 {
 		cfg.Pooling = profile.DefaultPooling()
@@ -116,7 +115,7 @@ func New(cfg Config) (*Embedder, error) {
 
 	ctxParams := llama.ContextDefaultParams()
 	ctxParams.NCtx = uint32(cfg.ContextSize)
-	ctxParams.NBatch = uint32(cfg.BatchSize)
+	ctxParams.NBatch = uint32(cfg.ContextSize)
 	ctxParams.PoolingType = cfg.Pooling
 	ctxParams.Embeddings = 1
 
@@ -256,11 +255,11 @@ func hashComment(text string) string {
 	return hex.EncodeToString(b[:])
 }
 
-func hashIndexedSymbolDocument(profile embeddingModel, path string, symbol indexing.IndexedSymbol) string {
-	return hashComment("embedding_doc_format:" + profile.ID() + "\n" + indexedSymbolDocument(profile, path, symbol))
+func hashIndexedSymbolDocument(profile embeddingBehavior, path string, symbol indexing.IndexedSymbol) string {
+	return hashComment("embedding_doc_format:" + profile.ProfileRevision() + "\n" + indexedSymbolDocument(profile, path, symbol))
 }
 
-func indexedSymbolDocument(profile embeddingModel, path string, symbol indexing.IndexedSymbol) string {
+func indexedSymbolDocument(profile embeddingBehavior, path string, symbol indexing.IndexedSymbol) string {
 	return profile.FormatIndexedSymbolDocument(path, symbol)
 }
 

--- a/internal/embed/llama/embedder_test.go
+++ b/internal/embed/llama/embedder_test.go
@@ -105,14 +105,14 @@ func TestNormalizeDocumentTitle(t *testing.T) {
 func TestModelForPath(t *testing.T) {
 	t.Parallel()
 
-	gemmaID := embeddingGemmaModel{}.ID()
-	qwenID := qwen3EmbeddingModel{}.ID()
+	gemmaID := embeddingGemmaModel{}.ProfileRevision()
+	qwenID := qwen3EmbeddingModel{}.ProfileRevision()
 
-	if got := modelForPath("/tmp/embeddinggemma-300m.gguf").ID(); got != gemmaID {
-		t.Fatalf("modelForPath(gemma) = %q", got)
+	if got := behaviorForPath("/tmp/embeddinggemma-300m.gguf").ProfileRevision(); got != gemmaID {
+		t.Fatalf("behaviorForPath(gemma) = %q", got)
 	}
-	if got := modelForPath("/tmp/Qwen3-Embedding-0.6B-Q8_0.gguf").ID(); got != qwenID {
-		t.Fatalf("modelForPath(qwen3) = %q", got)
+	if got := behaviorForPath("/tmp/Qwen3-Embedding-0.6B-Q8_0.gguf").ProfileRevision(); got != qwenID {
+		t.Fatalf("behaviorForPath(qwen3) = %q", got)
 	}
 }
 
@@ -133,22 +133,19 @@ func TestKnownModelProfiles(t *testing.T) {
 	if !ok || qwenProfile.ID != "qwen3" {
 		t.Fatalf("ResolveKnownModelProfile(qwen3) = (%#v, %v)", qwenProfile, ok)
 	}
-	if qwenProfile.DefaultContext != 8192 || qwenProfile.DefaultBatch != 8192 {
-		t.Fatalf("ResolveKnownModelProfile(qwen3) defaults = (%d, %d)", qwenProfile.DefaultContext, qwenProfile.DefaultBatch)
+	if qwenProfile.DefaultContextSize != 8192 {
+		t.Fatalf("ResolveKnownModelProfile(qwen3) default context = %d", qwenProfile.DefaultContextSize)
 	}
 
 	gemmaByPath, ok := RecognizeModelProfileForPath("/tmp/embeddinggemma-300m.gguf")
 	if !ok || gemmaByPath.ID != "embeddinggemma" {
 		t.Fatalf("RecognizeModelProfileForPath(gemma) = (%#v, %v)", gemmaByPath, ok)
 	}
-	if gemmaByPath.DefaultContext != 2048 || gemmaByPath.DefaultBatch != 2048 {
-		t.Fatalf("RecognizeModelProfileForPath(gemma) defaults = (%d, %d)", gemmaByPath.DefaultContext, gemmaByPath.DefaultBatch)
+	if gemmaByPath.DefaultContextSize != 2048 {
+		t.Fatalf("RecognizeModelProfileForPath(gemma) default context = %d", gemmaByPath.DefaultContextSize)
 	}
 	if got := DefaultContextSizeForModelPath("/tmp/Qwen3-Embedding-0.6B-Q8_0.gguf"); got != 8192 {
 		t.Fatalf("DefaultContextSizeForModelPath(qwen3) = %d", got)
-	}
-	if got := DefaultBatchSizeForModelPath("/tmp/Qwen3-Embedding-0.6B-Q8_0.gguf"); got != 8192 {
-		t.Fatalf("DefaultBatchSizeForModelPath(qwen3) = %d", got)
 	}
 }
 

--- a/internal/embed/llama/model_profile.go
+++ b/internal/embed/llama/model_profile.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hybridgroup/yzma/pkg/llama"
 	"github.com/uchebnick/unch/internal/indexing"
+	"github.com/uchebnick/unch/internal/modelcatalog"
 )
 
 const (
@@ -17,124 +18,132 @@ const (
 )
 
 type ModelProfile struct {
-	ID              string
-	DisplayName     string
-	Aliases         []string
-	DefaultFilename string
-	DownloadURL     string
-	DefaultContext  int
-	DefaultBatch    int
+	modelcatalog.Metadata
+	DefaultContextSize int
 }
 
-type embeddingModel interface {
-	Profile() ModelProfile
-	ID() string
+type embeddingBehavior interface {
+	ProfileRevision() string
 	DefaultPooling() llama.PoolingType
-	Matches(modelPath string) bool
 	FormatQuery(text string) string
 	FormatIndexedSymbolDocument(path string, symbol indexing.IndexedSymbol) string
+}
+
+type registeredEmbeddingModel struct {
+	TargetID string
+	Defaults runtimeDefaults
+	Behavior embeddingBehavior
+}
+
+type runtimeDefaults struct {
+	DefaultContextSize int
 }
 
 type embeddingGemmaModel struct{}
 
 type qwen3EmbeddingModel struct{}
 
-var embeddingModels = []embeddingModel{
-	qwen3EmbeddingModel{},
-	embeddingGemmaModel{},
+var embeddingModels = []registeredEmbeddingModel{
+	{
+		TargetID: "embeddinggemma",
+		Defaults: runtimeDefaults{DefaultContextSize: 2048},
+		Behavior: embeddingGemmaModel{},
+	},
+	{
+		TargetID: "qwen3",
+		Defaults: runtimeDefaults{DefaultContextSize: 8192},
+		Behavior: qwen3EmbeddingModel{},
+	},
 }
 
 // DefaultModelProfile returns the model profile used when --model is omitted.
 func DefaultModelProfile() ModelProfile {
-	return embeddingGemmaModel{}.Profile()
+	return profileForTarget(modelcatalog.DefaultInstallTarget())
 }
 
 // KnownModelProfiles returns the built-in GGUF embedding model profiles supported by the CLI.
 func KnownModelProfiles() []ModelProfile {
-	profiles := make([]ModelProfile, 0, len(embeddingModels))
-	for _, model := range embeddingModels {
-		profiles = append(profiles, model.Profile())
+	targets := modelcatalog.KnownInstallTargets()
+	profiles := make([]ModelProfile, 0, len(targets))
+	for _, target := range targets {
+		profiles = append(profiles, profileForTarget(target))
 	}
 	return profiles
 }
 
 // ResolveKnownModelProfile resolves a short model alias such as "embeddinggemma" or "qwen3".
 func ResolveKnownModelProfile(value string) (ModelProfile, bool) {
-	token := normalizeModelToken(value)
-	if token == "" {
+	target, ok := modelcatalog.ResolveInstallTarget(value)
+	if !ok {
 		return ModelProfile{}, false
 	}
 
-	for _, model := range embeddingModels {
-		profile := model.Profile()
-		for _, alias := range profile.Aliases {
-			if token == normalizeModelToken(alias) {
-				return profile, true
-			}
-		}
-	}
-
-	return ModelProfile{}, false
+	return profileForTarget(target), true
 }
 
 // RecognizeModelProfileForPath returns a built-in model profile when the path matches a known GGUF filename family.
 func RecognizeModelProfileForPath(modelPath string) (ModelProfile, bool) {
-	for _, model := range embeddingModels {
-		if model.Matches(modelPath) {
-			return model.Profile(), true
-		}
+	target, ok := modelcatalog.RecognizeInstallTargetForPath(modelPath)
+	if !ok {
+		return ModelProfile{}, false
 	}
-	return ModelProfile{}, false
+	return profileForTarget(target), true
 }
 
 // DefaultPoolingForModelPath returns the pooling mode that matches the known GGUF embedding model.
 func DefaultPoolingForModelPath(modelPath string) llama.PoolingType {
-	return modelForPath(modelPath).DefaultPooling()
+	return behaviorForPath(modelPath).DefaultPooling()
 }
 
 // DefaultContextSizeForModelPath returns the model-specific context size used when the CLI does not override it.
 func DefaultContextSizeForModelPath(modelPath string) int {
-	return modelForPath(modelPath).Profile().DefaultContext
+	return profileForPath(modelPath).DefaultContextSize
 }
 
-// DefaultBatchSizeForModelPath returns the model-specific batch size used when the CLI does not override it.
-func DefaultBatchSizeForModelPath(modelPath string) int {
-	return modelForPath(modelPath).Profile().DefaultBatch
+func profileForPath(modelPath string) ModelProfile {
+	target, ok := modelcatalog.RecognizeInstallTargetForPath(modelPath)
+	if !ok {
+		target = modelcatalog.DefaultInstallTarget()
+	}
+	return profileForTarget(target)
 }
 
-func modelForPath(modelPath string) embeddingModel {
+func behaviorForTargetID(targetID string) embeddingBehavior {
+	return registeredModelForTargetID(targetID).Behavior
+}
+
+func behaviorForPath(modelPath string) embeddingBehavior {
+	return behaviorForTargetID(profileForPath(modelPath).ID)
+}
+
+func profileForTarget(target modelcatalog.InstallTarget) ModelProfile {
+	defaults := runtimeDefaultsForTargetID(target.ID)
+	return ModelProfile{
+		Metadata:           target.Metadata.Clone(),
+		DefaultContextSize: defaults.DefaultContextSize,
+	}
+}
+
+func runtimeDefaultsForTargetID(targetID string) runtimeDefaults {
+	return registeredModelForTargetID(targetID).Defaults
+}
+
+func registeredModelForTargetID(targetID string) registeredEmbeddingModel {
 	for _, model := range embeddingModels {
-		if model.Matches(modelPath) {
+		if model.TargetID == targetID {
 			return model
 		}
 	}
 
-	return embeddingGemmaModel{}
+	return embeddingModels[0]
 }
 
-func (embeddingGemmaModel) Profile() ModelProfile {
-	return ModelProfile{
-		ID:              "embeddinggemma",
-		DisplayName:     "embeddinggemma-300m",
-		Aliases:         []string{"default", "embeddinggemma", "gemma", "embeddinggemma-300m"},
-		DefaultFilename: "embeddinggemma-300m.gguf",
-		DownloadURL:     "https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF/resolve/main/embeddinggemma-300M-Q8_0.gguf?download=true",
-		DefaultContext:  2048,
-		DefaultBatch:    2048,
-	}
-}
-
-func (embeddingGemmaModel) ID() string {
+func (embeddingGemmaModel) ProfileRevision() string {
 	return "embeddinggemma-v4"
 }
 
 func (embeddingGemmaModel) DefaultPooling() llama.PoolingType {
 	return llama.PoolingTypeMean
-}
-
-func (embeddingGemmaModel) Matches(modelPath string) bool {
-	name, full := normalizedModelPath(modelPath)
-	return strings.Contains(name, "embeddinggemma") || strings.Contains(full, "embeddinggemma")
 }
 
 func (embeddingGemmaModel) FormatQuery(text string) string {
@@ -147,31 +156,12 @@ func (embeddingGemmaModel) FormatIndexedSymbolDocument(path string, symbol index
 	return fmt.Sprintf(embeddingGemmaDocumentPrefix, normalizeDocumentTitle(title), normalizeText(body))
 }
 
-func (qwen3EmbeddingModel) Profile() ModelProfile {
-	return ModelProfile{
-		ID:              "qwen3",
-		DisplayName:     "Qwen3-Embedding-0.6B",
-		Aliases:         []string{"qwen3", "qwen3-embedding", "qwen3embedding", "qwen"},
-		DefaultFilename: "Qwen3-Embedding-0.6B-Q8_0.gguf",
-		DownloadURL:     "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf?download=true",
-		DefaultContext:  8192,
-		DefaultBatch:    8192,
-	}
-}
-
-func (qwen3EmbeddingModel) ID() string {
+func (qwen3EmbeddingModel) ProfileRevision() string {
 	return "qwen3-embedding-v1"
 }
 
 func (qwen3EmbeddingModel) DefaultPooling() llama.PoolingType {
 	return llama.PoolingTypeLast
-}
-
-func (qwen3EmbeddingModel) Matches(modelPath string) bool {
-	name, full := normalizedModelPath(modelPath)
-	return strings.Contains(name, "qwen3-embedding") ||
-		strings.Contains(name, "qwen3embedding") ||
-		(strings.Contains(full, "qwen3") && strings.Contains(full, "embed"))
 }
 
 func (qwen3EmbeddingModel) FormatQuery(text string) string {
@@ -264,16 +254,4 @@ func normalizeDocumentTitle(title string) string {
 		return "none"
 	}
 	return title
-}
-
-func normalizedModelPath(modelPath string) (string, string) {
-	full := strings.ToLower(strings.TrimSpace(modelPath))
-	name := strings.ToLower(filepath.Base(full))
-	return name, full
-}
-
-func normalizeModelToken(value string) string {
-	value = strings.ToLower(strings.TrimSpace(value))
-	replacer := strings.NewReplacer("-", "", "_", "", " ", "")
-	return replacer.Replace(value)
 }

--- a/internal/embed/llama/model_profile.go
+++ b/internal/embed/llama/model_profile.go
@@ -119,7 +119,7 @@ func behaviorForPath(modelPath string) embeddingBehavior {
 func profileForTarget(target modelcatalog.InstallTarget) ModelProfile {
 	defaults := runtimeDefaultsForTargetID(target.ID)
 	return ModelProfile{
-		Metadata:           target.Metadata.Clone(),
+		Metadata:           target.Clone(),
 		DefaultContextSize: defaults.DefaultContextSize,
 	}
 }

--- a/internal/modelcatalog/catalog.go
+++ b/internal/modelcatalog/catalog.go
@@ -1,0 +1,123 @@
+package modelcatalog
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Metadata is the shared identity layer for a known model.
+type Metadata struct {
+	ID          string
+	DisplayName string
+	Aliases     []string
+}
+
+func (m Metadata) Clone() Metadata {
+	cloned := m
+	cloned.Aliases = append([]string(nil), m.Aliases...)
+	return cloned
+}
+
+// InstallTarget describes how a known model is identified, downloaded, and placed on disk.
+// It intentionally excludes runtime defaults such as context size or pooling behavior.
+type InstallTarget struct {
+	Metadata
+	DefaultFilename string
+	DownloadURL     string
+}
+
+type knownInstallTarget struct {
+	InstallTarget
+	matchesPath func(name string, full string) bool
+}
+
+var knownInstallTargets = []knownInstallTarget{
+	{
+		InstallTarget: InstallTarget{
+			Metadata: Metadata{
+				ID:          "embeddinggemma",
+				DisplayName: "embeddinggemma-300m",
+				Aliases:     []string{"default", "embeddinggemma", "gemma", "embeddinggemma-300m"},
+			},
+			DefaultFilename: "embeddinggemma-300m.gguf",
+			DownloadURL:     "https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF/resolve/main/embeddinggemma-300M-Q8_0.gguf?download=true",
+		},
+		matchesPath: func(name string, full string) bool {
+			return strings.Contains(name, "embeddinggemma") || strings.Contains(full, "embeddinggemma")
+		},
+	},
+	{
+		InstallTarget: InstallTarget{
+			Metadata: Metadata{
+				ID:          "qwen3",
+				DisplayName: "Qwen3-Embedding-0.6B",
+				Aliases:     []string{"qwen3", "qwen3-embedding", "qwen3embedding", "qwen"},
+			},
+			DefaultFilename: "Qwen3-Embedding-0.6B-Q8_0.gguf",
+			DownloadURL:     "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf?download=true",
+		},
+		matchesPath: func(name string, full string) bool {
+			return strings.Contains(name, "qwen3-embedding") ||
+				strings.Contains(name, "qwen3embedding") ||
+				(strings.Contains(full, "qwen3") && strings.Contains(full, "embed"))
+		},
+	},
+}
+
+func DefaultInstallTarget() InstallTarget {
+	return cloneInstallTarget(knownInstallTargets[0].InstallTarget)
+}
+
+func KnownInstallTargets() []InstallTarget {
+	targets := make([]InstallTarget, 0, len(knownInstallTargets))
+	for _, target := range knownInstallTargets {
+		targets = append(targets, cloneInstallTarget(target.InstallTarget))
+	}
+	return targets
+}
+
+func ResolveInstallTarget(value string) (InstallTarget, bool) {
+	token := normalizeModelToken(value)
+	if token == "" {
+		return InstallTarget{}, false
+	}
+
+	for _, target := range knownInstallTargets {
+		for _, alias := range target.Aliases {
+			if token == normalizeModelToken(alias) {
+				return cloneInstallTarget(target.InstallTarget), true
+			}
+		}
+	}
+
+	return InstallTarget{}, false
+}
+
+func RecognizeInstallTargetForPath(modelPath string) (InstallTarget, bool) {
+	name, full := normalizedModelPath(modelPath)
+	for _, target := range knownInstallTargets {
+		if target.matchesPath(name, full) {
+			return cloneInstallTarget(target.InstallTarget), true
+		}
+	}
+
+	return InstallTarget{}, false
+}
+
+func cloneInstallTarget(target InstallTarget) InstallTarget {
+	cloned := target
+	cloned.Metadata = target.Metadata.Clone()
+	return cloned
+}
+
+func normalizedModelPath(modelPath string) (string, string) {
+	full := strings.ToLower(strings.TrimSpace(modelPath))
+	name := strings.ToLower(filepath.Base(full))
+	return name, full
+}
+
+func normalizeModelToken(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	replacer := strings.NewReplacer("-", "", "_", "", " ", "")
+	return replacer.Replace(value)
+}

--- a/internal/modelcatalog/catalog.go
+++ b/internal/modelcatalog/catalog.go
@@ -106,7 +106,7 @@ func RecognizeInstallTargetForPath(modelPath string) (InstallTarget, bool) {
 
 func cloneInstallTarget(target InstallTarget) InstallTarget {
 	cloned := target
-	cloned.Metadata = target.Metadata.Clone()
+	cloned.Metadata = target.Clone()
 	return cloned
 }
 

--- a/internal/modelcatalog/catalog_test.go
+++ b/internal/modelcatalog/catalog_test.go
@@ -1,0 +1,38 @@
+package modelcatalog
+
+import "testing"
+
+func TestKnownInstallTargets(t *testing.T) {
+	t.Parallel()
+
+	targets := KnownInstallTargets()
+	if len(targets) < 2 {
+		t.Fatalf("KnownInstallTargets() = %d, want at least 2", len(targets))
+	}
+
+	if got := DefaultInstallTarget().ID; got != "embeddinggemma" {
+		t.Fatalf("DefaultInstallTarget().ID = %q", got)
+	}
+
+	qwen, ok := ResolveInstallTarget("qwen3")
+	if !ok || qwen.ID != "qwen3" {
+		t.Fatalf("ResolveInstallTarget(qwen3) = (%#v, %v)", qwen, ok)
+	}
+
+	gemmaByPath, ok := RecognizeInstallTargetForPath("/tmp/embeddinggemma-300m.gguf")
+	if !ok || gemmaByPath.ID != "embeddinggemma" {
+		t.Fatalf("RecognizeInstallTargetForPath(gemma) = (%#v, %v)", gemmaByPath, ok)
+	}
+}
+
+func TestKnownInstallTargetsReturnClonedAliases(t *testing.T) {
+	t.Parallel()
+
+	targets := KnownInstallTargets()
+	targets[0].Aliases[0] = "mutated"
+
+	freshTargets := KnownInstallTargets()
+	if freshTargets[0].Aliases[0] == "mutated" {
+		t.Fatalf("KnownInstallTargets() returned shared alias slices")
+	}
+}

--- a/internal/runtime/model_cache.go
+++ b/internal/runtime/model_cache.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/uchebnick/unch/internal/modelcatalog"
 )
 
 type Reporter interface {
@@ -17,33 +19,8 @@ type Reporter interface {
 
 type ModelCache struct{}
 
-type knownEmbeddingModel struct {
-	ID              string
-	DisplayName     string
-	Aliases         []string
-	DefaultFilename string
-	DownloadURL     string
-}
-
-var knownEmbeddingModels = []knownEmbeddingModel{
-	{
-		ID:              "embeddinggemma",
-		DisplayName:     "embeddinggemma-300m",
-		Aliases:         []string{"default", "embeddinggemma", "gemma", "embeddinggemma-300m"},
-		DefaultFilename: "embeddinggemma-300m.gguf",
-		DownloadURL:     "https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF/resolve/main/embeddinggemma-300M-Q8_0.gguf?download=true",
-	},
-	{
-		ID:              "qwen3",
-		DisplayName:     "Qwen3-Embedding-0.6B",
-		Aliases:         []string{"qwen3", "qwen3-embedding", "qwen3embedding", "qwen"},
-		DefaultFilename: "Qwen3-Embedding-0.6B-Q8_0.gguf",
-		DownloadURL:     "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf?download=true",
-	},
-}
-
 func DefaultModelPath(modelsDir string) string {
-	return filepath.Join(modelsDir, defaultKnownEmbeddingModel().DefaultFilename)
+	return filepath.Join(modelsDir, modelcatalog.DefaultInstallTarget().DefaultFilename)
 }
 
 func CanonicalModelPath(requestedPath string, defaultPath string) (string, error) {
@@ -75,7 +52,7 @@ func (ModelCache) ResolveOrInstallModelPath(ctx context.Context, requestedPath s
 		}
 
 		if allowAutoDownload && selection.AutoDownload {
-			note, err := installEmbeddingModel(ctx, selection.ResolvedPath, selection.Profile, reporter)
+			note, err := installEmbeddingModel(ctx, selection.ResolvedPath, selection.Target, reporter)
 			if err != nil {
 				return "", "", err
 			}
@@ -93,7 +70,7 @@ func (ModelCache) ResolveOrInstallModelPath(ctx context.Context, requestedPath s
 	}
 
 	if allowAutoDownload && selection.AutoDownload {
-		note, err := installEmbeddingModel(ctx, selection.ResolvedPath, selection.Profile, reporter)
+		note, err := installEmbeddingModel(ctx, selection.ResolvedPath, selection.Target, reporter)
 		if err != nil {
 			return "", "", err
 		}
@@ -108,7 +85,7 @@ func (ModelCache) ResolveOrInstallModelPath(ctx context.Context, requestedPath s
 
 type modelSelection struct {
 	ResolvedPath string
-	Profile      knownEmbeddingModel
+	Target       modelcatalog.InstallTarget
 	AutoDownload bool
 }
 
@@ -122,15 +99,15 @@ func resolveModelSelection(requestedPath string, defaultPath string) (modelSelec
 	if requestedPath == "" {
 		return modelSelection{
 			ResolvedPath: defaultResolvedPath,
-			Profile:      defaultKnownEmbeddingModel(),
+			Target:       modelcatalog.DefaultInstallTarget(),
 			AutoDownload: true,
 		}, nil
 	}
 
-	if profile, ok := resolveKnownEmbeddingModel(requestedPath); ok {
+	if target, ok := modelcatalog.ResolveInstallTarget(requestedPath); ok {
 		return modelSelection{
-			ResolvedPath: filepath.Join(filepath.Dir(defaultResolvedPath), profile.DefaultFilename),
-			Profile:      profile,
+			ResolvedPath: filepath.Join(filepath.Dir(defaultResolvedPath), target.DefaultFilename),
+			Target:       target,
 			AutoDownload: true,
 		}, nil
 	}
@@ -142,18 +119,18 @@ func resolveModelSelection(requestedPath string, defaultPath string) (modelSelec
 
 	selection := modelSelection{ResolvedPath: resolvedPath}
 	if filepath.Clean(resolvedPath) == filepath.Clean(defaultResolvedPath) {
-		selection.Profile = defaultKnownEmbeddingModel()
+		selection.Target = modelcatalog.DefaultInstallTarget()
 		selection.AutoDownload = true
 		return selection, nil
 	}
-	if profile, ok := recognizeKnownEmbeddingModelForPath(resolvedPath); ok {
-		selection.Profile = profile
+	if target, ok := modelcatalog.RecognizeInstallTargetForPath(resolvedPath); ok {
+		selection.Target = target
 		selection.AutoDownload = true
 	}
 	return selection, nil
 }
 
-func installEmbeddingModel(ctx context.Context, destPath string, profile knownEmbeddingModel, reporter Reporter) (string, error) {
+func installEmbeddingModel(ctx context.Context, destPath string, target modelcatalog.InstallTarget, reporter Reporter) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 		return "", fmt.Errorf("create model dir: %w", err)
 	}
@@ -177,7 +154,7 @@ func installEmbeddingModel(ctx context.Context, destPath string, profile knownEm
 
 	url := strings.TrimSpace(os.Getenv("SEMSEARCH_MODEL_URL"))
 	if url == "" {
-		url = profile.DownloadURL
+		url = target.DownloadURL
 	}
 
 	stagingDir, err := os.MkdirTemp(filepath.Dir(destPath), filepath.Base(destPath)+".tmp-*")
@@ -189,7 +166,7 @@ func installEmbeddingModel(ctx context.Context, destPath string, profile knownEm
 	}()
 
 	if reporter != nil {
-		reporter.Logf("downloading %s model from %s to %s", profile.DisplayName, url, destPath)
+		reporter.Logf("downloading %s model from %s to %s", target.DisplayName, url, destPath)
 	}
 
 	progress := defaultProgressTracker
@@ -198,7 +175,7 @@ func installEmbeddingModel(ctx context.Context, destPath string, profile knownEm
 	}
 
 	if err := downloadModelWithContext(ctx, url, stagingDir, progress); err != nil {
-		return "", fmt.Errorf("download %s model from %s: %w", profile.DisplayName, url, err)
+		return "", fmt.Errorf("download %s model from %s: %w", target.DisplayName, url, err)
 	}
 
 	modelFile, err := findSingleGGUFFile(stagingDir)
@@ -211,68 +188,18 @@ func installEmbeddingModel(ctx context.Context, destPath string, profile knownEm
 	}
 
 	if err := activateModelFile(modelFile, destPath); err != nil {
-		return "", fmt.Errorf("activate downloaded %s model: %w", profile.DisplayName, err)
+		return "", fmt.Errorf("activate downloaded %s model: %w", target.DisplayName, err)
 	}
 
 	cleanupModelArtifacts(destPath, reporter)
-	return fmt.Sprintf("downloaded %s model to %s", profile.DisplayName, destPath), nil
+	return fmt.Sprintf("downloaded %s model to %s", target.DisplayName, destPath), nil
 }
 
 func modelSelectionID(selection modelSelection) string {
-	if selection.Profile.ID != "" {
-		return selection.Profile.ID
+	if selection.Target.ID != "" {
+		return selection.Target.ID
 	}
 	return "custom:" + filepath.ToSlash(filepath.Clean(selection.ResolvedPath))
-}
-
-func defaultKnownEmbeddingModel() knownEmbeddingModel {
-	return knownEmbeddingModels[0]
-}
-
-func resolveKnownEmbeddingModel(value string) (knownEmbeddingModel, bool) {
-	token := normalizeModelToken(value)
-	if token == "" {
-		return knownEmbeddingModel{}, false
-	}
-	for _, model := range knownEmbeddingModels {
-		for _, alias := range model.Aliases {
-			if token == normalizeModelToken(alias) {
-				return model, true
-			}
-		}
-	}
-	return knownEmbeddingModel{}, false
-}
-
-func recognizeKnownEmbeddingModelForPath(modelPath string) (knownEmbeddingModel, bool) {
-	name, full := normalizedModelPath(modelPath)
-	for _, model := range knownEmbeddingModels {
-		switch model.ID {
-		case "embeddinggemma":
-			if strings.Contains(name, "embeddinggemma") || strings.Contains(full, "embeddinggemma") {
-				return model, true
-			}
-		case "qwen3":
-			if strings.Contains(name, "qwen3-embedding") ||
-				strings.Contains(name, "qwen3embedding") ||
-				(strings.Contains(full, "qwen3") && strings.Contains(full, "embed")) {
-				return model, true
-			}
-		}
-	}
-	return knownEmbeddingModel{}, false
-}
-
-func normalizedModelPath(modelPath string) (string, string) {
-	full := strings.ToLower(strings.TrimSpace(modelPath))
-	name := strings.ToLower(filepath.Base(full))
-	return name, full
-}
-
-func normalizeModelToken(value string) string {
-	value = strings.ToLower(strings.TrimSpace(value))
-	replacer := strings.NewReplacer("-", "", "_", "", " ", "")
-	return replacer.Replace(value)
 }
 
 func repairInstalledModel(destPath string, reporter Reporter) (string, error) {

--- a/internal/runtime/model_cache_test.go
+++ b/internal/runtime/model_cache_test.go
@@ -213,7 +213,7 @@ func TestResolveModelSelectionSupportsKnownAliases(t *testing.T) {
 	if got, want := selection.ResolvedPath, defaultPath; got != want {
 		t.Fatalf("resolveModelSelection(default) path = %q, want %q", got, want)
 	}
-	if !selection.AutoDownload || selection.Profile.ID != "embeddinggemma" {
+	if !selection.AutoDownload || selection.Target.ID != "embeddinggemma" {
 		t.Fatalf("resolveModelSelection(default) = %#v", selection)
 	}
 
@@ -225,7 +225,7 @@ func TestResolveModelSelectionSupportsKnownAliases(t *testing.T) {
 	if got := qwenSelection.ResolvedPath; got != wantQwen {
 		t.Fatalf("resolveModelSelection(qwen3) path = %q, want %q", got, wantQwen)
 	}
-	if !qwenSelection.AutoDownload || qwenSelection.Profile.ID != "qwen3" {
+	if !qwenSelection.AutoDownload || qwenSelection.Target.ID != "qwen3" {
 		t.Fatalf("resolveModelSelection(qwen3) = %#v", qwenSelection)
 	}
 }


### PR DESCRIPTION
## What changed

- replaces the temporary `internal/modelspec` split with a cleaner shared `internal/modelcatalog` layer for known model identity and install metadata
- keeps the embedding runtime profile in `internal/embed/llama`, where pooling and query/document formatting already live, instead of mixing runtime defaults into the install catalog
- removes the separate `--batch-size` CLI knob from the embedding path and derives `n_batch` from the resolved context size
- updates the CLI help and README so the public surface matches the simplified model/runtime configuration

## Why

The previous shape still split one small model registry across two packages in a way that was harder to reason about than it needed to be. The install layer and the embedding runtime layer were both valid concepts, but `modelspec` sat awkwardly between them.

This change makes the boundaries more explicit:

- `internal/modelcatalog` owns model identity, aliases, filenames, download URLs, and path recognition
- `internal/runtime/model_cache` owns installation and activation
- `internal/embed/llama` owns embedding runtime behavior and the model-specific context defaults

It also drops `--batch-size` from the user-facing embeddings flow because, in the current path, it was just another way to tune the same effective input sizing surface without adding much practical value.

## Validation

- `go test ./...`
- `git diff --check`
