### PR TITLE
docs: add v0.3.9 release notes

### DIFF
--- a/.github/releases/v0.3.9.md
+++ b/.github/releases/v0.3.9.md
@@ -1,0 +1,22 @@
+# unch v0.3.9
+
+`v0.3.9` is an install-reliability and CLI-polish release. It keeps the local-first indexing and search flow intact while making published installers safer, fixing the `latest` install path so it stays on release assets, adding a simple CLI version check, and simplifying the public embedding-model tuning surface.
+
+## Highlights
+
+- shell and PowerShell installers now verify downloaded release assets against the published `checksums.txt` file before unpacking
+- unversioned installer paths now prefer GitHub `releases/latest` assets instead of unexpectedly falling back to `go install`
+- install smoke coverage now exercises the installer flow on macOS, Windows, Ubuntu, Debian, Arch, and NixOS-like Linux environments
+- `unch --version`, `unch -version`, and `unch version` now report the CLI build version, and release binaries inject the release tag into that output
+- `index` and `search` no longer expose a separate `--batch-size` knob; `--ctx-size` remains the public override for model context sizing
+- model install metadata now lives in a dedicated internal catalog, reducing duplication between runtime model profiles and install-time model resolution
+- install docs now show the current macOS/Linux `sudo sh -s -- -b ...` flow, the Windows PATH note, and `unch --version` as a lightweight post-install verification step
+- benchmark docs and CI summary flow were tightened up so the checked-in suites are described as `unch` regression tracking rather than cross-tool comparisons
+
+## Upgrade notes
+
+- no index rebuild is required when upgrading from `v0.3.8`
+- no remote index workflow migration is required for repositories already using `unch-index.yml`
+- if you automated `unch index` or `unch search` with `--batch-size`, drop that flag and keep `--ctx-size` only when you need to override the model default
+- you can verify the installed CLI with `unch --version` and `unch --help`
+- if you install from source, use `go install github.com/uchebnick/unch/cmd/unch@v0.3.9`


### PR DESCRIPTION
What changed
- added `.github/releases/v0.3.9.md`
- summarized the merged changes since `v0.3.8`, including installer checksum verification, `latest` release-asset install behavior, CLI version reporting, doc sync, and the `--batch-size` removal

Why
- the next tagged release needs checked-in release notes before publishing
- the notes are based on the merged `v0.3.8..origin/main` diff so the final release body matches what actually landed

Impact
- the next `v0.3.9` tag can publish with a ready release body instead of the auto-generated fallback text

Validation
- compared `v0.3.8..origin/main`
- `git diff --check`
