### PR TITLE
fix: stabilize embedding index runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,11 +147,36 @@ jobs:
               unch --help >/dev/null
             '
 
+  index-tag-smoke:
+    name: index-tag-smoke
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: release-assets-linux-amd64
+          path: dist
+
+      - name: Build local search index from release binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/extract
+          tar -C dist/extract -xzf dist/unch_Linux_x86_64.tar.gz
+          dist/extract/unch --version >/dev/null
+          dist/extract/unch index --root . --state-dir "${RUNNER_TEMP}/unch-index-smoke"
+
   release:
     name: publish-release
     needs:
       - build
       - go-install-tag-smoke
+      - index-tag-smoke
     runs-on: ubuntu-latest
 
     steps:

--- a/internal/embed/llama/embedder.go
+++ b/internal/embed/llama/embedder.go
@@ -34,6 +34,7 @@ type Embedder struct {
 	dim         int
 	profile     embeddingBehavior
 	contextSize int
+	tokenLimit  int
 }
 
 var (
@@ -131,6 +132,13 @@ func New(cfg Config) (*Embedder, error) {
 		return nil, fmt.Errorf("init context from model: %w", err)
 	}
 
+	tokenLimit := effectiveTokenLimit(
+		cfg.ContextSize,
+		int(llama.NCtx(ctx)),
+		int(llama.NBatch(ctx)),
+		int(llama.NUBatch(ctx)),
+	)
+
 	return &Embedder{
 		model:       model,
 		ctx:         ctx,
@@ -138,6 +146,7 @@ func New(cfg Config) (*Embedder, error) {
 		dim:         int(llama.ModelNEmbd(model)),
 		profile:     profile,
 		contextSize: cfg.ContextSize,
+		tokenLimit:  tokenLimit,
 	}, nil
 }
 
@@ -197,9 +206,9 @@ func (e *Embedder) Embed(text string) ([]float32, error) {
 		return nil, nil // Return empty if text results in zero tokens
 	}
 
-	// Truncate tokens if they exceed ContextSize
-	if len(tokens) > e.contextSize {
-		tokens = tokens[:e.contextSize]
+	// Truncate tokens to the smallest safe bound reported by the runtime.
+	if len(tokens) > e.tokenLimit {
+		tokens = tokens[:e.tokenLimit]
 	}
 
 	// Clear memory before processing new tokens
@@ -208,14 +217,10 @@ func (e *Embedder) Embed(text string) ([]float32, error) {
 		_ = llama.MemoryClear(mem, true)
 	}
 
-	if len(tokens) > e.contextSize {
-		tokens = tokens[:e.contextSize]
-	}
-
 	batch := llama.BatchGetOne(tokens)
-	defer func() {
-		_ = llama.BatchFree(batch)
-	}()
+	// yzma's single-sequence batch is not safe to free here: on real indexing
+	// workloads that triggered invalid pointer / heap corruption crashes on both
+	// Linux and Windows ARM CI.
 
 	ret, err := llama.Decode(e.ctx, batch)
 	if err != nil {
@@ -251,6 +256,19 @@ func (e *Embedder) IndexedSymbolHash(path string, symbol indexing.IndexedSymbol)
 // EmbedIndexedSymbol builds a retrieval document for a symbol and returns its embedding vector.
 func (e *Embedder) EmbedIndexedSymbol(path string, symbol indexing.IndexedSymbol) ([]float32, error) {
 	return e.Embed(indexedSymbolDocument(e.profile, path, symbol))
+}
+
+func effectiveTokenLimit(requested int, limits ...int) int {
+	limit := requested
+	for _, candidate := range limits {
+		if candidate <= 0 {
+			continue
+		}
+		if limit <= 0 || candidate < limit {
+			limit = candidate
+		}
+	}
+	return limit
 }
 
 func hashComment(text string) string {

--- a/internal/embed/llama/embedder_test.go
+++ b/internal/embed/llama/embedder_test.go
@@ -163,3 +163,30 @@ func TestHashCommentIsStable(t *testing.T) {
 		t.Fatalf("expected different comments to have different hashes")
 	}
 }
+
+func TestEffectiveTokenLimitPrefersSmallestPositiveBound(t *testing.T) {
+	t.Parallel()
+
+	got := effectiveTokenLimit(2048, 2048, 1024, 1536)
+	if got != 1024 {
+		t.Fatalf("effectiveTokenLimit() = %d, want 1024", got)
+	}
+}
+
+func TestEffectiveTokenLimitIgnoresZeroRuntimeValues(t *testing.T) {
+	t.Parallel()
+
+	got := effectiveTokenLimit(2048, 0, -1, 2048)
+	if got != 2048 {
+		t.Fatalf("effectiveTokenLimit() = %d, want 2048", got)
+	}
+}
+
+func TestEffectiveTokenLimitFallsBackToRuntimeBound(t *testing.T) {
+	t.Parallel()
+
+	got := effectiveTokenLimit(0, 4096, 1024, 0)
+	if got != 1024 {
+		t.Fatalf("effectiveTokenLimit() = %d, want 1024", got)
+	}
+}


### PR DESCRIPTION
## What changed

This fixes the embedding runtime path that was still crashing during real `unch index` runs.

- keep single-sequence llama batches alive for the duration of decode instead of freeing them on the Go side
- cap embedding token input to the smallest positive runtime bound reported by `NCtx`, `NBatch`, and `NUbatch`
- add targeted tests for the runtime-derived token limit helper
- gate tagged releases on a real `unch index` smoke run from the built Linux release artifact

## Why

The last release line was still able to publish even when real indexing was broken.

There were two related problems:

- the embedding path could hit native runtime crashes during indexing
- the release workflow only checked the `go install` path, not an actual `unch index` run from a release binary

This change hardens the runtime path and makes release publication depend on a real indexing smoke test.

## Validation

- `go test ./...`
- `git diff --check`
- `go run ./cmd/unch index --root . --state-dir /tmp/unch-index-smoke-pr`
