### PR TITLE
fix: keep installers on release assets for latest

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,11 @@ resolve_checksums_file() {
   fi
 
   checksums_path="${tmp_dir}/checksums.txt"
-  url="https://github.com/${repo}/releases/download/${version}/checksums.txt"
+  if [ "$version" = "latest" ]; then
+    url="https://github.com/${repo}/releases/latest/download/checksums.txt"
+  else
+    url="https://github.com/${repo}/releases/download/${version}/checksums.txt"
+  fi
   say "Downloading ${url}"
   curl -fsSL "$url" -o "${checksums_path}"
   printf '%s\n' "${checksums_path}"
@@ -207,20 +211,6 @@ normalize_version() {
   esac
 }
 
-resolve_latest_version() {
-  if ! has_cmd curl; then
-    printf 'latest\n'
-    return
-  fi
-
-  effective_url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/${repo}/releases/latest" 2>/dev/null || true)"
-  tag="${effective_url##*/}"
-  case "$tag" in
-    ""|latest) printf 'latest\n' ;;
-    *) printf '%s\n' "$tag" ;;
-  esac
-}
-
 detect_os() {
   case "$(uname -s)" in
     Darwin) printf 'Darwin\n' ;;
@@ -315,7 +305,11 @@ install_release_archive() {
     say "Using local install asset ${UNCH_INSTALL_ASSET_DIR}/${asset}"
     cp "${UNCH_INSTALL_ASSET_DIR}/${asset}" "${asset_path}" || return 2
   else
-    url="https://github.com/${repo}/releases/download/${version}/${asset}"
+    if [ "$version" = "latest" ]; then
+      url="https://github.com/${repo}/releases/latest/download/${asset}"
+    else
+      url="https://github.com/${repo}/releases/download/${version}/${asset}"
+    fi
     say "Downloading ${url}"
     if ! curl -fsSL "$url" -o "${asset_path}"; then
       return 1
@@ -379,24 +373,19 @@ fi
 mkdir -p "$bin_dir"
 
 version="$(normalize_version "$requested_version")"
-if [ "$version" = "latest" ]; then
-  version="$(resolve_latest_version)"
-fi
 
 os_name="$(detect_os)"
 arch_name="$(detect_arch)"
 
 installed="false"
 
-if [ "$version" != "latest" ] || [ -n "${UNCH_INSTALL_ASSET_DIR:-}" ]; then
-  if install_release_archive "$version" "$os_name" "$arch_name"; then
-    installed="true"
-  else
-    archive_status=$?
-    if [ "$archive_status" -eq 2 ]; then
-      say "Release archive install failed verification or extraction; refusing to continue."
-      exit 1
-    fi
+if install_release_archive "$version" "$os_name" "$arch_name"; then
+  installed="true"
+else
+  archive_status=$?
+  if [ "$archive_status" -eq 2 ]; then
+    say "Release archive install failed verification or extraction; refusing to continue."
+    exit 1
   fi
 fi
 

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -24,17 +24,17 @@ function Normalize-Version {
     return "v$RequestedVersion"
 }
 
-function Resolve-LatestVersion {
-    try {
-        $response = Invoke-WebRequest -Method Head -MaximumRedirection 0 -Uri "https://github.com/$Repo/releases/latest" -ErrorAction Stop
-        return "latest"
-    } catch {
-        $location = $_.Exception.Response.Headers.Location
-        if ($location) {
-            return [System.IO.Path]::GetFileName($location.ToString())
-        }
-        return "latest"
+function Get-ReleaseDownloadUrl {
+    param(
+        [string]$ResolvedVersion,
+        [string]$FileName
+    )
+
+    if ($ResolvedVersion -eq "latest") {
+        return "https://github.com/$Repo/releases/latest/download/$FileName"
     }
+
+    return "https://github.com/$Repo/releases/download/$ResolvedVersion/$FileName"
 }
 
 function Resolve-AssetArchive {
@@ -53,7 +53,7 @@ function Resolve-AssetArchive {
         }
     }
 
-    $url = "https://github.com/$Repo/releases/download/$ResolvedVersion/$AssetName"
+    $url = Get-ReleaseDownloadUrl -ResolvedVersion $ResolvedVersion -FileName $AssetName
     Write-Note "Downloading $url"
     try {
         Invoke-WebRequest -Uri $url -OutFile $DestinationPath
@@ -78,7 +78,7 @@ function Resolve-ChecksumsFile {
         throw "Missing checksums.txt in $assetDir"
     }
 
-    $url = "https://github.com/$Repo/releases/download/$ResolvedVersion/checksums.txt"
+    $url = Get-ReleaseDownloadUrl -ResolvedVersion $ResolvedVersion -FileName "checksums.txt"
     Write-Note "Downloading $url"
     Invoke-WebRequest -Uri $url -OutFile $DestinationPath
     return $DestinationPath
@@ -191,18 +191,13 @@ function Install-WithGo {
 }
 
 $resolvedVersion = Normalize-Version $Version
-if ($resolvedVersion -eq "latest") {
-    $resolvedVersion = Resolve-LatestVersion
-}
 
 $installed = $false
 
-if ($resolvedVersion -ne "latest" -or -not [string]::IsNullOrWhiteSpace($env:UNCH_INSTALL_ASSET_DIR)) {
-    $archiveInstall = Install-ReleaseArchive -ResolvedVersion $resolvedVersion -Destination $BinDir
-    $installed = $archiveInstall.Success
-    if (-not $installed -and $archiveInstall.Fatal) {
-        throw "Release archive install failed verification or extraction; refusing to continue."
-    }
+$archiveInstall = Install-ReleaseArchive -ResolvedVersion $resolvedVersion -Destination $BinDir
+$installed = $archiveInstall.Success
+if (-not $installed -and $archiveInstall.Fatal) {
+    throw "Release archive install failed verification or extraction; refusing to continue."
 }
 
 if (-not $installed) {


### PR DESCRIPTION
What changed
- keep both installers on the published release-asset path when the user asks for the latest version
- stop resolving `latest` into a version tag before attempting the archive download
- use `releases/latest/download/...` directly for the archive and `checksums.txt`

Root cause
- the installers treated `latest` as a special unresolved value
- that made the release-archive branch conditional in a way that could skip the archive path and fall through to `go install`
- on a normal end-user machine that looked like the installer was unexpectedly building the project from source

Validation
- `sh -n install.sh`
- `git diff --check origin/main..HEAD`
- local shell installer smoke with `UNCH_INSTALL_ASSET_DIR=... ./install.sh -b ...` and no explicit `-v`, followed by `unch --help`

Notes
- `install.ps1` was updated symmetrically, but I could not run a local PowerShell smoke in this environment because `pwsh` is not installed here
- the old `fix/verify-install-downloads` branch was force-reset to `origin/main` so the docs-only follow-up commits are no longer on that branch
