### PR TITLE
feat: add cli version output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,7 @@ jobs:
           set -euo pipefail
           bin_dir="${RUNNER_TEMP}/unch-bin"
           ./install.sh -b "${bin_dir}" -v vci-test
+          "${bin_dir}/unch" --version >/dev/null
           "${bin_dir}/unch" --help >/dev/null
 
       - name: Reject local asset with wrong shell checksum
@@ -419,6 +420,7 @@ jobs:
           rm -f "${bin_dir}/unch"
           ./install.sh -v vci-test
           command -v unch >/dev/null
+          unch --version >/dev/null
           unch --help >/dev/null
 
       - name: Install from local asset with PowerShell installer
@@ -429,6 +431,7 @@ jobs:
         run: |
           $binDir = Join-Path $env:RUNNER_TEMP "unch-bin"
           .\install\install.ps1 -BinDir $binDir -Version vci-test
+          & (Join-Path $binDir "unch.exe") --version | Out-Null
           & (Join-Path $binDir "unch.exe") --help | Out-Null
 
       - name: Reject local asset with wrong PowerShell checksum
@@ -510,6 +513,7 @@ jobs:
               '"${{ matrix.prepare }}"'
               export UNCH_INSTALL_ASSET_DIR=/assets
               ./install.sh -b /tmp/bin -v vci-test
+              /tmp/bin/unch --version >/dev/null
               /tmp/bin/unch --help >/dev/null
             '
 
@@ -530,6 +534,7 @@ jobs:
               rm -f "$HOME/.unch-install-bin-smoke/unch"
               ./install.sh -v vci-test
               command -v unch >/dev/null
+              unch --version >/dev/null
               unch --help >/dev/null
             '
 
@@ -572,6 +577,7 @@ jobs:
                   set -eu
                   export UNCH_INSTALL_ASSET_DIR=/assets
                   ./install.sh -b /tmp/bin -v vci-test
+                  /tmp/bin/unch --version >/dev/null
                   /tmp/bin/unch --help >/dev/null
                 "
             '
@@ -595,6 +601,7 @@ jobs:
               set -eu
               go install -buildvcs=false ./cmd/unch
               command -v unch
+              unch --version >/dev/null
               unch --help >/dev/null
             '
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,13 +81,16 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CC: ${{ matrix.cc || '' }}
+          BUILD_VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           mkdir -p dist/build
           if [ -n "${CC}" ]; then
             export CC
           fi
-          CGO_ENABLED=1 go build -trimpath -o dist/build/unch ./cmd/unch
+          CGO_ENABLED=1 go build -trimpath \
+            -ldflags "-X github.com/uchebnick/unch/internal/cli.buildVersion=${BUILD_VERSION}" \
+            -o dist/build/unch ./cmd/unch
           tar -C dist/build -czf "dist/${{ matrix.asset_name }}" unch
 
       - name: Build Windows archive
@@ -96,12 +99,15 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          BUILD_VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           mkdir -p dist/build
           export CGO_ENABLED=1
           export CC="${{ matrix.cc }}"
-          go build -trimpath -o dist/build/unch.exe ./cmd/unch
+          go build -trimpath \
+            -ldflags "-X github.com/uchebnick/unch/internal/cli.buildVersion=${BUILD_VERSION}" \
+            -o dist/build/unch.exe ./cmd/unch
 
       - name: Archive Windows asset
         if: runner.os == 'Windows'
@@ -137,6 +143,7 @@ jobs:
               export GOPROXY=direct
               go install -buildvcs=false "github.com/${GITHUB_REPOSITORY}/cmd/unch@${GITHUB_REF_NAME}"
               command -v unch
+              unch --version >/dev/null
               unch --help >/dev/null
             '
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ Published release archives:
 
 On those targets, the installers use published release archives by default, so Go is not required. `install.sh` and `install/install.ps1` only fall back to `go install` when no matching archive is available. `install.sh` is smoke-tested in CI on Ubuntu, Debian, Arch, and NixOS-like environments, including the default no-`-b` path selection flow; the PowerShell installer is smoke-tested on Windows `arm64` and `x86_64`.
 
+Verify the installed binary:
+
+```bash
+unch --version
+unch --help
+```
+
 See [Compatibility](docs/compatibility.md) for the support matrix and upgrade rules, and [Benchmarks](docs/benchmarks.md) for the checked-in `smoke`, `ci`, and `default` suites.
 
 Model selection accepts either a known model id or a direct `.gguf` path:

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -85,6 +85,7 @@ func printRootHelp(w io.Writer, program string) error {
 		"  bind    Bind the local manifest to a remote GitHub repo/workflow",
 		"  remote  Sync or download published search indexes",
 		"  help    Show root or command-specific help",
+		"  version Print the CLI version",
 	}
 	for _, line := range commands {
 		if _, err := fmt.Fprintln(w, line); err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -28,6 +28,9 @@ func Run(program string, args []string) (err error) {
 	if command == "help" {
 		return runHelp(program, commandArgs)
 	}
+	if command == "version" {
+		return printVersion(os.Stdout)
+	}
 	if command == "init" {
 		return runInit(ctx, program, commandArgs, cwd)
 	}
@@ -61,6 +64,8 @@ func detectCommand(args []string) (string, []string, error) {
 	switch args[0] {
 	case "-h", "--help", "help":
 		return "help", args[1:], nil
+	case "-version", "--version", "version":
+		return "version", args[1:], nil
 	case "bind", "create", "init", "index", "remote", "search":
 		return args[0], args[1:], nil
 	default:

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -18,6 +18,8 @@ func TestDetectCommand(t *testing.T) {
 		{name: "index command", args: []string{"index", "--root", "."}, want: "index"},
 		{name: "remote command", args: []string{"remote", "sync"}, want: "remote"},
 		{name: "search command", args: []string{"search", "RunCLI"}, want: "search"},
+		{name: "version flag", args: []string{"--version"}, want: "version"},
+		{name: "version command", args: []string{"version"}, want: "version"},
 		{name: "index flags without command", args: []string{"--root", "."}, want: "index"},
 		{name: "unknown command", args: []string{"download", "."}, wantErr: true},
 	}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -235,6 +235,54 @@ func TestRunRootHelp(t *testing.T) {
 	}
 }
 
+func TestRunRootHelpIncludesVersionCommand(t *testing.T) {
+	output := captureStdout(t, func() {
+		if err := Run("unch", []string{"--help"}); err != nil {
+			t.Fatalf("Run(--help) error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "version Print the CLI version") {
+		t.Fatalf("Run(--help) output = %q, want version command", output)
+	}
+}
+
+func TestRunVersionFlag(t *testing.T) {
+	originalVersion := buildVersion
+	buildVersion = "v9.9.9-test"
+	t.Cleanup(func() {
+		buildVersion = originalVersion
+	})
+
+	output := captureStdout(t, func() {
+		if err := Run("unch", []string{"--version"}); err != nil {
+			t.Fatalf("Run(--version) error: %v", err)
+		}
+	})
+
+	if strings.TrimSpace(output) != "v9.9.9-test" {
+		t.Fatalf("Run(--version) output = %q, want %q", output, "v9.9.9-test\n")
+	}
+}
+
+func TestRunVersionCommand(t *testing.T) {
+	originalVersion := buildVersion
+	buildVersion = "v9.9.9-test"
+	t.Cleanup(func() {
+		buildVersion = originalVersion
+	})
+
+	output := captureStdout(t, func() {
+		if err := Run("unch", []string{"version"}); err != nil {
+			t.Fatalf("Run(version) error: %v", err)
+		}
+	})
+
+	if strings.TrimSpace(output) != "v9.9.9-test" {
+		t.Fatalf("Run(version) output = %q, want %q", output, "v9.9.9-test\n")
+	}
+}
+
 func TestRunSearchHelp(t *testing.T) {
 	output := captureStdout(t, func() {
 		if err := Run("unch", []string{"search", "--help"}); err != nil {

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"runtime/debug"
+	"strings"
+)
+
+var buildVersion string
+
+func printVersion(w io.Writer) error {
+	_, err := fmt.Fprintln(w, versionString())
+	return err
+}
+
+func versionString() string {
+	if version := strings.TrimSpace(buildVersion); version != "" {
+		return version
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+
+	if version := strings.TrimSpace(info.Main.Version); version != "" && version != "(devel)" {
+		return version
+	}
+
+	var revision string
+	var dirty bool
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = strings.TrimSpace(setting.Value)
+		case "vcs.modified":
+			dirty = setting.Value == "true"
+		}
+	}
+
+	if revision == "" {
+		return "dev"
+	}
+	if len(revision) > 12 {
+		revision = revision[:12]
+	}
+	if dirty {
+		return "devel+" + revision + "-dirty"
+	}
+	return "devel+" + revision
+}

--- a/mintlify/installation.mdx
+++ b/mintlify/installation.mdx
@@ -120,6 +120,7 @@ On Windows source builds, that means an MSYS2 or MinGW-style toolchain, or an eq
 ## Verify the install
 
 ```bash
+unch --version
 unch --help
 ```
 


### PR DESCRIPTION
What changed
- added root-level `--version` / `-version` support and a `version` subcommand
- added a central CLI version formatter with injected build-version support for release binaries
- updated README and Mintlify installation docs to mention `unch --version` as part of install verification
- extended CI and release smoke checks to run `unch --version`

Why
- users need a quick way to confirm which CLI build they are running
- release binaries should report the release tag instead of a generic development string
- install docs should include a lightweight verification command that maps to the actual shipped CLI behavior

Validation
- `go test ./internal/cli`
- `go test ./...`
- `go run ./cmd/unch --version`
- `go run ./cmd/unch version`
- `GOBIN=$(mktemp -d) go install -buildvcs=false ./cmd/unch && unch --version`
- release-like build with `-ldflags '-X github.com/uchebnick/unch/internal/cli.buildVersion=v0.3.999-test'`
- `git diff --check`
