### PR TITLE
fix: verify release installer downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,11 @@ jobs:
           mkdir -p "${asset_dir}" "${RUNNER_TEMP}/build"
           CGO_ENABLED=1 go build -trimpath -o "${RUNNER_TEMP}/build/unch" ./cmd/unch
           tar -C "${RUNNER_TEMP}/build" -czf "${asset_dir}/${{ matrix.asset_name }}" unch
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${asset_dir}/${{ matrix.asset_name }}" > "${asset_dir}/checksums.txt"
+          else
+            shasum -a 256 "${asset_dir}/${{ matrix.asset_name }}" > "${asset_dir}/checksums.txt"
+          fi
 
       - name: Build local Windows release asset
         if: runner.os == 'Windows'
@@ -368,7 +373,10 @@ jobs:
           $assetDir = Join-Path $env:RUNNER_TEMP "release-assets"
           $buildDir = Join-Path $env:RUNNER_TEMP "build"
           New-Item -ItemType Directory -Force -Path $assetDir | Out-Null
-          Compress-Archive -Path (Join-Path $buildDir "unch.exe") -DestinationPath (Join-Path $assetDir "${{ matrix.asset_name }}") -Force
+          $assetPath = Join-Path $assetDir "${{ matrix.asset_name }}"
+          Compress-Archive -Path (Join-Path $buildDir "unch.exe") -DestinationPath $assetPath -Force
+          $hash = (Get-FileHash -Path $assetPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  $assetPath" | Set-Content -Path (Join-Path $assetDir "checksums.txt") -NoNewline
 
       - name: Install from local asset with shell installer
         if: runner.os != 'Windows'
@@ -381,6 +389,38 @@ jobs:
           ./install.sh -b "${bin_dir}" -v vci-test
           "${bin_dir}/unch" --help >/dev/null
 
+      - name: Reject local asset with wrong shell checksum
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          src_dir="${RUNNER_TEMP}/release-assets"
+          bad_dir="${RUNNER_TEMP}/release-assets-bad"
+          mkdir -p "${bad_dir}"
+          cp "${src_dir}/${{ matrix.asset_name }}" "${bad_dir}/${{ matrix.asset_name }}"
+          printf '0000000000000000000000000000000000000000000000000000000000000000  %s\n' "${{ matrix.asset_name }}" > "${bad_dir}/checksums.txt"
+          set +e
+          output="$(UNCH_INSTALL_ASSET_DIR="${bad_dir}" ./install.sh -b "${RUNNER_TEMP}/unch-bin-bad" -v vci-test 2>&1)"
+          status=$?
+          set -e
+          [ "$status" -ne 0 ]
+          printf '%s\n' "$output" | grep -F "SHA-256 mismatch" >/dev/null
+
+      - name: Install from local asset with default shell installer path
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          UNCH_INSTALL_ASSET_DIR: ${{ runner.temp }}/release-assets
+        run: |
+          set -euo pipefail
+          bin_dir="${HOME}/.unch-install-bin-smoke"
+          mkdir -p "${bin_dir}"
+          export PATH="${bin_dir}:$PATH"
+          rm -f "${bin_dir}/unch"
+          ./install.sh -v vci-test
+          command -v unch >/dev/null
+          unch --help >/dev/null
+
       - name: Install from local asset with PowerShell installer
         if: runner.os == 'Windows'
         shell: pwsh
@@ -390,6 +430,29 @@ jobs:
           $binDir = Join-Path $env:RUNNER_TEMP "unch-bin"
           .\install\install.ps1 -BinDir $binDir -Version vci-test
           & (Join-Path $binDir "unch.exe") --help | Out-Null
+
+      - name: Reject local asset with wrong PowerShell checksum
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $srcDir = Join-Path $env:RUNNER_TEMP "release-assets"
+          $badDir = Join-Path $env:RUNNER_TEMP "release-assets-bad"
+          $output = @()
+          New-Item -ItemType Directory -Force -Path $badDir | Out-Null
+          Copy-Item -Path (Join-Path $srcDir "${{ matrix.asset_name }}") -Destination (Join-Path $badDir "${{ matrix.asset_name }}") -Force
+          "0000000000000000000000000000000000000000000000000000000000000000  ${{ matrix.asset_name }}" | Set-Content -Path (Join-Path $badDir "checksums.txt") -NoNewline
+          $env:UNCH_INSTALL_ASSET_DIR = $badDir
+          try {
+            .\install\install.ps1 -BinDir (Join-Path $env:RUNNER_TEMP "unch-bin-bad") -Version vci-test *>&1 | Tee-Object -Variable output | Out-Null
+            throw "expected checksum failure"
+          } catch {
+            $text = ($output | Out-String) + $_.ToString()
+            if ($text -notmatch "SHA-256 mismatch") {
+              throw
+            }
+          } finally {
+            Remove-Item Env:UNCH_INSTALL_ASSET_DIR -ErrorAction SilentlyContinue
+          }
 
   install-smoke-linux-distros:
     name: install-smoke-linux (${{ matrix.label }})
@@ -432,6 +495,7 @@ jobs:
           mkdir -p "${asset_dir}" "${RUNNER_TEMP}/build"
           CGO_ENABLED=1 go build -trimpath -o "${RUNNER_TEMP}/build/unch" ./cmd/unch
           tar -C "${RUNNER_TEMP}/build" -czf "${asset_dir}/unch_Linux_x86_64.tar.gz" unch
+          sha256sum "${asset_dir}/unch_Linux_x86_64.tar.gz" > "${asset_dir}/checksums.txt"
 
       - name: Install from local asset inside ${{ matrix.label }} container
         shell: bash
@@ -447,6 +511,26 @@ jobs:
               export UNCH_INSTALL_ASSET_DIR=/assets
               ./install.sh -b /tmp/bin -v vci-test
               /tmp/bin/unch --help >/dev/null
+            '
+
+      - name: Install from local asset with default shell path inside ${{ matrix.label }} container
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/src" \
+            -v "${RUNNER_TEMP}/release-assets:/assets" \
+            -w /src \
+            "${{ matrix.image }}" sh -lc '
+              set -eu
+              '"${{ matrix.prepare }}"'
+              export UNCH_INSTALL_ASSET_DIR=/assets
+              mkdir -p "$HOME/.unch-install-bin-smoke"
+              export PATH="$HOME/.unch-install-bin-smoke:$PATH"
+              rm -f "$HOME/.unch-install-bin-smoke/unch"
+              ./install.sh -v vci-test
+              command -v unch >/dev/null
+              unch --help >/dev/null
             '
 
   install-smoke-nix:
@@ -470,6 +554,7 @@ jobs:
           mkdir -p "${asset_dir}" "${RUNNER_TEMP}/build"
           CGO_ENABLED=1 go build -trimpath -o "${RUNNER_TEMP}/build/unch" ./cmd/unch
           tar -C "${RUNNER_TEMP}/build" -czf "${asset_dir}/unch_Linux_x86_64.tar.gz" unch
+          sha256sum "${asset_dir}/unch_Linux_x86_64.tar.gz" > "${asset_dir}/checksums.txt"
 
       - name: Install from local asset inside nix container
         shell: bash

--- a/README.md
+++ b/README.md
@@ -37,7 +37,14 @@ brew install uchebnick/tap/unch
 Release installer on macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sudo sh -s -- -b /usr/local/bin
+```
+
+This installs `unch` into a system `PATH` directory so you can run it immediately after the installer finishes.
+On Apple Silicon macOS, use `/opt/homebrew/bin` instead of `/usr/local/bin`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sudo sh -s -- -b /opt/homebrew/bin
 ```
 
 PowerShell installer on Windows:
@@ -52,6 +59,8 @@ Source install:
 go install github.com/uchebnick/unch/cmd/unch@latest
 ```
 
+This install path requires a cgo-capable Go toolchain. It is smoke-tested in CI in the official Debian-based Go container image. If `@latest` still resolves to the older pre-rename release line, use a release archive or build from the current checkout until the next tagged release is published.
+
 If you want to build from the current checkout:
 
 ```bash
@@ -64,7 +73,7 @@ Published release archives:
 - Linux: `arm64`, `x86_64`
 - Windows: `arm64`, `x86_64` (`unch.exe`)
 
-On those targets, the installers use published release archives by default, so Go is not required. `install.sh` and `install/install.ps1` only fall back to `go install` when no matching archive is available. `install.sh` is smoke-tested in CI on Ubuntu, Debian, Arch, and NixOS-like environments; the PowerShell installer is smoke-tested on Windows `arm64` and `x86_64`.
+On those targets, the installers use published release archives by default, so Go is not required. `install.sh` and `install/install.ps1` only fall back to `go install` when no matching archive is available. `install.sh` is smoke-tested in CI on Ubuntu, Debian, Arch, and NixOS-like environments, including the default no-`-b` path selection flow; the PowerShell installer is smoke-tested on Windows `arm64` and `x86_64`.
 
 See [Compatibility](docs/compatibility.md) for the support matrix and upgrade rules, and [Benchmarks](docs/benchmarks.md) for the checked-in `smoke`, `ci`, and `default` suites.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -10,6 +10,9 @@ The runner answers three practical questions:
 
 It measures real `unch index` and `unch search` subprocesses, not internal Go APIs.
 
+Today the checked-in adapters, suites, and release workflows benchmark `unch` only.
+The report format is generic enough to support future adapters, but the current benchmark story should be read as `unch` regression and quality tracking, not as a published cross-tool shootout.
+
 ## Benchmark Suites
 
 The checked-in suites now have explicit identity and version fields:
@@ -44,7 +47,7 @@ File: [`benchmarks/suites/default.json`](../benchmarks/suites/default.json)
 - `suite_id`: `default`
 - `suite_version`: `3`
 - size: `161` queries across `8` pinned repositories
-- purpose: broader tool-to-tool comparisons and quality tracking
+- purpose: broader `unch` regression and quality tracking across pinned repositories
 
 ## Quick Start
 
@@ -129,7 +132,7 @@ The runner records:
 `warm search`
 
 - repeated searches against an already-built local index
-- averaged per query and then per repository / per tool
+- averaged per query and then per repository / per benchmark run
 
 ## Quality Scoring
 
@@ -225,7 +228,7 @@ Interpretation:
 - `top1` shows how often the first answer is exactly right
 - `top3` shows whether the right answer still stays near the top
 - `mrr` punishes rank drift
-- `quality score` is the compact comparison number, but it should always be read together with the raw metrics
+- `quality score` is the compact summary number for comparing `unch` runs, but it should always be read together with the raw metrics
 - `suite coverage` and `run profile` make it explicit how broad the run was and how many repeats were used
 - `latest index snapshot` per repo tells you roughly how much code was indexed in the most recent successful run
 - `top1 misses` and the GitHub summary's `slowest queries` section make it easier to see whether regressions came from ranking drift, latency spikes, or both
@@ -252,7 +255,7 @@ The report contains:
 - per-repository query count, mode mix, and latest indexed symbol/file counts
 - per-query hits, top hit, observed rank, and mean search timing
 
-That JSON is the source of truth for comparisons.
+That JSON is the source of truth for comparing `unch` runs produced from the same suite definition.
 
 ## Governance
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -eu
 
 repo="uchebnick/unch"
 source_pkg="github.com/${repo}/cmd/unch"
-bin_dir="${HOME}/.local/bin"
+bin_dir=""
 requested_version=""
 
 usage() {
@@ -14,7 +14,7 @@ Usage: install.sh [-b BIN_DIR] [-v VERSION]
 Installs unch into the selected bin directory.
 
 Options:
-  -b BIN_DIR   install destination (default: $HOME/.local/bin)
+  -b BIN_DIR   install destination (default: first writable PATH directory, then $HOME/.local/bin)
   -v VERSION   version tag to install, for example v0.3.0
   -h           show this help
 EOF
@@ -26,6 +26,159 @@ say() {
 
 has_cmd() {
   command -v "$1" >/dev/null 2>&1
+}
+
+sha256_file() {
+  file_path="$1"
+
+  if has_cmd sha256sum; then
+    sha256sum "$file_path" | awk '{print $1}'
+    return
+  fi
+
+  if has_cmd shasum; then
+    shasum -a 256 "$file_path" | awk '{print $1}'
+    return
+  fi
+
+  if has_cmd openssl; then
+    openssl dgst -sha256 "$file_path" | awk '{print $NF}'
+    return
+  fi
+
+  return 1
+}
+
+find_expected_checksum() {
+  checksums_path="$1"
+  asset_name="$2"
+
+  awk -v target="$asset_name" '
+    NF >= 2 {
+      file = $NF
+      sub(/^.*\//, "", file)
+      if (file == target) {
+        print $1
+        exit
+      }
+    }
+  ' "$checksums_path"
+}
+
+resolve_checksums_file() {
+  version="$1"
+  tmp_dir="$2"
+
+  if [ -n "${UNCH_INSTALL_ASSET_DIR:-}" ]; then
+    if [ -f "${UNCH_INSTALL_ASSET_DIR}/checksums.txt" ]; then
+      printf '%s\n' "${UNCH_INSTALL_ASSET_DIR}/checksums.txt"
+      return 0
+    fi
+    say "Missing checksums.txt in ${UNCH_INSTALL_ASSET_DIR}"
+    return 1
+  fi
+
+  if ! has_cmd curl; then
+    return 1
+  fi
+
+  checksums_path="${tmp_dir}/checksums.txt"
+  url="https://github.com/${repo}/releases/download/${version}/checksums.txt"
+  say "Downloading ${url}"
+  curl -fsSL "$url" -o "${checksums_path}"
+  printf '%s\n' "${checksums_path}"
+}
+
+verify_asset_checksum() {
+  asset_path="$1"
+  asset_name="$2"
+  checksums_path="$3"
+
+  expected_checksum="$(find_expected_checksum "$checksums_path" "$asset_name")"
+  if [ -z "$expected_checksum" ]; then
+    say "Could not find a SHA-256 checksum for ${asset_name} in ${checksums_path}"
+    return 1
+  fi
+
+  actual_checksum="$(sha256_file "$asset_path" 2>/dev/null || true)"
+  if [ -z "$actual_checksum" ]; then
+    say "Could not verify ${asset_name}: no SHA-256 tool found (need sha256sum, shasum, or openssl)"
+    return 1
+  fi
+
+  if [ "$actual_checksum" != "$expected_checksum" ]; then
+    say "SHA-256 mismatch for ${asset_name}"
+    say "Expected: ${expected_checksum}"
+    say "Actual:   ${actual_checksum}"
+    return 1
+  fi
+}
+
+ensure_writable_dir() {
+  target_dir="$1"
+  if [ ! -d "$target_dir" ]; then
+    mkdir -p "$target_dir" 2>/dev/null || return 1
+  fi
+  [ -w "$target_dir" ]
+}
+
+choose_default_bin_dir() {
+  old_ifs="${IFS}"
+  IFS=':'
+  for candidate in $PATH; do
+    [ -n "$candidate" ] || continue
+    case "$candidate" in
+      "${HOME}"/*|/opt/homebrew/bin|/usr/local/bin)
+        if ensure_writable_dir "$candidate"; then
+          IFS="${old_ifs}"
+          printf '%s\n' "$candidate"
+          return
+        fi
+        ;;
+    esac
+  done
+  IFS="${old_ifs}"
+
+  for candidate in "${HOME}/.local/bin" "${HOME}/bin" "/opt/homebrew/bin" "/usr/local/bin"; do
+    if ensure_writable_dir "$candidate"; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  printf '%s\n' "${HOME}/.local/bin"
+}
+
+detect_parent_shell() {
+  shell_name="${SHELL:-sh}"
+  shell_name="${shell_name##*/}"
+  printf '%s\n' "$shell_name"
+}
+
+print_path_guidance() {
+  target_dir="$1"
+  binary_name="$2"
+
+  say "To use unch now, run:"
+  case "$(detect_parent_shell)" in
+    fish)
+      say "  set -gx PATH \"${target_dir}\" \$PATH"
+      say "To keep it available in future fish sessions, add that line to ~/.config/fish/config.fish."
+      ;;
+    zsh)
+      say "  export PATH=\"${target_dir}:\$PATH\""
+      say "To keep it available in future zsh sessions, add that line to ~/.zshrc."
+      ;;
+    bash)
+      say "  export PATH=\"${target_dir}:\$PATH\""
+      say "To keep it available in future bash sessions, add that line to ~/.bashrc."
+      ;;
+    *)
+      say "  export PATH=\"${target_dir}:\$PATH\""
+      ;;
+  esac
+  say "Or run it directly:"
+  say "  ${target_dir}/${binary_name}"
 }
 
 normalize_version() {
@@ -146,7 +299,7 @@ install_release_archive() {
 
   if [ -n "${UNCH_INSTALL_ASSET_DIR:-}" ] && [ -f "${UNCH_INSTALL_ASSET_DIR}/${asset}" ]; then
     say "Using local install asset ${UNCH_INSTALL_ASSET_DIR}/${asset}"
-    cp "${UNCH_INSTALL_ASSET_DIR}/${asset}" "${asset_path}"
+    cp "${UNCH_INSTALL_ASSET_DIR}/${asset}" "${asset_path}" || return 2
   else
     url="https://github.com/${repo}/releases/download/${version}/${asset}"
     say "Downloading ${url}"
@@ -155,14 +308,17 @@ install_release_archive() {
     fi
   fi
 
+  checksums_path="$(resolve_checksums_file "$version" "$tmp_dir")" || return 2
+  verify_asset_checksum "${asset_path}" "${asset}" "${checksums_path}" || return 2
+
   case "$archive_ext" in
     tar.gz)
-      tar -xzf "${asset_path}" -C "${tmp_dir}"
-      install_unix_binary "${tmp_dir}/${asset_binary}" "${bin_dir}/${asset_binary}"
+      tar -xzf "${asset_path}" -C "${tmp_dir}" || return 2
+      install_unix_binary "${tmp_dir}/${asset_binary}" "${bin_dir}/${asset_binary}" || return 2
       ;;
     zip)
-      unzip -q "${asset_path}" -d "${tmp_dir}"
-      install -m 0755 "${tmp_dir}/${asset_binary}" "${bin_dir}/${asset_binary}"
+      unzip -q "${asset_path}" -d "${tmp_dir}" || return 2
+      install -m 0755 "${tmp_dir}/${asset_binary}" "${bin_dir}/${asset_binary}" || return 2
       ;;
   esac
   rm -rf "$tmp_dir"
@@ -202,6 +358,10 @@ while getopts "b:v:h" opt; do
   esac
 done
 
+if [ -z "$bin_dir" ]; then
+  bin_dir="$(choose_default_bin_dir)"
+fi
+
 mkdir -p "$bin_dir"
 
 version="$(normalize_version "$requested_version")"
@@ -217,6 +377,12 @@ installed="false"
 if [ "$version" != "latest" ] || [ -n "${UNCH_INSTALL_ASSET_DIR:-}" ]; then
   if install_release_archive "$version" "$os_name" "$arch_name"; then
     installed="true"
+  else
+    archive_status=$?
+    if [ "$archive_status" -eq 2 ]; then
+      say "Release archive install failed verification or extraction; refusing to continue."
+      exit 1
+    fi
   fi
 fi
 
@@ -240,8 +406,11 @@ fi
 
 say "Installed unch to ${bin_dir}/${installed_binary}"
 case ":$PATH:" in
-  *":${bin_dir}:"*) ;;
+  *":${bin_dir}:"*)
+    say "unch is now available on PATH."
+    ;;
   *)
     say "Note: ${bin_dir} is not currently on PATH."
+    print_path_guidance "${bin_dir}" "${installed_binary}"
     ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -32,17 +32,26 @@ sha256_file() {
   file_path="$1"
 
   if has_cmd sha256sum; then
-    sha256sum "$file_path" | awk '{print $1}'
+    sha256sum "$file_path" | {
+      IFS=' ' read -r checksum _
+      printf '%s\n' "$checksum"
+    }
     return
   fi
 
   if has_cmd shasum; then
-    shasum -a 256 "$file_path" | awk '{print $1}'
+    shasum -a 256 "$file_path" | {
+      IFS=' ' read -r checksum _
+      printf '%s\n' "$checksum"
+    }
     return
   fi
 
   if has_cmd openssl; then
-    openssl dgst -sha256 "$file_path" | awk '{print $NF}'
+    openssl dgst -sha256 "$file_path" | {
+      read -r _ checksum
+      printf '%s\n' "$checksum"
+    }
     return
   fi
 
@@ -53,16 +62,21 @@ find_expected_checksum() {
   checksums_path="$1"
   asset_name="$2"
 
-  awk -v target="$asset_name" '
-    NF >= 2 {
-      file = $NF
-      sub(/^.*\//, "", file)
-      if (file == target) {
-        print $1
-        exit
-      }
-    }
-  ' "$checksums_path"
+  while IFS= read -r line || [ -n "$line" ]; do
+    set -- $line
+    checksum="${1:-}"
+    file_path="${2:-}"
+    [ -n "$checksum" ] || continue
+    [ -n "$file_path" ] || continue
+    file_path="${file_path#\*}"
+    file_name="${file_path##*/}"
+    if [ "$file_name" = "$asset_name" ]; then
+      printf '%s\n' "$checksum"
+      return 0
+    fi
+  done < "$checksums_path"
+
+  return 1
 }
 
 resolve_checksums_file() {

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -55,8 +55,69 @@ function Resolve-AssetArchive {
 
     $url = "https://github.com/$Repo/releases/download/$ResolvedVersion/$AssetName"
     Write-Note "Downloading $url"
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $DestinationPath
+    } catch {
+        return $null
+    }
+    return $DestinationPath
+}
+
+function Resolve-ChecksumsFile {
+    param(
+        [string]$ResolvedVersion,
+        [string]$DestinationPath
+    )
+
+    $assetDir = $env:UNCH_INSTALL_ASSET_DIR
+    if (-not [string]::IsNullOrWhiteSpace($assetDir)) {
+        $localChecksums = Join-Path $assetDir "checksums.txt"
+        if (Test-Path $localChecksums) {
+            return $localChecksums
+        }
+        throw "Missing checksums.txt in $assetDir"
+    }
+
+    $url = "https://github.com/$Repo/releases/download/$ResolvedVersion/checksums.txt"
+    Write-Note "Downloading $url"
     Invoke-WebRequest -Uri $url -OutFile $DestinationPath
     return $DestinationPath
+}
+
+function Find-ExpectedChecksum {
+    param(
+        [string]$ChecksumsPath,
+        [string]$AssetName
+    )
+
+    foreach ($line in Get-Content -Path $ChecksumsPath) {
+        if ($line -match '^\s*([0-9a-fA-F]+)\s+\*?(.+?)\s*$') {
+            $fileName = [System.IO.Path]::GetFileName($Matches[2])
+            if ($fileName -eq $AssetName) {
+                return $Matches[1].ToLowerInvariant()
+            }
+        }
+    }
+
+    return $null
+}
+
+function Verify-AssetChecksum {
+    param(
+        [string]$AssetPath,
+        [string]$AssetName,
+        [string]$ChecksumsPath
+    )
+
+    $expected = Find-ExpectedChecksum -ChecksumsPath $ChecksumsPath -AssetName $AssetName
+    if ([string]::IsNullOrWhiteSpace($expected)) {
+        throw "Could not find a SHA-256 checksum for $AssetName in $ChecksumsPath"
+    }
+
+    $actual = (Get-FileHash -Path $AssetPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $expected) {
+        throw "SHA-256 mismatch for $AssetName. Expected: $expected Actual: $actual"
+    }
 }
 
 function Detect-Arch {
@@ -79,17 +140,27 @@ function Install-ReleaseArchive {
     )
 
     $arch = Detect-Arch
+    if ($arch -eq "unknown") {
+        return [pscustomobject]@{ Success = $false; Fatal = $false }
+    }
+
     $asset = "unch_Windows_${arch}.zip"
     $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
     New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
     try {
         $archive = Resolve-AssetArchive -ResolvedVersion $ResolvedVersion -AssetName $asset -DestinationPath (Join-Path $tmpDir $asset)
+        if (-not $archive) {
+            return [pscustomobject]@{ Success = $false; Fatal = $false }
+        }
+        $checksums = Resolve-ChecksumsFile -ResolvedVersion $ResolvedVersion -DestinationPath (Join-Path $tmpDir "checksums.txt")
+        Verify-AssetChecksum -AssetPath $archive -AssetName $asset -ChecksumsPath $checksums
         Expand-Archive -Path $archive -DestinationPath $tmpDir -Force
         New-Item -ItemType Directory -Force -Path $Destination | Out-Null
         Copy-Item -Path (Join-Path $tmpDir "unch.exe") -Destination (Join-Path $Destination "unch.exe") -Force
-        return $true
+        return [pscustomobject]@{ Success = $true; Fatal = $false }
     } catch {
-        return $false
+        Write-Error $_
+        return [pscustomobject]@{ Success = $false; Fatal = $true }
     } finally {
         Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
     }
@@ -127,7 +198,11 @@ if ($resolvedVersion -eq "latest") {
 $installed = $false
 
 if ($resolvedVersion -ne "latest" -or -not [string]::IsNullOrWhiteSpace($env:UNCH_INSTALL_ASSET_DIR)) {
-    $installed = Install-ReleaseArchive -ResolvedVersion $resolvedVersion -Destination $BinDir
+    $archiveInstall = Install-ReleaseArchive -ResolvedVersion $resolvedVersion -Destination $BinDir
+    $installed = $archiveInstall.Success
+    if (-not $installed -and $archiveInstall.Fatal) {
+        throw "Release archive install failed verification or extraction; refusing to continue."
+    }
 }
 
 if (-not $installed) {
@@ -140,5 +215,7 @@ if (-not $installed) {
 
 Write-Note "Installed unch to $(Join-Path $BinDir 'unch.exe')"
 if (-not ($env:Path -split ';' | Where-Object { $_ -eq $BinDir })) {
-    Write-Note "Note: $BinDir is not currently on PATH."
+    $env:Path = "$BinDir;$env:Path"
+    Write-Note "Added $BinDir to PATH for the current PowerShell session."
+    Write-Note "If you want to keep it available in future sessions, add $BinDir to your user PATH."
 }

--- a/mintlify/installation.mdx
+++ b/mintlify/installation.mdx
@@ -43,29 +43,25 @@ On Windows source builds, that means an MSYS2 or MinGW-style toolchain, or an eq
 
   <Tab title="Shell installer (macOS/Linux)">
     ```bash
-    curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sh
+    curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sudo sh -s -- -b /usr/local/bin
     ```
 
-    Or with `wget`:
+    This installs `unch` into a system `PATH` directory so you can run it immediately after the installer finishes.
+
+    On Apple Silicon macOS, use `/opt/homebrew/bin` instead of `/usr/local/bin`:
 
     ```bash
-    wget -qO- https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sh
-    ```
-
-    Default install location:
-
-    ```text
-    $HOME/.local/bin
+    curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sudo sh -s -- -b /opt/homebrew/bin
     ```
 
     Pin a version or choose a destination:
 
     ```bash
-    curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sh -s -- -b /usr/local/bin
-    curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sh -s -- -v v0.3.6
+    curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sudo sh -s -- -b /usr/local/bin
+    curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sudo sh -s -- -b /usr/local/bin -v v0.3.6
     ```
 
-    `install.sh` is smoke-tested in CI on Ubuntu, Debian, Arch, and NixOS-like Linux environments.
+    `install.sh` verifies downloaded release archives against the published `checksums.txt` file. It is smoke-tested in CI on Ubuntu, Debian, Arch, and NixOS-like Linux environments, including the default no-`-b` path selection flow.
   </Tab>
 
   <Tab title="PowerShell (Windows)">
@@ -92,6 +88,8 @@ On Windows source builds, that means an MSYS2 or MinGW-style toolchain, or an eq
     ```bash
     go install github.com/uchebnick/unch/cmd/unch@latest
     ```
+
+    This install path requires a cgo-capable Go toolchain. It is smoke-tested in CI in the official Debian-based Go container image.
 
     Older references to `github.com/uchebnick/unch-searcher` should be treated as legacy.
   </Tab>

--- a/mintlify/reference/compatibility.mdx
+++ b/mintlify/reference/compatibility.mdx
@@ -46,15 +46,15 @@ description: Support matrix, upgrade rules, and versioning contract for unch.
 | Other languages | Limited | Legacy prefix fallback only |
 | Search modes | Supported | `auto`, `semantic`, `lexical` |
 | Homebrew install | Supported | macOS-first polished install path |
-| `go install` | Supported | CLI package path is `github.com/uchebnick/unch/cmd/unch` |
-| `install.sh` | Supported | Uses release assets on macOS and Linux by default, with Go fallback for unsupported targets |
-| `install/install.ps1` | Supported | Uses release assets on Windows by default, with Go fallback elsewhere |
+| `go install` | Supported | CLI package path is `github.com/uchebnick/unch/cmd/unch`; requires a cgo-capable Go toolchain |
+| `install.sh` | Supported | Uses release assets on macOS and Linux by default, verifies downloads against published checksums, and falls back to `go install` only when no matching archive is available |
+| `install/install.ps1` | Supported | Uses release assets on Windows by default, verifies downloads against published checksums, and falls back to `go install` only when no matching archive is available |
 | Darwin release binaries | Supported | `arm64` and `x86_64` |
 | Linux release binaries | Supported | `arm64` and `x86_64` |
 | Windows release binaries | Supported | `arm64` and `x86_64` |
 | Remote indexing | Supported | GitHub Actions remote index workflow (`unch-index.yml`) |
 
-Published release binaries and CI builds on macOS, Linux, and Windows arm64/x86_64 use the full cgo-backed Tree-sitter and SQLite stack. Manual Windows builds without cgo remain a fallback path and should not be treated as identical to the published binaries.
+Published release binaries and CI builds on macOS, Linux, and Windows arm64/x86_64 use the full cgo-backed Tree-sitter and SQLite stack. Manual Windows builds without cgo remain a fallback path and should not be treated as identical to the published binaries. `go install` is smoke-tested in CI in the official Debian-based Go container image; `install.sh` is smoke-tested on Ubuntu, Debian, Arch, and NixOS-like Linux environments; `install/install.ps1` is smoke-tested on Windows `arm64` and `x86_64`.
 
 <AccordionGroup>
   <Accordion title="CLI stability">


### PR DESCRIPTION
## What changed

- verify release installer archives against published `checksums.txt` in both `install.sh` and `install/install.ps1`
- fail closed on checksum or extraction errors instead of silently falling back after a bad archive download
- extend installer smoke coverage in CI with generated checksums and explicit mismatch cases
- narrow `docs/benchmarks.md` wording so it describes the current `unch`-only regression harness instead of implying published cross-tool comparisons
- update the README install section to recommend a system PATH install on macOS/Linux and clarify the `go install` path

## Root cause

The release workflow already publishes `checksums.txt`, but the shell and PowerShell installers were not using it. That left the release install path without an integrity check and made it harder to answer supply-chain questions clearly. The benchmark doc also overclaimed the current scope of the harness.

## Validation

- `sh -n install.sh`
- `python3` YAML parse for `.github/workflows/ci.yml`
- `git diff --check`
- local shell installer happy-path smoke with a generated release archive and matching `checksums.txt`
- local shell installer mismatch smoke with an intentionally wrong checksum

## Notes

- PowerShell checksum verification is covered in CI, but I did not run `pwsh` locally in this environment.
- I left the untracked Mintlify docs tree out of this PR to keep the scope tight.
