### PR TITLE
docs: refresh v0.3.11 release notes

### DIFF
--- a/.github/releases/v0.3.11.md
+++ b/.github/releases/v0.3.11.md
@@ -1,11 +1,14 @@
 # unch v0.3.11
 
-`v0.3.11` is a hotfix release that addresses inference errors (`decode returned non-zero: 1`) preventing code indexing on wide-context repositories.
+`v0.3.11` is a hotfix release focused on stabilizing real-world code indexing.
 
 ## Highlights
 
-- Fixed a `llama.cpp` crash (KV cache overflow) by reliably clearing embedding evaluation state memory between files
-- Corrected invalid CGO runtime state that could leak while processing minified JavaScript files sequentially
+- Fixed a native embedding runtime crash during `unch index` by keeping single-sequence llama batches alive for the full decode path
+- Capped embedding token input to the smallest positive runtime bound reported by `NCtx`, `NBatch`, and `NUbatch`
+- Kept the earlier embedding-state cleanup fix that prevented `decode returned non-zero: 1` failures on wider indexing workloads
+- Added a tagged-release smoke gate that runs a real `unch index` from the built release binary before publishing
+- Refreshed MSYS2 keyring updates for Windows ARM CI so release validation stays healthy there
 
 ## Upgrade notes
 


### PR DESCRIPTION
## What changed

Refresh the draft `v0.3.11` notes so they describe the actual indexing hotfix that is about to ship.

## Why

The previous draft only covered the earlier memory-clear fix. It did not mention:

- the native runtime crash fix in the embedding decode path
- the runtime-aware token bound safeguard
- the new tagged-release indexing smoke gate
- the Windows ARM MSYS2 keyring refresh in CI

## Validation

- `git diff --check`
