### PR TITLE
docs: sync install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/uchebnick/unch/gh-pages/coverage/coverage-badge.json)](https://github.com/uchebnick/unch/actions/workflows/ci.yml)
 [![Go 1.25+](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white)](https://github.com/uchebnick/unch)
 [![Docs](https://img.shields.io/badge/Docs-unch.mintlify.app-0F172A)](https://unch.mintlify.app/)
-[![Telegram News](https://img.shields.io/badge/Telegram-News-26A5E4?logo=telegram&logoColor=white)](https://t.me/unchnews)
 [![Telegram Chat](https://img.shields.io/badge/Telegram-Chat-26A5E4?logo=telegram&logoColor=white)](https://t.me/unchchat)
 
 **Semantic code search for code symbols and docs.**
@@ -53,13 +52,16 @@ PowerShell installer on Windows:
 iwr https://raw.githubusercontent.com/uchebnick/unch/main/install/install.ps1 -useb | iex
 ```
 
+This makes `unch` available immediately in the current PowerShell session.
+To keep it available in future PowerShell or terminal sessions, add `$HOME\AppData\Local\Programs\unch\bin` to your user `PATH`.
+
 Source install:
 
 ```bash
 go install github.com/uchebnick/unch/cmd/unch@latest
 ```
 
-This install path requires a cgo-capable Go toolchain. It is smoke-tested in CI in the official Debian-based Go container image. If `@latest` still resolves to the older pre-rename release line, use a release archive or build from the current checkout until the next tagged release is published.
+This install path requires a cgo-capable Go toolchain. It is smoke-tested in CI in the official Debian-based Go container image. To pin a specific release, use `@<tag>`.
 
 If you want to build from the current checkout:
 

--- a/mintlify/installation.mdx
+++ b/mintlify/installation.mdx
@@ -58,7 +58,7 @@ On Windows source builds, that means an MSYS2 or MinGW-style toolchain, or an eq
 
     ```bash
     curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sudo sh -s -- -b /usr/local/bin
-    curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sudo sh -s -- -b /usr/local/bin -v v0.3.6
+    curl -fsSL https://raw.githubusercontent.com/uchebnick/unch/main/install.sh | sudo sh -s -- -b /usr/local/bin -v <tag>
     ```
 
     `install.sh` verifies downloaded release archives against the published `checksums.txt` file. It is smoke-tested in CI on Ubuntu, Debian, Arch, and NixOS-like Linux environments, including the default no-`-b` path selection flow.
@@ -78,8 +78,11 @@ On Windows source builds, that means an MSYS2 or MinGW-style toolchain, or an eq
     After downloading the script locally, you can override the target or pin a version:
 
     ```powershell
-    .\install\install.ps1 -BinDir "C:\Tools\unch\bin" -Version v0.3.6
+    .\install\install.ps1 -BinDir "C:\Tools\unch\bin" -Version <tag>
     ```
+
+    `unch` is available immediately in the current PowerShell session after the installer finishes.
+    To keep it available in future PowerShell or terminal sessions, add `$HOME\AppData\Local\Programs\unch\bin` to your user `PATH`.
 
     The PowerShell installer is smoke-tested in CI on Windows `x86_64` and `arm64`.
   </Tab>
@@ -89,7 +92,7 @@ On Windows source builds, that means an MSYS2 or MinGW-style toolchain, or an eq
     go install github.com/uchebnick/unch/cmd/unch@latest
     ```
 
-    This install path requires a cgo-capable Go toolchain. It is smoke-tested in CI in the official Debian-based Go container image.
+    This install path requires a cgo-capable Go toolchain. It is smoke-tested in CI in the official Debian-based Go container image. To pin a specific release, use `@<tag>`.
 
     Older references to `github.com/uchebnick/unch-searcher` should be treated as legacy.
   </Tab>


### PR DESCRIPTION
What changed
- clarified that the Windows PowerShell installer makes `unch` available immediately only in the current PowerShell session
- documented the follow-up PATH step for future PowerShell or terminal sessions
- replaced hard-coded version examples with `<tag>` placeholders in Mintlify install examples
- simplified the `go install` note to describe release pinning with `@<tag>`
- removed the Telegram News badge from the README hero

Why
- the install docs had started to drift from the actual installer behavior
- hard-coded old version examples age quickly and make the docs look stale
- the Windows PATH behavior is easy to miss without an explicit note

Impact
- install docs are now more accurate for current users
- version-pinning examples should stay valid across releases

Validation
- `git diff --check`
