### PR TITLE
feat: add openrouter embedding provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ unch index --model qwen3
 unch search --model qwen3 "create a new router"
 ```
 
+OpenRouter is also supported as an embedding provider:
+
+```bash
+unch auth openrouter --token sk-or-...
+unch index --provider openrouter --model openai/text-embedding-3-small
+unch search --provider openrouter --model openai/text-embedding-3-small "create a new router"
+```
+
+By default `unch auth openrouter` writes `~/.config/unch/tokens.json`, so you do not need to keep the token in your shell environment. Use `--local` if you want to store it in `.semsearch/tokens.json` for one repository.
+
 ## Quick Start
 
 ```bash
@@ -101,6 +111,15 @@ cd path/to/repo
 unch index --root .
 unch search "create a new router"
 unch search --details "get path variables from a request"
+```
+
+OpenRouter flow:
+
+```bash
+cd path/to/repo
+unch auth openrouter --token sk-or-...
+unch index --root . --provider openrouter --model openai/text-embedding-3-small
+unch search --provider openrouter --model openai/text-embedding-3-small "create a new router"
 ```
 
 Real output from indexing [`gorilla/mux`](https://github.com/gorilla/mux):
@@ -122,9 +141,9 @@ $ unch search --details "get path variables from a request"
    docs: Vars returns the route variables for the current request, if any.
 ```
 
-The first run may download the default embedding model, fetch local `yzma` runtime libraries, and create `./.semsearch/`.
+The first local `llama.cpp` run may download the default embedding model, fetch local `yzma` runtime libraries, and create `./.semsearch/`.
 
-Each model keeps its own active index snapshot. Rebuilding `qwen3` does not replace the active `embeddinggemma` snapshot until the new run finishes successfully.
+Each provider and model pair keeps its own active index snapshot. Rebuilding `openrouter/openai/text-embedding-3-small` does not replace the active `llama.cpp/embeddinggemma` snapshot until the new run finishes successfully.
 
 ## What It Supports Today
 
@@ -147,6 +166,7 @@ unch index --root .
 Useful flags:
 
 - `--exclude` to skip generated, vendor, or irrelevant paths
+- `--provider` to switch between local `llama.cpp` embeddings and remote `openrouter`
 - `--model` to use `embeddinggemma`, `qwen3`, or a custom `.gguf` path
 - `--ctx-size` to override the selected model context size; `0` uses the model default
 - `--lib` to use an existing `yzma` runtime directory
@@ -166,6 +186,7 @@ Useful flags:
 - `--mode` for `auto`, `semantic`, or `lexical`
 - `--limit` to control result count
 - `--max-distance` to narrow semantic matches
+- `--provider` to select the embedding provider that matches the indexed snapshot
 - `--model` to search with `embeddinggemma`, `qwen3`, or a custom `.gguf` path
 - `--ctx-size` to override the selected model context size; `0` uses the model default
 - `--state-dir` to search against a custom `.semsearch` directory

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ unch index --provider openrouter --model openai/text-embedding-3-small
 unch search --provider openrouter --model openai/text-embedding-3-small "create a new router"
 ```
 
-By default `unch auth openrouter` writes `tokens.json` into the global `unch` state directory, so you do not need to keep the token in your shell environment. Use `--local` if you want to store it in `.semsearch/tokens.json` for one repository.
+By default `unch auth openrouter` writes `~/.config/unch/tokens.json`, so you do not need to keep the token in your shell environment. Use `--local` if you want to store it in `.semsearch/tokens.json` for one repository.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ unch index --provider openrouter --model openai/text-embedding-3-small
 unch search --provider openrouter --model openai/text-embedding-3-small "create a new router"
 ```
 
-By default `unch auth openrouter` writes `~/.config/unch/tokens.json`, so you do not need to keep the token in your shell environment. Use `--local` if you want to store it in `.semsearch/tokens.json` for one repository.
+By default `unch auth openrouter` writes `tokens.json` into the global `unch` state directory, so you do not need to keep the token in your shell environment. Use `--local` if you want to store it in `.semsearch/tokens.json` for one repository.
 
 ## Quick Start
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -28,7 +28,7 @@ This document describes the current compatibility contract for `unch`.
 
 - `index.db` is a rebuildable cache artifact, not a durable user database.
 - Compatibility is determined by the schema and query expectations of the running `unch` binary.
-- Active index state is model-scoped: each embedding model family keeps its own active snapshot.
+- Active index state is provider-scoped and model-scoped: each provider and embedding model pair keeps its own active snapshot.
 - When the current binary cannot use a database layout, the correct fix is to rebuild the index, not to migrate user data in place.
 - Local upgrades may therefore require `unch index` after releases that change indexing or storage behavior.
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -55,7 +55,7 @@ func runAuthOpenRouter(program string, args []string) error {
 					"OPENROUTER_API_KEY=sk-or-... " + cliName(program) + " auth openrouter",
 				},
 				[]string{
-					"By default this writes ~/.config/unch/tokens.json and keeps project state untouched.",
+					"By default this writes the token into the global unch state directory and keeps project state untouched.",
 					"Use --local to write .semsearch/tokens.json for one repository workspace.",
 					"OPENROUTER_API_KEY still overrides saved values at runtime when it is set.",
 				},

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/uchebnick/unch/internal/semsearch"
+)
+
+func runAuth(ctx context.Context, program string, args []string, cwd string) error {
+	_ = ctx
+	_ = cwd
+
+	if len(args) == 0 {
+		return fmt.Errorf("auth requires a target, for example: openrouter")
+	}
+	if isHelpArg(args[0]) {
+		return printAuthHelp(os.Stdout, cliName(program))
+	}
+
+	switch args[0] {
+	case "openrouter":
+		return runAuthOpenRouter(program, args[1:])
+	default:
+		return fmt.Errorf("unknown auth target %q", args[0])
+	}
+}
+
+func runAuthOpenRouter(program string, args []string) error {
+	fs := flag.NewFlagSet(program+" auth openrouter", flag.ContinueOnError)
+	fs.SetOutput(nil)
+	fs.Usage = func() {}
+
+	token := fs.String("token", "", "OpenRouter API key to store")
+	local := fs.Bool("local", false, "store the token in .semsearch/tokens.json instead of the global unch config")
+	root := fs.String("root", ".", "repository root used with --local")
+	stateDir := fs.String("state-dir", "", "path to .semsearch directory used with --local; defaults to <root>/.semsearch")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return printFlagSetHelp(
+				os.Stdout,
+				fs,
+				cliName(program)+" auth openrouter [flags]",
+				"Save an OpenRouter API key for future unch commands.",
+				[]string{
+					cliName(program) + " auth openrouter --token sk-or-...",
+					cliName(program) + " auth openrouter --token sk-or-... --local",
+					"OPENROUTER_API_KEY=sk-or-... " + cliName(program) + " auth openrouter",
+				},
+				[]string{
+					"By default this writes ~/.config/unch/tokens.json and keeps project state untouched.",
+					"Use --local to write .semsearch/tokens.json for one repository workspace.",
+					"OPENROUTER_API_KEY still overrides saved values at runtime when it is set.",
+				},
+			)
+		}
+		return err
+	}
+	if len(fs.Args()) > 0 {
+		return fmt.Errorf("unexpected positional arguments for auth openrouter: %s", strings.Join(fs.Args(), " "))
+	}
+
+	tokenValue := strings.TrimSpace(*token)
+	if tokenValue == "" {
+		tokenValue = strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY"))
+	}
+	if tokenValue == "" {
+		return fmt.Errorf("missing token: pass --token or set OPENROUTER_API_KEY")
+	}
+
+	var targetPath string
+	if *local {
+		rootAbs, err := filepath.Abs(*root)
+		if err != nil {
+			return fmt.Errorf("resolve root: %w", err)
+		}
+		localDir := filepath.Join(rootAbs, ".semsearch")
+		if trimmed := strings.TrimSpace(*stateDir); trimmed != "" {
+			localDir, err = filepath.Abs(trimmed)
+			if err != nil {
+				return fmt.Errorf("resolve state dir: %w", err)
+			}
+		}
+		if err := os.MkdirAll(localDir, 0o755); err != nil {
+			return fmt.Errorf("create local state dir: %w", err)
+		}
+		targetPath = semsearch.LocalTokensPath(localDir)
+	} else {
+		globalPath, err := semsearch.GlobalTokensPath()
+		if err != nil {
+			return err
+		}
+		targetPath = globalPath
+	}
+
+	if err := semsearch.SaveProviderToken(targetPath, "openrouter", tokenValue); err != nil {
+		return err
+	}
+
+	scope := "global"
+	if *local {
+		scope = "local"
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "Saved %s OpenRouter token to %s\n", scope, targetPath)
+	return nil
+}
+
+func printAuthHelp(w io.Writer, program string) error {
+	_, err := fmt.Fprintf(
+		w,
+		"Usage:\n  %s auth openrouter [flags]\n\nTargets:\n  openrouter  Save an OpenRouter API key in global or local tokens.json\n\nUse `%s auth openrouter --help` for flags.\n",
+		program,
+		program,
+	)
+	return err
+}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -55,7 +55,7 @@ func runAuthOpenRouter(program string, args []string) error {
 					"OPENROUTER_API_KEY=sk-or-... " + cliName(program) + " auth openrouter",
 				},
 				[]string{
-					"By default this writes the token into the global unch state directory and keeps project state untouched.",
+					"By default this writes ~/.config/unch/tokens.json and keeps project state untouched.",
 					"Use --local to write .semsearch/tokens.json for one repository workspace.",
 					"OPENROUTER_API_KEY still overrides saved values at runtime when it is set.",
 				},

--- a/internal/cli/embedding.go
+++ b/internal/cli/embedding.go
@@ -55,12 +55,7 @@ func prepareEmbedder(
 		apiKey, err := semsearch.ResolveProviderToken(targetPaths.LocalDir, provider.String())
 		if err != nil {
 			if s != nil {
-				envName := strings.TrimSpace(providerTokenEnvName(provider.String()))
-				if envName == "" {
-					printSessionLine(s, "Warning: token for provider %q is not configured. Run `unch auth %s --token <token>`.", provider, provider)
-				} else {
-					printSessionLine(s, "Warning: token for provider %q is not configured. Run `unch auth %s --token <token>` or set %s.", provider, provider, envName)
-				}
+				printMissingProviderCredentialsWarning(provider)
 			}
 			return preparedEmbedder{}, fmt.Errorf("resolve openrouter token: %w", err)
 		}
@@ -151,4 +146,24 @@ func providerTokenEnvName(provider string) string {
 	default:
 		return ""
 	}
+}
+
+func preflightProviderConfig(provider appembed.Provider, localDir string) error {
+	switch provider {
+	case appembed.ProviderOpenRouter:
+		_, err := semsearch.ResolveProviderToken(localDir, provider.String())
+		if err != nil {
+			return fmt.Errorf("resolve %s token: %w", provider, err)
+		}
+	}
+	return nil
+}
+
+func printMissingProviderCredentialsWarning(provider appembed.Provider) {
+	envName := strings.TrimSpace(providerTokenEnvName(provider.String()))
+	if envName == "" {
+		printSessionLine(nil, "Warning: credentials for provider %q are not configured.", provider)
+		return
+	}
+	printSessionLine(nil, "Warning: credentials for provider %q are not configured. Save a token for this provider or set %s.", provider, envName)
 }

--- a/internal/cli/embedding.go
+++ b/internal/cli/embedding.go
@@ -55,7 +55,12 @@ func prepareEmbedder(
 		apiKey, err := semsearch.ResolveProviderToken(targetPaths.LocalDir, provider.String())
 		if err != nil {
 			if s != nil {
-				printSessionLine(s, "Warning: OpenRouter token is not configured. Run `unch auth openrouter --token <token>` or set OPENROUTER_API_KEY.")
+				envName := strings.TrimSpace(providerTokenEnvName(provider.String()))
+				if envName == "" {
+					printSessionLine(s, "Warning: token for provider %q is not configured. Run `unch auth %s --token <token>`.", provider, provider)
+				} else {
+					printSessionLine(s, "Warning: token for provider %q is not configured. Run `unch auth %s --token <token>` or set %s.", provider, provider, envName)
+				}
 			}
 			return preparedEmbedder{}, fmt.Errorf("resolve openrouter token: %w", err)
 		}
@@ -136,5 +141,14 @@ func prepareEmbedder(
 		}, nil
 	default:
 		return preparedEmbedder{}, fmt.Errorf("unsupported embedding provider %q", provider)
+	}
+}
+
+func providerTokenEnvName(provider string) string {
+	switch strings.TrimSpace(strings.ToLower(provider)) {
+	case "openrouter":
+		return "OPENROUTER_API_KEY"
+	default:
+		return ""
 	}
 }

--- a/internal/cli/embedding.go
+++ b/internal/cli/embedding.go
@@ -54,7 +54,10 @@ func prepareEmbedder(
 		}
 		apiKey, err := semsearch.ResolveProviderToken(targetPaths.LocalDir, provider.String())
 		if err != nil {
-			return preparedEmbedder{}, err
+			if s != nil {
+				printSessionLine(s, "Warning: OpenRouter token is not configured. Run `unch auth openrouter --token <token>` or set OPENROUTER_API_KEY.")
+			}
+			return preparedEmbedder{}, fmt.Errorf("resolve openrouter token: %w", err)
 		}
 
 		embedder, err := loadEmbedderWithSpinner(ctx, s, func() (appembed.Embedder, error) {

--- a/internal/cli/embedding.go
+++ b/internal/cli/embedding.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	appembed "github.com/uchebnick/unch/internal/embed"
+	llamaembed "github.com/uchebnick/unch/internal/embed/llama"
+	openrouterembed "github.com/uchebnick/unch/internal/embed/openrouter"
+	"github.com/uchebnick/unch/internal/runtime"
+	"github.com/uchebnick/unch/internal/semsearch"
+	"github.com/uchebnick/unch/internal/termui"
+)
+
+type preparedEmbedder struct {
+	Embedder      appembed.Embedder
+	Provider      appembed.Provider
+	ModelID       string
+	ResolvedModel string
+	ResolvedLib   string
+	ContextSize   int
+}
+
+func prepareEmbedder(
+	ctx context.Context,
+	s *termui.Session,
+	targetPaths semsearch.Paths,
+	requestedProvider string,
+	requestedModel string,
+	requestedLib string,
+	contextSize int,
+	verbose bool,
+	runtimes runtime.YzmaResolver,
+	models runtime.ModelCache,
+) (preparedEmbedder, error) {
+	provider, err := appembed.ParseProvider(requestedProvider)
+	if err != nil {
+		return preparedEmbedder{}, err
+	}
+
+	switch provider {
+	case appembed.ProviderOpenRouter:
+		if strings.TrimSpace(requestedLib) != "" {
+			return preparedEmbedder{}, fmt.Errorf("--lib is only supported with provider llama.cpp")
+		}
+		modelID := strings.TrimSpace(requestedModel)
+		if modelID == "" {
+			modelID = strings.TrimSpace(os.Getenv("OPENROUTER_MODEL"))
+		}
+		if modelID == "" {
+			return preparedEmbedder{}, fmt.Errorf("provider openrouter requires --model or OPENROUTER_MODEL")
+		}
+		apiKey, err := semsearch.ResolveProviderToken(targetPaths.LocalDir, provider.String())
+		if err != nil {
+			return preparedEmbedder{}, err
+		}
+
+		embedder, err := loadEmbedderWithSpinner(ctx, s, func() (appembed.Embedder, error) {
+			return openrouterembed.New(ctx, openrouterembed.Config{
+				ModelID:     modelID,
+				APIKey:      apiKey,
+				BaseURL:     strings.TrimSpace(os.Getenv("OPENROUTER_BASE_URL")),
+				HTTPReferer: strings.TrimSpace(os.Getenv("OPENROUTER_HTTP_REFERER")),
+				AppTitle:    strings.TrimSpace(os.Getenv("OPENROUTER_APP_TITLE")),
+				Formatter:   appembed.FormatterForModel(modelID),
+			})
+		})
+		if err != nil {
+			return preparedEmbedder{}, err
+		}
+
+		return preparedEmbedder{
+			Embedder:      embedder,
+			Provider:      provider,
+			ModelID:       modelID,
+			ResolvedModel: modelID,
+		}, nil
+	case appembed.ProviderLlamaCPP:
+		defaultModelPath := runtime.DefaultModelPath(targetPaths.ModelsDir)
+		requestedModelPath := strings.TrimSpace(requestedModel)
+		if requestedModelPath == "" {
+			requestedModelPath = defaultModelPath
+		}
+
+		resolvedLibPath, libNote, err := runtimes.ResolveOrInstallYzmaLibPath(ctx, strings.TrimSpace(requestedLib), targetPaths.LocalDir, s)
+		if err != nil {
+			return preparedEmbedder{}, err
+		}
+		if libNote != "" && s != nil {
+			s.Logf("%s", libNote)
+		}
+
+		resolvedModelPath, modelNote, err := models.ResolveOrInstallModelPath(ctx, requestedModelPath, defaultModelPath, true, s)
+		if err != nil {
+			return preparedEmbedder{}, err
+		}
+		if modelNote != "" && s != nil {
+			s.Logf("%s", modelNote)
+		}
+
+		modelID, err := runtime.CanonicalModelID(requestedModelPath, defaultModelPath)
+		if err != nil {
+			return preparedEmbedder{}, fmt.Errorf("resolve model id: %w", err)
+		}
+
+		resolvedContextSize := contextSize
+		if resolvedContextSize <= 0 {
+			resolvedContextSize = defaultContextSize(resolvedModelPath)
+		}
+
+		embedder, err := loadEmbedderWithSpinner(ctx, s, func() (appembed.Embedder, error) {
+			return llamaembed.New(llamaembed.Config{
+				ModelPath:   resolvedModelPath,
+				LibPath:     resolvedLibPath,
+				ContextSize: resolvedContextSize,
+				Verbose:     verbose,
+				Pooling:     defaultPooling(resolvedModelPath),
+			})
+		})
+		if err != nil {
+			return preparedEmbedder{}, err
+		}
+
+		return preparedEmbedder{
+			Embedder:      embedder,
+			Provider:      provider,
+			ModelID:       modelID,
+			ResolvedModel: resolvedModelPath,
+			ResolvedLib:   resolvedLibPath,
+			ContextSize:   resolvedContextSize,
+		}, nil
+	default:
+		return preparedEmbedder{}, fmt.Errorf("unsupported embedding provider %q", provider)
+	}
+}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -28,6 +28,11 @@ func runHelp(program string, args []string) error {
 	}
 
 	switch args[0] {
+	case "auth":
+		if len(args) > 1 && args[1] == "openrouter" {
+			return runAuth(context.TODO(), name, []string{"openrouter", "--help"}, ".")
+		}
+		return printAuthHelp(os.Stdout, name)
 	case "index":
 		return runIndex(context.TODO(), name, []string{"--help"}, ".", indexing.FileScanner{}, runtime.YzmaResolver{}, runtime.ModelCache{})
 	case "search":
@@ -39,6 +44,11 @@ func runHelp(program string, args []string) error {
 			return runCreate(context.TODO(), name, []string{"ci", "--help"}, ".")
 		}
 		return printCreateHelp(os.Stdout, name)
+	case "start":
+		if len(args) > 1 && args[1] == "mcp" {
+			return runStart(context.TODO(), name, []string{"mcp", "--help"}, ".")
+		}
+		return printStartHelp(os.Stdout, name)
 	case "bind":
 		if len(args) > 1 && args[1] == "ci" {
 			return runBind(context.TODO(), name, []string{"ci", "--help"}, ".")
@@ -78,12 +88,14 @@ func printRootHelp(w io.Writer, program string) error {
 		return err
 	}
 	commands := []string{
+		"  auth    Save provider credentials such as OpenRouter API key",
 		"  index   Build or refresh the local search index",
 		"  search  Query the current index",
 		"  init    Create .semsearch state in a repository",
 		"  create  Generate helper files such as GitHub Actions workflow",
 		"  bind    Bind the local manifest to a remote GitHub repo/workflow",
 		"  remote  Sync or download published search indexes",
+		"  start   Start long-running helpers such as MCP server",
 		"  help    Show root or command-specific help",
 		"  version Print the CLI version",
 	}
@@ -118,11 +130,13 @@ func printRootHelp(w io.Writer, program string) error {
 		return err
 	}
 	examples := []string{
+		fmt.Sprintf("  %s auth openrouter --token sk-or-...", program),
 		fmt.Sprintf("  %s index --root .", program),
 		fmt.Sprintf("  %s search \"sqlite schema\"", program),
 		fmt.Sprintf("  %s search --details \"get path variables from a request\"", program),
 		fmt.Sprintf("  %s index --model qwen3", program),
 		fmt.Sprintf("  %s index --model ~/.semsearch/models/Qwen3-Embedding-0.6B-Q8_0.gguf", program),
+		fmt.Sprintf("  %s start mcp", program),
 		fmt.Sprintf("  %s help search", program),
 	}
 	for _, line := range examples {

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hybridgroup/yzma/pkg/llama"
+	appembed "github.com/uchebnick/unch/internal/embed"
 	llamaembed "github.com/uchebnick/unch/internal/embed/llama"
 	appsearch "github.com/uchebnick/unch/internal/search"
 	"github.com/uchebnick/unch/internal/termui"
@@ -160,9 +161,9 @@ func isCharDevice(file *os.File) bool {
 	return info.Mode()&os.ModeCharDevice != 0
 }
 
-func loadEmbedderWithSpinner(ctx context.Context, s *termui.Session, cfg llamaembed.Config) (*llamaembed.Embedder, error) {
+func loadEmbedderWithSpinner(ctx context.Context, s *termui.Session, load func() (appembed.Embedder, error)) (appembed.Embedder, error) {
 	if s == nil || !s.Interactive() {
-		embedder, err := llamaembed.New(cfg)
+		embedder, err := load()
 		if err != nil {
 			if s != nil {
 				s.Clear()
@@ -194,7 +195,7 @@ func loadEmbedderWithSpinner(ctx context.Context, s *termui.Session, cfg llamaem
 		}
 	}()
 
-	embedder, err := llamaembed.New(cfg)
+	embedder, err := load()
 	close(done)
 
 	if err != nil {

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -7,9 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/uchebnick/unch/internal/embed/llama"
+	appembed "github.com/uchebnick/unch/internal/embed"
 	"github.com/uchebnick/unch/internal/filehashdb"
 	"github.com/uchebnick/unch/internal/indexdb"
 	"github.com/uchebnick/unch/internal/indexing"
@@ -31,6 +30,7 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 	stateDir := fs.String("state-dir", "", "path to .semsearch directory; defaults to <root>/.semsearch")
 	dbPath := fs.String("db", "", "deprecated: path to .semsearch/index.db, or to a .semsearch directory")
 	modelPath := fs.String("model", defaultModelPath, "path to GGUF embedding model, or a known model id such as embeddinggemma or qwen3")
+	provider := fs.String("provider", appembed.DefaultProvider().String(), "embedding provider: llama.cpp or openrouter")
 	libPath := fs.String("lib", "", "path to yzma library directory, or to one of its shared library files")
 	contextPrefix := fs.String("context-prefix", "@filectx:", "legacy file context prefix used only by fallback indexers")
 	commentPrefix := fs.String("comment-prefix", "@search:", "legacy comment prefix used only by fallback indexers")
@@ -50,10 +50,12 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 					cliName(program) + " index --root .",
 					cliName(program) + " index --exclude node_modules --exclude dist",
 					cliName(program) + " index --model qwen3",
+					cliName(program) + " index --provider openrouter --model openai/text-embedding-3-small",
 					cliName(program) + " index --model ~/.semsearch/models/Qwen3-Embedding-0.6B-Q8_0.gguf",
 				},
 				[]string{
 					"Omit --model to auto-download the default embeddinggemma GGUF model.",
+					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, ~/.config/unch/tokens.json, then .semsearch/tokens.json.",
 					"Known model ids today: embeddinggemma and qwen3.",
 					"Changing --model changes the embedding space; rebuild the index before searching with the new model.",
 					"--comment-prefix and --context-prefix are legacy fallback knobs for unsupported files or parser failures.",
@@ -120,16 +122,6 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 		}
 	}
 
-	resolvedDefaultModelPath := runtime.DefaultModelPath(targetPaths.ModelsDir)
-	requestedModelPath := strings.TrimSpace(*modelPath)
-	if requestedModelPath == "" {
-		requestedModelPath = resolvedDefaultModelPath
-	}
-
-	modelID, err := runtime.CanonicalModelID(requestedModelPath, resolvedDefaultModelPath)
-	if err != nil {
-		return fmt.Errorf("resolve model id: %w", err)
-	}
 	resolvedGitignore, err := indexing.ResolveGitignorePath(rootAbs, *gitignorePath)
 	if err != nil {
 		return fmt.Errorf("resolve gitignore: %w", err)
@@ -147,62 +139,51 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 
 	s.Logf("scanner_fingerprint=%s", scannerFingerprint)
 
+	prepared, err := prepareEmbedder(
+		ctx,
+		s,
+		targetPaths,
+		*provider,
+		*modelPath,
+		*libPath,
+		*contextSize,
+		*verbose,
+		runtimes,
+		models,
+	)
+	if err != nil {
+		return err
+	}
+	defer prepared.Embedder.Close()
+
 	var currentFileHashes map[string]string
-	if currentState, ok, err := hashStore.Current(ctx, modelID); err != nil {
+	if currentState, ok, err := hashStore.Current(ctx, prepared.Provider.String(), prepared.ModelID); err != nil {
 		return fmt.Errorf("read current file hash state: %w", err)
 	} else if ok && currentState.ScannerFingerprint == scannerFingerprint {
 		currentFileHashes = currentState.Files
 	}
 	s.Logf("current_file_hashes=%d", len(currentFileHashes))
 
-	fileHashStateVersion, err := hashStore.BeginState(ctx, modelID, scannerFingerprint)
+	fileHashStateVersion, err := hashStore.BeginState(ctx, prepared.Provider.String(), prepared.ModelID, scannerFingerprint)
 	if err != nil {
 		return fmt.Errorf("begin file hash state: %w", err)
 	}
 	s.Logf("staged_file_hash_state_version=%d", fileHashStateVersion)
 
-	resolvedLibPath, libNote, err := runtimes.ResolveOrInstallYzmaLibPath(ctx, *libPath, targetPaths.LocalDir, s)
-	if err != nil {
-		return err
-	}
-	if libNote != "" {
-		s.Logf("%s", libNote)
-	}
-
-	resolvedModelPath, modelNote, err := models.ResolveOrInstallModelPath(ctx, requestedModelPath, resolvedDefaultModelPath, true, s)
-	if err != nil {
-		return err
-	}
-	if modelNote != "" {
-		s.Logf("%s", modelNote)
-	}
-
-	resolvedContextSize := *contextSize
-	if resolvedContextSize <= 0 {
-		resolvedContextSize = defaultContextSize(resolvedModelPath)
-	}
-
 	s.Logf("state_dir=%s", targetPaths.LocalDir)
 	s.Logf("index_db=%s", resolvedIndexPath)
-	s.Logf("lib=%s", resolvedLibPath)
-	s.Logf("model=%s", resolvedModelPath)
-	s.Logf("model_id=%s", modelID)
-	s.Logf("ctx_size=%d", resolvedContextSize)
+	s.Logf("provider=%s", prepared.Provider)
+	if prepared.ResolvedLib != "" {
+		s.Logf("lib=%s", prepared.ResolvedLib)
+	}
+	s.Logf("model=%s", prepared.ResolvedModel)
+	s.Logf("model_id=%s", prepared.ModelID)
+	if prepared.ContextSize > 0 {
+		s.Logf("ctx_size=%d", prepared.ContextSize)
+	}
 	s.Logf("root=%s", rootAbs)
 
-	embedder, err := loadEmbedderWithSpinner(ctx, s, llamaembed.Config{
-		ModelPath:   resolvedModelPath,
-		LibPath:     resolvedLibPath,
-		ContextSize: resolvedContextSize,
-		Verbose:     *verbose,
-		Pooling:     defaultPooling(resolvedModelPath),
-	})
-	if err != nil {
-		return err
-	}
-	defer embedder.Close()
-
-	repo, err := indexdb.Open(ctx, resolvedIndexPath, embedder.Dim())
+	repo, err := indexdb.Open(ctx, resolvedIndexPath, prepared.Embedder.Dim())
 	if err != nil {
 		return err
 	}
@@ -213,7 +194,7 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 	service := indexing.Service{
 		Scanner:  scanner,
 		Repo:     repo,
-		Embedder: embedder,
+		Embedder: prepared.Embedder,
 		Hashes:   hashStore,
 	}
 
@@ -223,7 +204,8 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 		Excludes:             excludes,
 		ContextPrefix:        *contextPrefix,
 		CommentPrefix:        *commentPrefix,
-		ModelID:              modelID,
+		Provider:             prepared.Provider.String(),
+		ModelID:              prepared.ModelID,
 		CurrentFileHashes:    currentFileHashes,
 		FileHashStateVersion: fileHashStateVersion,
 	}, s)
@@ -237,7 +219,7 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 	}
 	s.Logf("manifest version=%d indexing_hash=%s", manifest.Version, manifest.IndexingHash)
 
-	if err := hashStore.ActivateState(ctx, modelID, fileHashStateVersion); err != nil {
+	if err := hashStore.ActivateState(ctx, prepared.Provider.String(), prepared.ModelID, fileHashStateVersion); err != nil {
 		return fmt.Errorf("activate file hash state: %w", err)
 	}
 	if err := hashStore.CleanupInactiveStates(ctx); err != nil {

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -55,7 +55,7 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 				},
 				[]string{
 					"Omit --model to auto-download the default embeddinggemma GGUF model.",
-					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, ~/.config/unch/tokens.json, then .semsearch/tokens.json.",
+					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, then the global unch tokens.json, then .semsearch/tokens.json.",
 					"Known model ids today: embeddinggemma and qwen3.",
 					"Changing --model changes the embedding space; rebuild the index before searching with the new model.",
 					"--comment-prefix and --context-prefix are legacy fallback knobs for unsupported files or parser failures.",

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -82,6 +82,17 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 		return fmt.Errorf("resolve root: %w", err)
 	}
 
+	previewPaths, _, _, err := previewStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
+	if err != nil {
+		return err
+	}
+	if parsedProvider, err := appembed.ParseProvider(*provider); err == nil && parsedProvider == appembed.ProviderOpenRouter {
+		if err := preflightProviderConfig(parsedProvider, previewPaths.LocalDir); err != nil {
+			printMissingProviderCredentialsWarning(parsedProvider)
+			return err
+		}
+	}
+
 	targetPaths, resolvedIndexPath, _, err := resolveStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
 	if err != nil {
 		return err

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -55,7 +55,7 @@ func runIndex(ctx context.Context, program string, args []string, cwd string, sc
 				},
 				[]string{
 					"Omit --model to auto-download the default embeddinggemma GGUF model.",
-					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, then the global unch tokens.json, then .semsearch/tokens.json.",
+					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, then ~/.config/unch/tokens.json, then .semsearch/tokens.json.",
 					"Known model ids today: embeddinggemma and qwen3.",
 					"Changing --model changes the embedding space; rebuild the index before searching with the new model.",
 					"--comment-prefix and --context-prefix are legacy fallback knobs for unsupported files or parser failures.",

--- a/internal/cli/mcp_backend.go
+++ b/internal/cli/mcp_backend.go
@@ -1,0 +1,364 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	appembed "github.com/uchebnick/unch/internal/embed"
+	"github.com/uchebnick/unch/internal/filehashdb"
+	"github.com/uchebnick/unch/internal/indexdb"
+	"github.com/uchebnick/unch/internal/indexing"
+	unchmcp "github.com/uchebnick/unch/internal/mcp"
+	"github.com/uchebnick/unch/internal/runtime"
+	appsearch "github.com/uchebnick/unch/internal/search"
+	"github.com/uchebnick/unch/internal/semsearch"
+)
+
+type mcpBackendConfig struct {
+	RootAbs           string
+	TargetPaths       semsearch.Paths
+	IndexPath         string
+	RequestedProvider string
+	RequestedModel    string
+	RequestedLibPath  string
+	ContextSize       int
+	Verbose           bool
+}
+
+type preparedMCPResources struct {
+	embedder          appembed.Embedder
+	repo              *indexdb.Store
+	provider          appembed.Provider
+	modelID           string
+	resolvedModel     string
+	resolvedLibPath   string
+	contextSize       int
+}
+
+type mcpBackend struct {
+	cfg      mcpBackendConfig
+	scanner  indexing.FileScanner
+	models   runtime.ModelCache
+	runtimes runtime.YzmaResolver
+
+	runMu sync.Mutex
+	mu    sync.Mutex
+
+	prepared *preparedMCPResources
+}
+
+func newMCPBackend(cfg mcpBackendConfig) *mcpBackend {
+	return &mcpBackend{cfg: cfg}
+}
+
+func (b *mcpBackend) Version() string {
+	return versionString()
+}
+
+func (b *mcpBackend) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var firstErr error
+	if b.prepared != nil {
+		if b.prepared.repo != nil {
+			if err := b.prepared.repo.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		if b.prepared.embedder != nil {
+			b.prepared.embedder.Close()
+		}
+	}
+	b.prepared = nil
+	return firstErr
+}
+
+func (b *mcpBackend) WorkspaceStatus(_ context.Context) (unchmcp.WorkspaceStatusResult, error) {
+	result := unchmcp.WorkspaceStatusResult{
+		Root:           b.cfg.RootAbs,
+		StateDir:       b.cfg.TargetPaths.LocalDir,
+		IndexDB:        b.cfg.IndexPath,
+		RequestedModel: b.cfg.RequestedModel,
+		RequestedLib:   b.cfg.RequestedLibPath,
+		RequestedProvider: b.cfg.RequestedProvider,
+		ContextSize:    b.cfg.ContextSize,
+	}
+
+	if info, err := os.Stat(b.cfg.IndexPath); err == nil && !info.IsDir() {
+		result.IndexPresent = true
+	}
+
+	if manifest, err := semsearch.ReadManifest(b.cfg.TargetPaths.LocalDir); err == nil {
+		result.ManifestVersion = manifest.Version
+		result.ManifestSource = manifest.Source
+		if manifest.Remote != nil {
+			result.RemoteCIURL = manifest.Remote.CIURL
+		}
+	}
+
+	b.mu.Lock()
+	if b.prepared != nil {
+		result.Provider = b.prepared.provider.String()
+		result.ModelID = b.prepared.modelID
+		result.ResolvedModel = b.prepared.resolvedModel
+		result.ResolvedLib = b.prepared.resolvedLibPath
+		if result.ContextSize <= 0 {
+			result.ContextSize = b.prepared.contextSize
+		}
+	}
+	b.mu.Unlock()
+
+	return result, nil
+}
+
+func (b *mcpBackend) SearchCode(ctx context.Context, params unchmcp.SearchCodeParams) (unchmcp.SearchCodeResult, error) {
+	b.runMu.Lock()
+	defer b.runMu.Unlock()
+
+	mode, err := appsearch.NormalizeMode(params.Mode)
+	if err != nil {
+		return unchmcp.SearchCodeResult{}, err
+	}
+	if params.Limit <= 0 {
+		params.Limit = 10
+	}
+
+	prepared, err := b.ensurePrepared(ctx)
+	if err != nil {
+		return unchmcp.SearchCodeResult{}, err
+	}
+
+	if _, err := semsearch.EnsureFileWeights(b.cfg.TargetPaths.LocalDir); err != nil {
+		return unchmcp.SearchCodeResult{}, err
+	}
+	fileWeights, err := semsearch.LoadFileWeights(b.cfg.TargetPaths.LocalDir)
+	if err != nil {
+		return unchmcp.SearchCodeResult{}, err
+	}
+
+	service := appsearch.Service{
+		Repo:         prepared.repo,
+		Embedder:     prepared.embedder,
+		PathWeighter: fileWeights,
+	}
+
+	maxDistance := 0.85
+	if params.MaxDistance != nil {
+		maxDistance = *params.MaxDistance
+	}
+
+	results, err := service.Run(ctx, appsearch.Params{
+		QueryText:   strings.TrimSpace(params.Query),
+		Limit:       params.Limit,
+		Mode:        mode,
+		MaxDistance: maxDistance,
+		Provider:    prepared.provider.String(),
+		ModelID:     prepared.modelID,
+	}, nil)
+	if err != nil {
+		return unchmcp.SearchCodeResult{}, err
+	}
+
+	hits := make([]unchmcp.SearchHit, 0, len(results))
+	for _, result := range results {
+		hit := unchmcp.SearchHit{
+			Path:          formatRelativeToRoot(b.cfg.RootAbs, result.Path),
+			Line:          result.Line,
+			Metric:        result.DisplayMetric,
+			Kind:          result.Kind,
+			Name:          result.Name,
+			QualifiedName: result.QualifiedName,
+			Signature:     result.Signature,
+			Distance:      result.Distance,
+		}
+		if params.Details {
+			hit.Documentation = result.Documentation
+			hit.Body = result.Body
+		}
+		hits = append(hits, hit)
+	}
+
+	return unchmcp.SearchCodeResult{
+		Query:       strings.TrimSpace(params.Query),
+		Mode:        mode,
+		Provider:    prepared.provider.String(),
+		ModelID:     prepared.modelID,
+		StateDir:    b.cfg.TargetPaths.LocalDir,
+		ResultCount: len(hits),
+		Hits:        hits,
+	}, nil
+}
+
+func (b *mcpBackend) IndexRepository(ctx context.Context, params unchmcp.IndexRepositoryParams) (unchmcp.IndexRepositoryResult, error) {
+	b.runMu.Lock()
+	defer b.runMu.Unlock()
+
+	prepared, err := b.ensurePrepared(ctx)
+	if err != nil {
+		return unchmcp.IndexRepositoryResult{}, err
+	}
+
+	if _, err := semsearch.EnsureFileWeights(b.cfg.TargetPaths.LocalDir); err != nil {
+		return unchmcp.IndexRepositoryResult{}, err
+	}
+
+	commentPrefix := strings.TrimSpace(params.CommentPrefix)
+	if commentPrefix == "" {
+		commentPrefix = "@search:"
+	}
+	contextPrefix := strings.TrimSpace(params.ContextPrefix)
+	if contextPrefix == "" {
+		contextPrefix = "@filectx:"
+	}
+
+	resolvedGitignore, err := indexing.ResolveGitignorePath(b.cfg.RootAbs, strings.TrimSpace(params.Gitignore))
+	if err != nil {
+		return unchmcp.IndexRepositoryResult{}, fmt.Errorf("resolve gitignore: %w", err)
+	}
+
+	hashStore, err := filehashdb.Open(ctx, b.cfg.TargetPaths.FileHashDB)
+	if err != nil {
+		return unchmcp.IndexRepositoryResult{}, fmt.Errorf("open file hash db: %w", err)
+	}
+	defer func() {
+		_ = hashStore.Close()
+	}()
+
+	scannerFingerprint := indexing.BuildScannerFingerprint(commentPrefix, contextPrefix, params.Excludes)
+
+	var currentFileHashes map[string]string
+	if currentState, ok, err := hashStore.Current(ctx, prepared.provider.String(), prepared.modelID); err != nil {
+		return unchmcp.IndexRepositoryResult{}, fmt.Errorf("read current file hash state: %w", err)
+	} else if ok && currentState.ScannerFingerprint == scannerFingerprint {
+		currentFileHashes = currentState.Files
+	}
+
+	fileHashStateVersion, err := hashStore.BeginState(ctx, prepared.provider.String(), prepared.modelID, scannerFingerprint)
+	if err != nil {
+		return unchmcp.IndexRepositoryResult{}, fmt.Errorf("begin file hash state: %w", err)
+	}
+
+	scanner := b.scanner
+	scanner.Root = b.cfg.RootAbs
+
+	service := indexing.Service{
+		Scanner:  scanner,
+		Repo:     prepared.repo,
+		Embedder: prepared.embedder,
+		Hashes:   hashStore,
+	}
+
+	manifest, manifestErr := semsearch.ReadManifest(b.cfg.TargetPaths.LocalDir)
+	detachedRemoteBinding := manifestErr == nil && semsearch.HasRemoteBinding(manifest)
+
+	result, err := service.Run(ctx, indexing.Params{
+		Root:                 b.cfg.RootAbs,
+		GitignorePath:        resolvedGitignore,
+		Excludes:             params.Excludes,
+		ContextPrefix:        contextPrefix,
+		CommentPrefix:        commentPrefix,
+		Provider:             prepared.provider.String(),
+		ModelID:              prepared.modelID,
+		CurrentFileHashes:    currentFileHashes,
+		FileHashStateVersion: fileHashStateVersion,
+	}, nil)
+	if err != nil {
+		return unchmcp.IndexRepositoryResult{}, err
+	}
+
+	nextManifest, err := semsearch.UpdateIndexManifest(b.cfg.TargetPaths.LocalDir, b.cfg.IndexPath, result.Version)
+	if err != nil {
+		return unchmcp.IndexRepositoryResult{}, fmt.Errorf("update manifest: %w", err)
+	}
+	if err := hashStore.ActivateState(ctx, prepared.provider.String(), prepared.modelID, fileHashStateVersion); err != nil {
+		return unchmcp.IndexRepositoryResult{}, fmt.Errorf("activate file hash state: %w", err)
+	}
+	if err := hashStore.CleanupInactiveStates(ctx); err != nil {
+		return unchmcp.IndexRepositoryResult{}, fmt.Errorf("cleanup inactive file hash states: %w", err)
+	}
+
+	return unchmcp.IndexRepositoryResult{
+		Provider:              prepared.provider.String(),
+		ModelID:               prepared.modelID,
+		StateDir:              b.cfg.TargetPaths.LocalDir,
+		Version:               nextManifest.Version,
+		IndexedFiles:          result.IndexedFiles,
+		IndexedSymbols:        result.IndexedSymbols,
+		DetachedRemoteBinding: detachedRemoteBinding,
+	}, nil
+}
+
+func (b *mcpBackend) ensurePrepared(ctx context.Context) (*preparedMCPResources, error) {
+	b.mu.Lock()
+	if b.prepared != nil {
+		prepared := b.prepared
+		b.mu.Unlock()
+		return prepared, nil
+	}
+	b.mu.Unlock()
+
+	preparedEmbedder, err := prepareEmbedder(
+		ctx,
+		nil,
+		b.cfg.TargetPaths,
+		b.cfg.RequestedProvider,
+		b.cfg.RequestedModel,
+		b.cfg.RequestedLibPath,
+		b.cfg.ContextSize,
+		b.cfg.Verbose,
+		b.runtimes,
+		b.models,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load embedder: %w", err)
+	}
+
+	repo, err := indexdb.Open(ctx, b.cfg.IndexPath, preparedEmbedder.Embedder.Dim())
+	if err != nil {
+		preparedEmbedder.Embedder.Close()
+		return nil, err
+	}
+
+	prepared := &preparedMCPResources{
+		embedder:          preparedEmbedder.Embedder,
+		repo:              repo,
+		provider:          preparedEmbedder.Provider,
+		modelID:           preparedEmbedder.ModelID,
+		resolvedModel:     preparedEmbedder.ResolvedModel,
+		resolvedLibPath:   preparedEmbedder.ResolvedLib,
+		contextSize:       preparedEmbedder.ContextSize,
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.prepared != nil {
+		_ = repo.Close()
+		preparedEmbedder.Embedder.Close()
+		return b.prepared, nil
+	}
+	b.prepared = prepared
+	return prepared, nil
+}
+
+func formatRelativeToRoot(root string, target string) string {
+	if !filepath.IsAbs(target) {
+		return filepath.ToSlash(filepath.Clean(target))
+	}
+
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return target
+	}
+	if rel == "." {
+		return rel
+	}
+	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return target
+	}
+	return filepath.ToSlash(rel)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -34,6 +34,9 @@ func Run(program string, args []string) (err error) {
 	if command == "init" {
 		return runInit(ctx, program, commandArgs, cwd)
 	}
+	if command == "auth" {
+		return runAuth(ctx, program, commandArgs, cwd)
+	}
 	if command == "bind" {
 		return runBind(ctx, program, commandArgs, cwd)
 	}
@@ -42,6 +45,9 @@ func Run(program string, args []string) (err error) {
 	}
 	if command == "remote" {
 		return runRemote(ctx, program, commandArgs, cwd)
+	}
+	if command == "start" {
+		return runStart(ctx, program, commandArgs, cwd)
 	}
 
 	scanner := indexing.FileScanner{}
@@ -66,7 +72,7 @@ func detectCommand(args []string) (string, []string, error) {
 		return "help", args[1:], nil
 	case "-version", "--version", "version":
 		return "version", args[1:], nil
-	case "bind", "create", "init", "index", "remote", "search":
+	case "auth", "bind", "create", "init", "index", "remote", "search", "start":
 		return args[0], args[1:], nil
 	default:
 		if len(args[0]) > 0 && args[0][0] == '-' {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -12,12 +12,14 @@ func TestDetectCommand(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "default index", args: nil, want: "index"},
+		{name: "auth command", args: []string{"auth", "openrouter"}, want: "auth"},
 		{name: "create command", args: []string{"create", "ci"}, want: "create"},
 		{name: "bind command", args: []string{"bind", "ci", "https://github.com/acme/widgets/actions/workflows/unch-index.yml"}, want: "bind"},
 		{name: "init command", args: []string{"init"}, want: "init"},
 		{name: "index command", args: []string{"index", "--root", "."}, want: "index"},
 		{name: "remote command", args: []string{"remote", "sync"}, want: "remote"},
 		{name: "search command", args: []string{"search", "RunCLI"}, want: "search"},
+		{name: "start command", args: []string{"start", "mcp"}, want: "start"},
 		{name: "version flag", args: []string{"--version"}, want: "version"},
 		{name: "version command", args: []string{"version"}, want: "version"},
 		{name: "index flags without command", args: []string{"--root", "."}, want: "index"},

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -160,8 +160,8 @@ func TestRunDispatchesInitCommand(t *testing.T) {
 }
 
 func TestRunDispatchesAuthCommand(t *testing.T) {
-	configHome := t.TempDir()
-	t.Setenv("UNCH_CONFIG_HOME", configHome)
+	semsearchHome := t.TempDir()
+	t.Setenv("SEMSEARCH_HOME", semsearchHome)
 
 	output := captureStdout(t, func() {
 		if err := Run("unch", []string{"auth", "openrouter", "--token", "sk-or-test"}); err != nil {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -160,8 +160,8 @@ func TestRunDispatchesInitCommand(t *testing.T) {
 }
 
 func TestRunDispatchesAuthCommand(t *testing.T) {
-	semsearchHome := t.TempDir()
-	t.Setenv("SEMSEARCH_HOME", semsearchHome)
+	configHome := t.TempDir()
+	t.Setenv("UNCH_CONFIG_HOME", configHome)
 
 	output := captureStdout(t, func() {
 		if err := Run("unch", []string{"auth", "openrouter", "--token", "sk-or-test"}); err != nil {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -185,6 +185,42 @@ func TestRunDispatchesAuthCommand(t *testing.T) {
 	}
 }
 
+func TestRunAuthDoesNotCreateRepoSemsearch(t *testing.T) {
+	root := t.TempDir()
+	configHome := t.TempDir()
+	t.Setenv("UNCH_CONFIG_HOME", configHome)
+	chdirForTest(t, root)
+
+	if err := Run("unch", []string{"auth", "openrouter", "--token", "sk-or-test"}); err != nil {
+		t.Fatalf("Run(auth openrouter) error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, ".semsearch")); !os.IsNotExist(err) {
+		t.Fatalf(".semsearch exists unexpectedly after global auth")
+	}
+}
+
+func TestRunIndexOpenRouterWithoutTokenDoesNotCreateRepoSemsearch(t *testing.T) {
+	root := t.TempDir()
+	configHome := t.TempDir()
+	t.Setenv("UNCH_CONFIG_HOME", configHome)
+	chdirForTest(t, root)
+
+	source := filepath.Join(root, "main.go")
+	if err := os.WriteFile(source, []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error: %v", source, err)
+	}
+
+	err := Run("unch", []string{"index", "--provider", "openrouter", "--model", "openai/text-embedding-3-small"})
+	if err == nil || !strings.Contains(err.Error(), "resolve openrouter token") {
+		t.Fatalf("Run(index openrouter) error = %v, want missing token error", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, ".semsearch")); !os.IsNotExist(err) {
+		t.Fatalf(".semsearch exists unexpectedly after failed openrouter index")
+	}
+}
+
 func TestRunDispatchesCreateCommand(t *testing.T) {
 	root := t.TempDir()
 	chdirForTest(t, root)

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hybridgroup/yzma/pkg/llama"
 	"github.com/uchebnick/unch/internal/indexing"
 	"github.com/uchebnick/unch/internal/runtime"
+	"github.com/uchebnick/unch/internal/semsearch"
 )
 
 func captureStdout(t *testing.T, fn func()) string {
@@ -158,6 +159,32 @@ func TestRunDispatchesInitCommand(t *testing.T) {
 	}
 }
 
+func TestRunDispatchesAuthCommand(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("UNCH_CONFIG_HOME", configHome)
+
+	output := captureStdout(t, func() {
+		if err := Run("unch", []string{"auth", "openrouter", "--token", "sk-or-test"}); err != nil {
+			t.Fatalf("Run(auth openrouter) error: %v", err)
+		}
+	})
+
+	globalPath, err := semsearch.GlobalTokensPath()
+	if err != nil {
+		t.Fatalf("GlobalTokensPath() error: %v", err)
+	}
+	data, err := os.ReadFile(globalPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error: %v", globalPath, err)
+	}
+	if !strings.Contains(string(data), "\"openrouter\": \"sk-or-test\"") {
+		t.Fatalf("tokens file = %q, want openrouter token", string(data))
+	}
+	if !strings.Contains(output, "Saved global OpenRouter token") {
+		t.Fatalf("Run(auth openrouter) output = %q", output)
+	}
+}
+
 func TestRunDispatchesCreateCommand(t *testing.T) {
 	root := t.TempDir()
 	chdirForTest(t, root)
@@ -244,6 +271,36 @@ func TestRunRootHelpIncludesVersionCommand(t *testing.T) {
 
 	if !strings.Contains(output, "version Print the CLI version") {
 		t.Fatalf("Run(--help) output = %q, want version command", output)
+	}
+	if !strings.Contains(output, "auth    Save provider credentials such as OpenRouter API key") {
+		t.Fatalf("Run(--help) output = %q, want auth command", output)
+	}
+	if !strings.Contains(output, "start   Start long-running helpers such as MCP server") {
+		t.Fatalf("Run(--help) output = %q, want start command", output)
+	}
+}
+
+func TestRunStartHelp(t *testing.T) {
+	output := captureStdout(t, func() {
+		if err := Run("unch", []string{"help", "start"}); err != nil {
+			t.Fatalf("Run(help start) error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "unch start mcp [flags]") {
+		t.Fatalf("Run(help start) output = %q, want MCP start usage", output)
+	}
+}
+
+func TestRunStartMCPFlagHelp(t *testing.T) {
+	output := captureStdout(t, func() {
+		if err := runStart(context.Background(), "unch", []string{"mcp", "--help"}, "."); err != nil {
+			t.Fatalf("runStart(mcp --help) error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "workspace_status, search_code, and index_repository tools") {
+		t.Fatalf("runStart(mcp --help) output = %q, want tool list", output)
 	}
 }
 

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -56,7 +56,7 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 				},
 				[]string{
 					"Omit --model to reuse the default embeddinggemma GGUF model.",
-					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, then the global unch tokens.json, then .semsearch/tokens.json.",
+					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, then ~/.config/unch/tokens.json, then .semsearch/tokens.json.",
 					"Known model ids today: embeddinggemma and qwen3.",
 					"Use the same embedding model for both index and search, otherwise ranking quality will be wrong.",
 					"Switching models requires rebuilding the index with `unch index` first.",

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -96,6 +96,17 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 		return fmt.Errorf("resolve root: %w", err)
 	}
 
+	previewPaths, _, _, err := previewStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
+	if err != nil {
+		return err
+	}
+	if parsedProvider, err := appembed.ParseProvider(*provider); err == nil && parsedProvider == appembed.ProviderOpenRouter {
+		if err := preflightProviderConfig(parsedProvider, previewPaths.LocalDir); err != nil {
+			printMissingProviderCredentialsWarning(parsedProvider)
+			return err
+		}
+	}
+
 	targetPaths, resolvedIndexPath, shouldSyncRemote, err := resolveStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
 	if err != nil {
 		return err

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	llamaembed "github.com/uchebnick/unch/internal/embed/llama"
+	appembed "github.com/uchebnick/unch/internal/embed"
 	"github.com/uchebnick/unch/internal/indexdb"
 	"github.com/uchebnick/unch/internal/indexing"
 	"github.com/uchebnick/unch/internal/runtime"
@@ -29,6 +29,7 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 	stateDir := fs.String("state-dir", "", "path to .semsearch directory; defaults to <root>/.semsearch")
 	dbPath := fs.String("db", "", "deprecated: path to .semsearch/index.db, or to a .semsearch directory")
 	modelPath := fs.String("model", defaultModelPath, "path to GGUF embedding model, or a known model id such as embeddinggemma or qwen3")
+	provider := fs.String("provider", appembed.DefaultProvider().String(), "embedding provider: llama.cpp or openrouter")
 	libPath := fs.String("lib", "", "path to yzma library directory, or to one of its shared library files")
 	queryFlag := fs.String("query", "", "search query; if empty, remaining args are joined")
 	contextSize := fs.Int("ctx-size", 0, "llama context size; 0 uses the selected model default")
@@ -50,10 +51,12 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 					cliName(program) + " search --mode lexical \"Run\"",
 					cliName(program) + " search --details \"get path variables from a request\"",
 					cliName(program) + " search --model qwen3 \"search query\"",
+					cliName(program) + " search --provider openrouter --model openai/text-embedding-3-small \"search query\"",
 					cliName(program) + " search --model ~/.semsearch/models/Qwen3-Embedding-0.6B-Q8_0.gguf \"search query\"",
 				},
 				[]string{
 					"Omit --model to reuse the default embeddinggemma GGUF model.",
+					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, ~/.config/unch/tokens.json, then .semsearch/tokens.json.",
 					"Known model ids today: embeddinggemma and qwen3.",
 					"Use the same embedding model for both index and search, otherwise ranking quality will be wrong.",
 					"Switching models requires rebuilding the index with `unch index` first.",
@@ -127,61 +130,41 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 		}
 	}
 
-	resolvedLibPath, libNote, err := runtimes.ResolveOrInstallYzmaLibPath(ctx, *libPath, targetPaths.LocalDir, s)
+	prepared, err := prepareEmbedder(
+		ctx,
+		s,
+		targetPaths,
+		*provider,
+		*modelPath,
+		*libPath,
+		*contextSize,
+		*verbose,
+		runtimes,
+		models,
+	)
 	if err != nil {
 		return err
 	}
-	if libNote != "" {
-		s.Logf("%s", libNote)
-	}
-
-	resolvedDefaultModelPath := runtime.DefaultModelPath(targetPaths.ModelsDir)
-	requestedModelPath := strings.TrimSpace(*modelPath)
-	if requestedModelPath == "" {
-		requestedModelPath = resolvedDefaultModelPath
-	}
-
-	resolvedModelPath, modelNote, err := models.ResolveOrInstallModelPath(ctx, requestedModelPath, resolvedDefaultModelPath, true, s)
-	if err != nil {
-		return err
-	}
-	if modelNote != "" {
-		s.Logf("%s", modelNote)
-	}
-	modelID, err := runtime.CanonicalModelID(requestedModelPath, resolvedDefaultModelPath)
-	if err != nil {
-		return fmt.Errorf("resolve model id: %w", err)
-	}
-	resolvedContextSize := *contextSize
-	if resolvedContextSize <= 0 {
-		resolvedContextSize = defaultContextSize(resolvedModelPath)
-	}
+	defer prepared.Embedder.Close()
 
 	s.Logf("index_db=%s", resolvedIndexPath)
 	s.Logf("state_dir=%s", targetPaths.LocalDir)
-	s.Logf("lib=%s", resolvedLibPath)
-	s.Logf("model=%s", resolvedModelPath)
-	s.Logf("model_id=%s", modelID)
-	s.Logf("ctx_size=%d", resolvedContextSize)
+	s.Logf("provider=%s", prepared.Provider)
+	if prepared.ResolvedLib != "" {
+		s.Logf("lib=%s", prepared.ResolvedLib)
+	}
+	s.Logf("model=%s", prepared.ResolvedModel)
+	s.Logf("model_id=%s", prepared.ModelID)
+	if prepared.ContextSize > 0 {
+		s.Logf("ctx_size=%d", prepared.ContextSize)
+	}
 	s.Logf("root=%s", rootAbs)
 	s.Logf("query=%q", queryText)
 	s.Logf("limit=%d", *limit)
 	s.Logf("mode=%s", searchMode)
 	s.Logf("max_distance=%.4f", *maxDistance)
 
-	embedder, err := loadEmbedderWithSpinner(ctx, s, llamaembed.Config{
-		ModelPath:   resolvedModelPath,
-		LibPath:     resolvedLibPath,
-		ContextSize: resolvedContextSize,
-		Verbose:     *verbose,
-		Pooling:     defaultPooling(resolvedModelPath),
-	})
-	if err != nil {
-		return err
-	}
-	defer embedder.Close()
-
-	repo, err := indexdb.Open(ctx, resolvedIndexPath, embedder.Dim())
+	repo, err := indexdb.Open(ctx, resolvedIndexPath, prepared.Embedder.Dim())
 	if err != nil {
 		return err
 	}
@@ -196,7 +179,7 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 
 	service := appsearch.Service{
 		Repo:         repo,
-		Embedder:     embedder,
+		Embedder:     prepared.Embedder,
 		PathWeighter: fileWeights,
 	}
 
@@ -205,11 +188,12 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 		Limit:       *limit,
 		Mode:        searchMode,
 		MaxDistance: *maxDistance,
-		ModelID:     modelID,
+		Provider:    prepared.Provider.String(),
+		ModelID:     prepared.ModelID,
 	}, s)
 	if err != nil {
 		if errors.Is(err, indexdb.ErrNoActiveSnapshot) {
-			return fmt.Errorf("no active index for model %q; run `unch index --model %s` first", modelID, modelID)
+			return fmt.Errorf("no active index for provider %q and model %q; run `unch index --provider %s --model %s` first", prepared.Provider, prepared.ModelID, prepared.Provider, prepared.ModelID)
 		}
 		return err
 	}

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -56,7 +56,7 @@ func runSearch(ctx context.Context, program string, args []string, cwd string, _
 				},
 				[]string{
 					"Omit --model to reuse the default embeddinggemma GGUF model.",
-					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, ~/.config/unch/tokens.json, then .semsearch/tokens.json.",
+					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, then the global unch tokens.json, then .semsearch/tokens.json.",
 					"Known model ids today: embeddinggemma and qwen3.",
 					"Use the same embedding model for both index and search, otherwise ranking quality will be wrong.",
 					"Switching models requires rebuilding the index with `unch index` first.",

--- a/internal/cli/search_test.go
+++ b/internal/cli/search_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -94,5 +95,28 @@ func TestResolveStateTargetRejectsStateDirAndDBTogether(t *testing.T) {
 	_, _, _, err := resolveStateTarget(t.TempDir(), "/tmp/.semsearch", true, "/tmp/.semsearch/index.db", true)
 	if err == nil || err.Error() != "use either --state-dir or --db, not both" {
 		t.Fatalf("resolveStateTarget() error = %v", err)
+	}
+}
+
+func TestPreviewStateTargetDoesNotCreateDirectories(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	paths, indexPath, stateDirOwnsIndex, err := previewStateTarget(root, "", false, "", false)
+	if err != nil {
+		t.Fatalf("previewStateTarget() error: %v", err)
+	}
+	if !stateDirOwnsIndex {
+		t.Fatalf("stateDirOwnsIndex = false, want true")
+	}
+	if paths.LocalDir != filepath.Join(root, ".semsearch") {
+		t.Fatalf("paths.LocalDir = %q", paths.LocalDir)
+	}
+	if indexPath != filepath.Join(root, ".semsearch", "index.db") {
+		t.Fatalf("indexPath = %q", indexPath)
+	}
+	if _, err := os.Stat(paths.LocalDir); !os.IsNotExist(err) {
+		t.Fatalf("previewStateTarget created %q unexpectedly", paths.LocalDir)
 	}
 }

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -65,7 +65,7 @@ func runStartMCP(ctx context.Context, program string, args []string) error {
 					"From the repository root, `unch start mcp` is enough in the common case.",
 					"Stdout is reserved for MCP protocol messages; use this command as a child process from an MCP client.",
 					"The server exposes workspace_status, search_code, and index_repository tools.",
-					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, ~/.config/unch/tokens.json, then .semsearch/tokens.json.",
+					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, then the global unch tokens.json, then .semsearch/tokens.json.",
 					"Use one MCP process per repository workspace; the process reuses the same model/runtime configuration across tool calls.",
 				},
 			)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -92,6 +92,17 @@ func runStartMCP(ctx context.Context, program string, args []string) error {
 		return fmt.Errorf("resolve root: %w", err)
 	}
 
+	previewPaths, _, _, err := previewStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
+	if err != nil {
+		return err
+	}
+	if parsedProvider, err := appembed.ParseProvider(*provider); err == nil && parsedProvider == appembed.ProviderOpenRouter {
+		if err := preflightProviderConfig(parsedProvider, previewPaths.LocalDir); err != nil {
+			printMissingProviderCredentialsWarning(parsedProvider)
+			return err
+		}
+	}
+
 	targetPaths, resolvedIndexPath, _, err := resolveStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
 	if err != nil {
 		return err

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -65,7 +65,7 @@ func runStartMCP(ctx context.Context, program string, args []string) error {
 					"From the repository root, `unch start mcp` is enough in the common case.",
 					"Stdout is reserved for MCP protocol messages; use this command as a child process from an MCP client.",
 					"The server exposes workspace_status, search_code, and index_repository tools.",
-					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, then the global unch tokens.json, then .semsearch/tokens.json.",
+					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, then ~/.config/unch/tokens.json, then .semsearch/tokens.json.",
 					"Use one MCP process per repository workspace; the process reuses the same model/runtime configuration across tool calls.",
 				},
 			)

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	appembed "github.com/uchebnick/unch/internal/embed"
+	unchmcp "github.com/uchebnick/unch/internal/mcp"
+)
+
+func runStart(ctx context.Context, program string, args []string, cwd string) error {
+	_ = cwd
+
+	if len(args) == 0 {
+		return fmt.Errorf("start requires a target, for example: mcp")
+	}
+	if isHelpArg(args[0]) {
+		return printStartHelp(os.Stdout, cliName(program))
+	}
+
+	switch args[0] {
+	case "mcp":
+		return runStartMCP(ctx, program, args[1:])
+	default:
+		return fmt.Errorf("unknown start target %q", args[0])
+	}
+}
+
+func runStartMCP(ctx context.Context, program string, args []string) error {
+	defaultModelPath := defaultModelFlagValue()
+
+	fs := flag.NewFlagSet(program+" start mcp", flag.ContinueOnError)
+	fs.SetOutput(nil)
+	fs.Usage = func() {}
+
+	root := fs.String("root", ".", "repository root served by the MCP process")
+	stateDir := fs.String("state-dir", "", "path to .semsearch directory; defaults to <root>/.semsearch")
+	dbPath := fs.String("db", "", "deprecated: path to .semsearch/index.db, or to a .semsearch directory")
+	modelPath := fs.String("model", defaultModelPath, "path to GGUF embedding model, or a known model id such as embeddinggemma or qwen3")
+	provider := fs.String("provider", appembed.DefaultProvider().String(), "embedding provider: llama.cpp or openrouter")
+	libPath := fs.String("lib", "", "path to yzma library directory, or to one of its shared library files")
+	contextSize := fs.Int("ctx-size", 0, "llama context size; 0 uses the selected model default")
+	verbose := fs.Bool("verbose", false, "enable yzma verbose logging")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return printFlagSetHelp(
+				os.Stdout,
+				fs,
+				cliName(program)+" start mcp [flags]",
+				"Start an MCP stdio server for one repository workspace.",
+				[]string{
+					cliName(program) + " start mcp",
+					cliName(program) + " start mcp --root ~/src/repo --state-dir ~/src/repo/.semsearch",
+					cliName(program) + " start mcp --root . --model qwen3",
+					cliName(program) + " start mcp --provider openrouter --model openai/text-embedding-3-small",
+				},
+				[]string{
+					"From the repository root, `unch start mcp` is enough in the common case.",
+					"Stdout is reserved for MCP protocol messages; use this command as a child process from an MCP client.",
+					"The server exposes workspace_status, search_code, and index_repository tools.",
+					"Use --provider openrouter with --model <remote-model-id>; token lookup checks OPENROUTER_API_KEY, ~/.config/unch/tokens.json, then .semsearch/tokens.json.",
+					"Use one MCP process per repository workspace; the process reuses the same model/runtime configuration across tool calls.",
+				},
+			)
+		}
+		return err
+	}
+	if len(fs.Args()) > 0 {
+		return fmt.Errorf("unexpected positional arguments for start mcp: %s", strings.Join(fs.Args(), " "))
+	}
+
+	stateDirWasExplicit := false
+	dbWasExplicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "state-dir" {
+			stateDirWasExplicit = true
+		}
+		if f.Name == "db" {
+			dbWasExplicit = true
+		}
+	})
+
+	rootAbs, err := filepath.Abs(*root)
+	if err != nil {
+		return fmt.Errorf("resolve root: %w", err)
+	}
+
+	targetPaths, resolvedIndexPath, _, err := resolveStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
+	if err != nil {
+		return err
+	}
+
+	backend := newMCPBackend(mcpBackendConfig{
+		RootAbs:           rootAbs,
+		TargetPaths:       targetPaths,
+		IndexPath:         resolvedIndexPath,
+		RequestedProvider: strings.TrimSpace(*provider),
+		RequestedModel:    strings.TrimSpace(*modelPath),
+		RequestedLibPath:  strings.TrimSpace(*libPath),
+		ContextSize:       *contextSize,
+		Verbose:           *verbose,
+	})
+	defer func() {
+		_ = backend.Close()
+	}()
+
+	server := unchmcp.NewServer(backend)
+	if err := server.Serve(ctx, os.Stdin, os.Stdout); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func printStartHelp(w io.Writer, program string) error {
+	_, err := fmt.Fprintf(
+		w,
+		"Usage:\n  %s start mcp [flags]\n\nTargets:\n  mcp  Start an MCP stdio server for one repository workspace\n\nUse `%s start mcp --help` for flags.\n",
+		program,
+		program,
+	)
+	return err
+}

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -6,16 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/uchebnick/unch/internal/runtime"
 	"github.com/uchebnick/unch/internal/semsearch"
 )
 
 func defaultModelFlagValue() string {
-	modelsDir, err := semsearch.DefaultModelsDir()
-	if err != nil {
-		return ""
-	}
-	return runtime.DefaultModelPath(modelsDir)
+	return ""
 }
 
 func resolveStateTarget(rootAbs string, stateDirInput string, stateDirWasExplicit bool, dbInput string, dbWasExplicit bool) (semsearch.Paths, string, bool, error) {

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -13,38 +13,62 @@ func defaultModelFlagValue() string {
 	return ""
 }
 
-func resolveStateTarget(rootAbs string, stateDirInput string, stateDirWasExplicit bool, dbInput string, dbWasExplicit bool) (semsearch.Paths, string, bool, error) {
+func previewStateTarget(rootAbs string, stateDirInput string, stateDirWasExplicit bool, dbInput string, dbWasExplicit bool) (semsearch.Paths, string, bool, error) {
 	if stateDirWasExplicit && dbWasExplicit {
 		return semsearch.Paths{}, "", false, fmt.Errorf("use either --state-dir or --db, not both")
 	}
 	if stateDirWasExplicit {
-		return resolveExplicitStateDirTarget(stateDirInput)
+		return previewExplicitStateDirTarget(stateDirInput)
 	}
 	if dbWasExplicit {
-		return resolveLegacyIndexTarget(dbInput)
+		return previewLegacyIndexTarget(dbInput)
 	}
 
-	paths, err := semsearch.PreparePaths(rootAbs)
+	localDir := filepath.Join(rootAbs, ".semsearch")
+	modelsDir, err := semsearch.DefaultModelsDir()
 	if err != nil {
 		return semsearch.Paths{}, "", false, err
 	}
-	return paths, filepath.Join(paths.LocalDir, "index.db"), true, nil
+	return semsearch.Paths{
+		LocalDir:     localDir,
+		ManifestPath: semsearch.ManifestFilePath(localDir),
+		FileHashDB:   filepath.Join(localDir, "filehashes.db"),
+		ModelsDir:    modelsDir,
+	}, filepath.Join(localDir, "index.db"), true, nil
 }
 
-func resolveExplicitStateDirTarget(stateDirInput string) (semsearch.Paths, string, bool, error) {
+func resolveStateTarget(rootAbs string, stateDirInput string, stateDirWasExplicit bool, dbInput string, dbWasExplicit bool) (semsearch.Paths, string, bool, error) {
+	preview, resolvedIndexPath, stateDirOwnsIndex, err := previewStateTarget(rootAbs, stateDirInput, stateDirWasExplicit, dbInput, dbWasExplicit)
+	if err != nil {
+		return semsearch.Paths{}, "", false, err
+	}
+	paths, err := semsearch.PathsForLocalDir(preview.LocalDir)
+	if err != nil {
+		return semsearch.Paths{}, "", false, err
+	}
+	return paths, resolvedIndexPath, stateDirOwnsIndex, nil
+}
+
+func previewExplicitStateDirTarget(stateDirInput string) (semsearch.Paths, string, bool, error) {
 	resolvedStateDir, err := filepath.Abs(strings.TrimSpace(stateDirInput))
 	if err != nil {
 		return semsearch.Paths{}, "", false, fmt.Errorf("resolve state dir: %w", err)
 	}
 
-	paths, err := semsearch.PathsForLocalDir(resolvedStateDir)
+	modelsDir, err := semsearch.DefaultModelsDir()
 	if err != nil {
 		return semsearch.Paths{}, "", false, err
+	}
+	paths := semsearch.Paths{
+		LocalDir:     resolvedStateDir,
+		ManifestPath: semsearch.ManifestFilePath(resolvedStateDir),
+		FileHashDB:   filepath.Join(resolvedStateDir, "filehashes.db"),
+		ModelsDir:    modelsDir,
 	}
 	return paths, filepath.Join(paths.LocalDir, "index.db"), true, nil
 }
 
-func resolveLegacyIndexTarget(dbInput string) (semsearch.Paths, string, bool, error) {
+func previewLegacyIndexTarget(dbInput string) (semsearch.Paths, string, bool, error) {
 	resolvedInput, err := filepath.Abs(strings.TrimSpace(dbInput))
 	if err != nil {
 		return semsearch.Paths{}, "", false, fmt.Errorf("resolve legacy index path: %w", err)
@@ -74,9 +98,15 @@ func resolveLegacyIndexTarget(dbInput string) (semsearch.Paths, string, bool, er
 		return semsearch.Paths{}, "", false, fmt.Errorf("stat legacy index path: %w", statErr)
 	}
 
-	paths, err := semsearch.PathsForLocalDir(localDir)
+	modelsDir, err := semsearch.DefaultModelsDir()
 	if err != nil {
 		return semsearch.Paths{}, "", false, err
+	}
+	paths := semsearch.Paths{
+		LocalDir:     localDir,
+		ManifestPath: semsearch.ManifestFilePath(localDir),
+		FileHashDB:   filepath.Join(localDir, "filehashes.db"),
+		ModelsDir:    modelsDir,
 	}
 	return paths, resolvedIndexPath, stateDirOwnsIndex, nil
 }

--- a/internal/embed/embedder.go
+++ b/internal/embed/embedder.go
@@ -1,0 +1,11 @@
+package embed
+
+import "github.com/uchebnick/unch/internal/indexing"
+
+type Embedder interface {
+	Close()
+	Dim() int
+	EmbedQuery(text string) ([]float32, error)
+	IndexedSymbolHash(path string, symbol indexing.IndexedSymbol) string
+	EmbedIndexedSymbol(path string, symbol indexing.IndexedSymbol) ([]float32, error)
+}

--- a/internal/embed/format.go
+++ b/internal/embed/format.go
@@ -1,0 +1,209 @@
+package embed
+
+import (
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/uchebnick/unch/internal/indexing"
+	"github.com/uchebnick/unch/internal/modelcatalog"
+)
+
+const (
+	embeddingGemmaRetrievalQueryPrefix = "task: code retrieval | query: "
+	embeddingGemmaDocumentPrefix       = "title: %s | text: %s"
+
+	qwen3CodeRetrievalInstruction = "Given a code search query, retrieve relevant code symbols and documentation that answer the query."
+)
+
+type Formatter interface {
+	ProfileRevision() string
+	FormatQuery(text string) string
+	FormatIndexedSymbolDocument(path string, symbol indexing.IndexedSymbol) string
+}
+
+type genericFormatter struct{}
+
+type embeddingGemmaFormatter struct{}
+
+type qwen3Formatter struct{}
+
+func FormatterForModel(model string) Formatter {
+	if target, ok := modelcatalog.ResolveInstallTarget(model); ok {
+		return formatterForTargetID(target.ID)
+	}
+	if target, ok := modelcatalog.RecognizeInstallTargetForPath(model); ok {
+		return formatterForTargetID(target.ID)
+	}
+
+	token := strings.ToLower(strings.TrimSpace(model))
+	switch {
+	case strings.Contains(token, "qwen3") && strings.Contains(token, "embed"):
+		return qwen3Formatter{}
+	case strings.Contains(token, "embeddinggemma"), strings.Contains(token, "gemma"):
+		return embeddingGemmaFormatter{}
+	default:
+		return genericFormatter{}
+	}
+}
+
+func IndexedSymbolHash(formatter Formatter, path string, symbol indexing.IndexedSymbol) string {
+	document := formatter.FormatIndexedSymbolDocument(path, symbol)
+	return hashNormalizedText("embedding_doc_format:" + formatter.ProfileRevision() + "\n" + document)
+}
+
+func normalizeText(s string) string {
+	s = strings.ToValidUTF8(s, "")
+	s = strings.ReplaceAll(s, "\x00", "")
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return s
+}
+
+func (genericFormatter) ProfileRevision() string {
+	return "generic-v1"
+}
+
+func (genericFormatter) FormatQuery(text string) string {
+	return normalizeText(text)
+}
+
+func (genericFormatter) FormatIndexedSymbolDocument(path string, symbol indexing.IndexedSymbol) string {
+	title, body := indexedSymbolDocumentParts(path, symbol)
+	return formatGenericDocument(title, body)
+}
+
+func (embeddingGemmaFormatter) ProfileRevision() string {
+	return "embeddinggemma-v4"
+}
+
+func (embeddingGemmaFormatter) FormatQuery(text string) string {
+	return embeddingGemmaRetrievalQueryPrefix + normalizeText(text)
+}
+
+func (embeddingGemmaFormatter) FormatIndexedSymbolDocument(path string, symbol indexing.IndexedSymbol) string {
+	title, body := indexedSymbolDocumentParts(path, symbol)
+	return fmt.Sprintf(embeddingGemmaDocumentPrefix, normalizeDocumentTitle(title), normalizeText(body))
+}
+
+func (qwen3Formatter) ProfileRevision() string {
+	return "qwen3-embedding-v1"
+}
+
+func (qwen3Formatter) FormatQuery(text string) string {
+	return formatQwen3Query(qwen3CodeRetrievalInstruction, text)
+}
+
+func (qwen3Formatter) FormatIndexedSymbolDocument(path string, symbol indexing.IndexedSymbol) string {
+	title, body := indexedSymbolDocumentParts(path, symbol)
+	return formatGenericDocument(title, body)
+}
+
+func formatterForTargetID(targetID string) Formatter {
+	switch targetID {
+	case "qwen3":
+		return qwen3Formatter{}
+	case "embeddinggemma":
+		return embeddingGemmaFormatter{}
+	default:
+		return genericFormatter{}
+	}
+}
+
+func indexedSymbolDocumentParts(path string, symbol indexing.IndexedSymbol) (string, string) {
+	kind := normalizeText(symbol.Kind)
+	name := normalizeText(symbol.Name)
+	qualifiedName := normalizeText(symbol.QualifiedName)
+	signature := normalizeText(symbol.Signature)
+	documentation := normalizeText(symbol.Documentation)
+	fileContext := normalizeText(symbol.FileContext)
+	bodyText := normalizeText(symbol.Body)
+
+	var body strings.Builder
+	body.WriteString("Path: ")
+	body.WriteString(path)
+	if kind != "" {
+		body.WriteString("\nKind: ")
+		body.WriteString(kind)
+	}
+	if name != "" {
+		body.WriteString("\nName: ")
+		body.WriteString(name)
+	}
+	if qualifiedName != "" && qualifiedName != name {
+		body.WriteString("\nQualified name: ")
+		body.WriteString(qualifiedName)
+	}
+	if signature != "" {
+		body.WriteString("\nSignature:\n")
+		body.WriteString(signature)
+	}
+	if documentation != "" {
+		body.WriteString("\nDocumentation:\n")
+		body.WriteString(documentation)
+	}
+	if fileContext != "" {
+		body.WriteString("\nFile context:\n")
+		body.WriteString(fileContext)
+	}
+	if bodyText != "" {
+		body.WriteString("\nBody snippet:\n")
+		body.WriteString(bodyText)
+	}
+
+	title := normalizeDocumentTitle(strings.TrimSpace(filepath.Base(path)))
+	if qualifiedName != "" {
+		title = normalizeDocumentTitle(strings.TrimSpace(title + " " + qualifiedName))
+	}
+	if title == "" || title == "." || title == string(filepath.Separator) {
+		title = "symbol"
+	}
+
+	return title, body.String()
+}
+
+func formatQwen3Query(instruction string, query string) string {
+	return fmt.Sprintf("Instruct: %s\nQuery: %s", normalizeText(instruction), normalizeText(query))
+}
+
+func formatGenericDocument(title string, text string) string {
+	title = normalizeDocumentTitle(title)
+	text = normalizeText(text)
+
+	switch {
+	case title == "" && text == "":
+		return ""
+	case title == "":
+		return text
+	case text == "":
+		return "Title: " + title
+	default:
+		return "Title: " + title + "\n" + text
+	}
+}
+
+func normalizeDocumentTitle(title string) string {
+	title = normalizeText(title)
+	title = strings.ReplaceAll(title, "|", "/")
+	if title == "" {
+		return "none"
+	}
+	return title
+}
+
+func hashNormalizedText(text string) string {
+	sum := xxhash.Sum64String(normalizeText(text))
+	var buf [8]byte
+	buf[0] = byte(sum >> 56)
+	buf[1] = byte(sum >> 48)
+	buf[2] = byte(sum >> 40)
+	buf[3] = byte(sum >> 32)
+	buf[4] = byte(sum >> 24)
+	buf[5] = byte(sum >> 16)
+	buf[6] = byte(sum >> 8)
+	buf[7] = byte(sum)
+	return hex.EncodeToString(buf[:])
+}

--- a/internal/embed/llama/embedder.go
+++ b/internal/embed/llama/embedder.go
@@ -1,7 +1,6 @@
 package llamaembed
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math"
 	"os"
@@ -11,9 +10,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/cespare/xxhash/v2"
 	"github.com/hybridgroup/yzma/pkg/llama"
 	"github.com/jupiterrider/ffi"
+	appembed "github.com/uchebnick/unch/internal/embed"
 	"github.com/uchebnick/unch/internal/indexing"
 	unchruntime "github.com/uchebnick/unch/internal/runtime"
 )
@@ -32,8 +31,9 @@ type Embedder struct {
 	ctx         llama.Context
 	vocab       llama.Vocab
 	dim         int
-	profile     embeddingBehavior
+	formatter   appembed.Formatter
 	contextSize int
+	tokenLimit  int
 }
 
 var (
@@ -50,7 +50,7 @@ func New(cfg Config) (*Embedder, error) {
 		return nil, err
 	}
 
-	profile := behaviorForPath(cfg.ModelPath)
+	formatter := formatterForPath(cfg.ModelPath)
 
 	resolvedLibPath, _, err := unchruntime.ResolveYzmaLibPath(cfg.LibPath)
 	if err != nil {
@@ -66,7 +66,7 @@ func New(cfg Config) (*Embedder, error) {
 		cfg.ContextSize = profileForPath(cfg.ModelPath).DefaultContextSize
 	}
 	if cfg.Pooling == 0 {
-		cfg.Pooling = profile.DefaultPooling()
+		cfg.Pooling = DefaultPoolingForModelPath(cfg.ModelPath)
 	}
 
 	llamaGlobalMu.Lock()
@@ -131,13 +131,21 @@ func New(cfg Config) (*Embedder, error) {
 		return nil, fmt.Errorf("init context from model: %w", err)
 	}
 
+	tokenLimit := effectiveTokenLimit(
+		cfg.ContextSize,
+		int(llama.NCtx(ctx)),
+		int(llama.NBatch(ctx)),
+		int(llama.NUBatch(ctx)),
+	)
+
 	return &Embedder{
 		model:       model,
 		ctx:         ctx,
 		vocab:       llama.ModelGetVocab(model),
 		dim:         int(llama.ModelNEmbd(model)),
-		profile:     profile,
+		formatter:   formatter,
 		contextSize: cfg.ContextSize,
+		tokenLimit:  tokenLimit,
 	}, nil
 }
 
@@ -197,9 +205,9 @@ func (e *Embedder) Embed(text string) ([]float32, error) {
 		return nil, nil // Return empty if text results in zero tokens
 	}
 
-	// Truncate tokens if they exceed ContextSize
-	if len(tokens) > e.contextSize {
-		tokens = tokens[:e.contextSize]
+	// Truncate tokens to the smallest safe bound reported by the runtime.
+	if len(tokens) > e.tokenLimit {
+		tokens = tokens[:e.tokenLimit]
 	}
 
 	// Clear memory before processing new tokens
@@ -208,14 +216,10 @@ func (e *Embedder) Embed(text string) ([]float32, error) {
 		_ = llama.MemoryClear(mem, true)
 	}
 
-	if len(tokens) > e.contextSize {
-		tokens = tokens[:e.contextSize]
-	}
-
 	batch := llama.BatchGetOne(tokens)
-	defer func() {
-		_ = llama.BatchFree(batch)
-	}()
+	// yzma's single-sequence batch is not safe to free here: on real indexing
+	// workloads that triggered invalid pointer / heap corruption crashes on both
+	// Linux and Windows ARM CI.
 
 	ret, err := llama.Decode(e.ctx, batch)
 	if err != nil {
@@ -240,50 +244,39 @@ func (e *Embedder) Embed(text string) ([]float32, error) {
 }
 
 func (e *Embedder) EmbedQuery(text string) ([]float32, error) {
-	return e.Embed(e.profile.FormatQuery(text))
+	return e.Embed(e.formatter.FormatQuery(text))
 }
 
 // IndexedSymbolHash returns the stable embedding-document hash for one symbol without running the model.
 func (e *Embedder) IndexedSymbolHash(path string, symbol indexing.IndexedSymbol) string {
-	return hashIndexedSymbolDocument(e.profile, path, symbol)
+	return appembed.IndexedSymbolHash(e.formatter, path, symbol)
 }
 
 // EmbedIndexedSymbol builds a retrieval document for a symbol and returns its embedding vector.
 func (e *Embedder) EmbedIndexedSymbol(path string, symbol indexing.IndexedSymbol) ([]float32, error) {
-	return e.Embed(indexedSymbolDocument(e.profile, path, symbol))
+	return e.Embed(e.formatter.FormatIndexedSymbolDocument(path, symbol))
 }
 
-func hashComment(text string) string {
-	sum := xxhash.Sum64String(normalizeText(text))
-
-	var b [8]byte
-	b[0] = byte(sum >> 56)
-	b[1] = byte(sum >> 48)
-	b[2] = byte(sum >> 40)
-	b[3] = byte(sum >> 32)
-	b[4] = byte(sum >> 24)
-	b[5] = byte(sum >> 16)
-	b[6] = byte(sum >> 8)
-	b[7] = byte(sum)
-
-	return hex.EncodeToString(b[:])
+func effectiveTokenLimit(requested int, limits ...int) int {
+	limit := requested
+	for _, candidate := range limits {
+		if candidate <= 0 {
+			continue
+		}
+		if limit <= 0 || candidate < limit {
+			limit = candidate
+		}
+	}
+	return limit
 }
 
-func hashIndexedSymbolDocument(profile embeddingBehavior, path string, symbol indexing.IndexedSymbol) string {
-	return hashComment("embedding_doc_format:" + profile.ProfileRevision() + "\n" + indexedSymbolDocument(profile, path, symbol))
-}
-
-func indexedSymbolDocument(profile embeddingBehavior, path string, symbol indexing.IndexedSymbol) string {
-	return profile.FormatIndexedSymbolDocument(path, symbol)
-}
-
-func normalizeText(s string) string {
-	s = strings.ToValidUTF8(s, "")
-	s = strings.ReplaceAll(s, "\x00", "")
-	s = strings.TrimSpace(s)
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	s = strings.ReplaceAll(s, "\r", "\n")
-	return s
+func normalizeText(text string) string {
+	text = strings.ToValidUTF8(text, "")
+	text = strings.ReplaceAll(text, "\x00", "")
+	text = strings.TrimSpace(text)
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	return text
 }
 
 func l2Normalize(v []float32) {

--- a/internal/embed/llama/embedder_test.go
+++ b/internal/embed/llama/embedder_test.go
@@ -4,13 +4,14 @@ import (
 	"strings"
 	"testing"
 
+	appembed "github.com/uchebnick/unch/internal/embed"
 	"github.com/uchebnick/unch/internal/indexing"
 )
 
 func TestFormatIndexedSymbolDocumentIncludesMetadataAndBody(t *testing.T) {
 	t.Parallel()
 
-	doc := embeddingGemmaModel{}.FormatIndexedSymbolDocument(
+	doc := appembed.FormatterForModel("embeddinggemma").FormatIndexedSymbolDocument(
 		"/tmp/internal/model_cache.go",
 		indexing.IndexedSymbol{
 			Kind:          "function",
@@ -42,7 +43,7 @@ func TestFormatIndexedSymbolDocumentIncludesMetadataAndBody(t *testing.T) {
 func TestFormatEmbeddingGemmaQuery(t *testing.T) {
 	t.Parallel()
 
-	got := embeddingGemmaModel{}.FormatQuery("global model cache")
+	got := appembed.FormatterForModel("embeddinggemma").FormatQuery("global model cache")
 	want := "task: code retrieval | query: global model cache"
 	if got != want {
 		t.Fatalf("formatEmbeddingGemmaQuery() = %q, want %q", got, want)
@@ -52,7 +53,7 @@ func TestFormatEmbeddingGemmaQuery(t *testing.T) {
 func TestFormatQwen3Query(t *testing.T) {
 	t.Parallel()
 
-	got := formatQwen3Query(qwen3CodeRetrievalInstruction, "global model cache")
+	got := appembed.FormatterForModel("qwen3").FormatQuery("global model cache")
 	want := "Instruct: Given a code search query, retrieve relevant code symbols and documentation that answer the query.\nQuery: global model cache"
 	if got != want {
 		t.Fatalf("formatQwen3Query() = %q, want %q", got, want)
@@ -62,7 +63,7 @@ func TestFormatQwen3Query(t *testing.T) {
 func TestFormatQwen3IndexedSymbolDocumentIncludesTitleAndMetadata(t *testing.T) {
 	t.Parallel()
 
-	doc := qwen3EmbeddingModel{}.FormatIndexedSymbolDocument(
+	doc := appembed.FormatterForModel("qwen3").FormatIndexedSymbolDocument(
 		"/tmp/internal/model_cache.go",
 		indexing.IndexedSymbol{
 			Kind:          "function",
@@ -91,27 +92,16 @@ func TestFormatQwen3IndexedSymbolDocumentIncludesTitleAndMetadata(t *testing.T) 
 	}
 }
 
-func TestNormalizeDocumentTitle(t *testing.T) {
-	t.Parallel()
-
-	if got := normalizeDocumentTitle("internal/model|cache.go"); got != "internal/model/cache.go" {
-		t.Fatalf("normalizeDocumentTitle() = %q", got)
-	}
-	if got := normalizeDocumentTitle(""); got != "none" {
-		t.Fatalf("normalizeDocumentTitle(empty) = %q", got)
-	}
-}
-
 func TestModelForPath(t *testing.T) {
 	t.Parallel()
 
-	gemmaID := embeddingGemmaModel{}.ProfileRevision()
-	qwenID := qwen3EmbeddingModel{}.ProfileRevision()
+	gemmaID := appembed.FormatterForModel("embeddinggemma").ProfileRevision()
+	qwenID := appembed.FormatterForModel("qwen3").ProfileRevision()
 
-	if got := behaviorForPath("/tmp/embeddinggemma-300m.gguf").ProfileRevision(); got != gemmaID {
+	if got := formatterForPath("/tmp/embeddinggemma-300m.gguf").ProfileRevision(); got != gemmaID {
 		t.Fatalf("behaviorForPath(gemma) = %q", got)
 	}
-	if got := behaviorForPath("/tmp/Qwen3-Embedding-0.6B-Q8_0.gguf").ProfileRevision(); got != qwenID {
+	if got := formatterForPath("/tmp/Qwen3-Embedding-0.6B-Q8_0.gguf").ProfileRevision(); got != qwenID {
 		t.Fatalf("behaviorForPath(qwen3) = %q", got)
 	}
 }
@@ -149,17 +139,49 @@ func TestKnownModelProfiles(t *testing.T) {
 	}
 }
 
-func TestHashCommentIsStable(t *testing.T) {
+func TestIndexedSymbolHashIsStable(t *testing.T) {
 	t.Parallel()
 
-	hashA := hashComment("same comment")
-	hashB := hashComment("same comment")
-	hashC := hashComment("other comment")
+	formatter := appembed.FormatterForModel("embeddinggemma")
+	symbolA := indexing.IndexedSymbol{Name: "A", QualifiedName: "A", Documentation: "same comment"}
+	symbolB := indexing.IndexedSymbol{Name: "A", QualifiedName: "A", Documentation: "same comment"}
+	symbolC := indexing.IndexedSymbol{Name: "A", QualifiedName: "A", Documentation: "other comment"}
+
+	hashA := appembed.IndexedSymbolHash(formatter, "a.go", symbolA)
+	hashB := appembed.IndexedSymbolHash(formatter, "a.go", symbolB)
+	hashC := appembed.IndexedSymbolHash(formatter, "a.go", symbolC)
 
 	if hashA != hashB {
 		t.Fatalf("expected identical comments to have identical hashes")
 	}
 	if hashA == hashC {
 		t.Fatalf("expected different comments to have different hashes")
+	}
+}
+
+func TestEffectiveTokenLimitPrefersSmallestPositiveBound(t *testing.T) {
+	t.Parallel()
+
+	got := effectiveTokenLimit(2048, 2048, 1024, 1536)
+	if got != 1024 {
+		t.Fatalf("effectiveTokenLimit() = %d, want 1024", got)
+	}
+}
+
+func TestEffectiveTokenLimitIgnoresZeroRuntimeValues(t *testing.T) {
+	t.Parallel()
+
+	got := effectiveTokenLimit(2048, 0, -1, 2048)
+	if got != 2048 {
+		t.Fatalf("effectiveTokenLimit() = %d, want 2048", got)
+	}
+}
+
+func TestEffectiveTokenLimitFallsBackToRuntimeBound(t *testing.T) {
+	t.Parallel()
+
+	got := effectiveTokenLimit(0, 4096, 1024, 0)
+	if got != 1024 {
+		t.Fatalf("effectiveTokenLimit() = %d, want 1024", got)
 	}
 }

--- a/internal/embed/llama/model_profile.go
+++ b/internal/embed/llama/model_profile.go
@@ -11,11 +11,6 @@ type ModelProfile struct {
 	DefaultContextSize int
 }
 
-type embeddingBehavior interface {
-	DefaultPooling() llama.PoolingType
-	Formatter() appembed.Formatter
-}
-
 type registeredEmbeddingModel struct {
 	TargetID string
 	Defaults runtimeDefaults

--- a/internal/embed/llama/model_profile.go
+++ b/internal/embed/llama/model_profile.go
@@ -1,20 +1,9 @@
 package llamaembed
 
 import (
-	"fmt"
-	"path/filepath"
-	"strings"
-
 	"github.com/hybridgroup/yzma/pkg/llama"
-	"github.com/uchebnick/unch/internal/indexing"
+	appembed "github.com/uchebnick/unch/internal/embed"
 	"github.com/uchebnick/unch/internal/modelcatalog"
-)
-
-const (
-	embeddingGemmaRetrievalQueryPrefix = "task: code retrieval | query: "
-	embeddingGemmaDocumentPrefix       = "title: %s | text: %s"
-
-	qwen3CodeRetrievalInstruction = "Given a code search query, retrieve relevant code symbols and documentation that answer the query."
 )
 
 type ModelProfile struct {
@@ -23,36 +12,33 @@ type ModelProfile struct {
 }
 
 type embeddingBehavior interface {
-	ProfileRevision() string
 	DefaultPooling() llama.PoolingType
-	FormatQuery(text string) string
-	FormatIndexedSymbolDocument(path string, symbol indexing.IndexedSymbol) string
+	Formatter() appembed.Formatter
 }
 
 type registeredEmbeddingModel struct {
 	TargetID string
 	Defaults runtimeDefaults
-	Behavior embeddingBehavior
+	Pooling  llama.PoolingType
+	Format   appembed.Formatter
 }
 
 type runtimeDefaults struct {
 	DefaultContextSize int
 }
 
-type embeddingGemmaModel struct{}
-
-type qwen3EmbeddingModel struct{}
-
 var embeddingModels = []registeredEmbeddingModel{
 	{
 		TargetID: "embeddinggemma",
 		Defaults: runtimeDefaults{DefaultContextSize: 2048},
-		Behavior: embeddingGemmaModel{},
+		Pooling:  llama.PoolingTypeMean,
+		Format:   appembed.FormatterForModel("embeddinggemma"),
 	},
 	{
 		TargetID: "qwen3",
 		Defaults: runtimeDefaults{DefaultContextSize: 8192},
-		Behavior: qwen3EmbeddingModel{},
+		Pooling:  llama.PoolingTypeLast,
+		Format:   appembed.FormatterForModel("qwen3"),
 	},
 }
 
@@ -92,7 +78,7 @@ func RecognizeModelProfileForPath(modelPath string) (ModelProfile, bool) {
 
 // DefaultPoolingForModelPath returns the pooling mode that matches the known GGUF embedding model.
 func DefaultPoolingForModelPath(modelPath string) llama.PoolingType {
-	return behaviorForPath(modelPath).DefaultPooling()
+	return registeredModelForTargetID(profileForPath(modelPath).ID).Pooling
 }
 
 // DefaultContextSizeForModelPath returns the model-specific context size used when the CLI does not override it.
@@ -108,12 +94,12 @@ func profileForPath(modelPath string) ModelProfile {
 	return profileForTarget(target)
 }
 
-func behaviorForTargetID(targetID string) embeddingBehavior {
-	return registeredModelForTargetID(targetID).Behavior
+func formatterForTargetID(targetID string) appembed.Formatter {
+	return registeredModelForTargetID(targetID).Format
 }
 
-func behaviorForPath(modelPath string) embeddingBehavior {
-	return behaviorForTargetID(profileForPath(modelPath).ID)
+func formatterForPath(modelPath string) appembed.Formatter {
+	return formatterForTargetID(profileForPath(modelPath).ID)
 }
 
 func profileForTarget(target modelcatalog.InstallTarget) ModelProfile {
@@ -136,122 +122,4 @@ func registeredModelForTargetID(targetID string) registeredEmbeddingModel {
 	}
 
 	return embeddingModels[0]
-}
-
-func (embeddingGemmaModel) ProfileRevision() string {
-	return "embeddinggemma-v4"
-}
-
-func (embeddingGemmaModel) DefaultPooling() llama.PoolingType {
-	return llama.PoolingTypeMean
-}
-
-func (embeddingGemmaModel) FormatQuery(text string) string {
-	text = normalizeText(text)
-	return embeddingGemmaRetrievalQueryPrefix + text
-}
-
-func (embeddingGemmaModel) FormatIndexedSymbolDocument(path string, symbol indexing.IndexedSymbol) string {
-	title, body := indexedSymbolDocumentParts(path, symbol)
-	return fmt.Sprintf(embeddingGemmaDocumentPrefix, normalizeDocumentTitle(title), normalizeText(body))
-}
-
-func (qwen3EmbeddingModel) ProfileRevision() string {
-	return "qwen3-embedding-v1"
-}
-
-func (qwen3EmbeddingModel) DefaultPooling() llama.PoolingType {
-	return llama.PoolingTypeLast
-}
-
-func (qwen3EmbeddingModel) FormatQuery(text string) string {
-	return formatQwen3Query(qwen3CodeRetrievalInstruction, text)
-}
-
-func (qwen3EmbeddingModel) FormatIndexedSymbolDocument(path string, symbol indexing.IndexedSymbol) string {
-	title, body := indexedSymbolDocumentParts(path, symbol)
-	return formatQwen3Document(title, body)
-}
-
-func indexedSymbolDocumentParts(path string, symbol indexing.IndexedSymbol) (string, string) {
-	kind := normalizeText(symbol.Kind)
-	name := normalizeText(symbol.Name)
-	qualifiedName := normalizeText(symbol.QualifiedName)
-	signature := normalizeText(symbol.Signature)
-	documentation := normalizeText(symbol.Documentation)
-	fileContext := normalizeText(symbol.FileContext)
-	bodyText := normalizeText(symbol.Body)
-
-	var body strings.Builder
-	body.WriteString("Path: ")
-	body.WriteString(path)
-	if kind != "" {
-		body.WriteString("\nKind: ")
-		body.WriteString(kind)
-	}
-	if name != "" {
-		body.WriteString("\nName: ")
-		body.WriteString(name)
-	}
-	if qualifiedName != "" && qualifiedName != name {
-		body.WriteString("\nQualified name: ")
-		body.WriteString(qualifiedName)
-	}
-	if signature != "" {
-		body.WriteString("\nSignature:\n")
-		body.WriteString(signature)
-	}
-	if documentation != "" {
-		body.WriteString("\nDocumentation:\n")
-		body.WriteString(documentation)
-	}
-	if fileContext != "" {
-		body.WriteString("\nFile context:\n")
-		body.WriteString(fileContext)
-	}
-	if bodyText != "" {
-		body.WriteString("\nBody snippet:\n")
-		body.WriteString(bodyText)
-	}
-
-	title := normalizeDocumentTitle(strings.TrimSpace(filepath.Base(path)))
-	if qualifiedName != "" {
-		title = normalizeDocumentTitle(strings.TrimSpace(title + " " + qualifiedName))
-	}
-	if title == "" || title == "." || title == string(filepath.Separator) {
-		title = "symbol"
-	}
-
-	return title, body.String()
-}
-
-func formatQwen3Query(instruction string, query string) string {
-	instruction = normalizeText(instruction)
-	query = normalizeText(query)
-	return fmt.Sprintf("Instruct: %s\nQuery: %s", instruction, query)
-}
-
-func formatQwen3Document(title string, text string) string {
-	title = normalizeDocumentTitle(title)
-	text = normalizeText(text)
-
-	switch {
-	case title == "" && text == "":
-		return ""
-	case title == "":
-		return text
-	case text == "":
-		return "Title: " + title
-	default:
-		return "Title: " + title + "\n" + text
-	}
-}
-
-func normalizeDocumentTitle(title string) string {
-	title = normalizeText(title)
-	title = strings.ReplaceAll(title, "|", "/")
-	if title == "" {
-		return "none"
-	}
-	return title
 }

--- a/internal/embed/openrouter/embedder.go
+++ b/internal/embed/openrouter/embedder.go
@@ -1,0 +1,187 @@
+package openrouterembed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	appembed "github.com/uchebnick/unch/internal/embed"
+	"github.com/uchebnick/unch/internal/indexing"
+)
+
+const defaultBaseURL = "https://openrouter.ai/api/v1"
+
+type Config struct {
+	ModelID     string
+	APIKey      string
+	BaseURL     string
+	HTTPReferer string
+	AppTitle    string
+	HTTPClient  *http.Client
+	Formatter   appembed.Formatter
+}
+
+type Embedder struct {
+	client      *http.Client
+	endpoint    string
+	apiKey      string
+	httpReferer string
+	appTitle    string
+	modelID     string
+	formatter   appembed.Formatter
+	dim         int
+}
+
+type embeddingsRequest struct {
+	Model          string   `json:"model"`
+	Input          []string `json:"input"`
+	EncodingFormat string   `json:"encoding_format,omitempty"`
+}
+
+type embeddingsResponse struct {
+	Data []struct {
+		Embedding []float32 `json:"embedding"`
+		Index     int       `json:"index"`
+	} `json:"data"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+func New(ctx context.Context, cfg Config) (*Embedder, error) {
+	modelID := strings.TrimSpace(cfg.ModelID)
+	if modelID == "" {
+		return nil, fmt.Errorf("empty OpenRouter model id")
+	}
+	apiKey := strings.TrimSpace(cfg.APIKey)
+	if apiKey == "" {
+		return nil, fmt.Errorf("missing OPENROUTER_API_KEY")
+	}
+
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+	formatter := cfg.Formatter
+	if formatter == nil {
+		formatter = appembed.FormatterForModel(modelID)
+	}
+
+	embedder := &Embedder{
+		client:      client,
+		endpoint:    baseURL + "/embeddings",
+		apiKey:      apiKey,
+		httpReferer: strings.TrimSpace(cfg.HTTPReferer),
+		appTitle:    strings.TrimSpace(cfg.AppTitle),
+		modelID:     modelID,
+		formatter:   formatter,
+	}
+
+	probe, err := embedder.embedInput(ctx, "unch dimension probe")
+	if err != nil {
+		return nil, err
+	}
+	embedder.dim = len(probe)
+	if embedder.dim <= 0 {
+		return nil, fmt.Errorf("OpenRouter returned empty embedding for %s", modelID)
+	}
+
+	return embedder, nil
+}
+
+func (e *Embedder) Close() {}
+
+func (e *Embedder) Dim() int {
+	if e == nil {
+		return 0
+	}
+	return e.dim
+}
+
+func (e *Embedder) EmbedQuery(text string) ([]float32, error) {
+	return e.embedInput(context.Background(), e.formatter.FormatQuery(text))
+}
+
+func (e *Embedder) IndexedSymbolHash(path string, symbol indexing.IndexedSymbol) string {
+	return appembed.IndexedSymbolHash(e.formatter, path, symbol)
+}
+
+func (e *Embedder) EmbedIndexedSymbol(path string, symbol indexing.IndexedSymbol) ([]float32, error) {
+	return e.embedInput(context.Background(), e.formatter.FormatIndexedSymbolDocument(path, symbol))
+}
+
+func (e *Embedder) embedInput(ctx context.Context, input string) ([]float32, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil, nil
+	}
+
+	reqBody, err := json.Marshal(embeddingsRequest{
+		Model:          e.modelID,
+		Input:          []string{input},
+		EncodingFormat: "float",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode embeddings request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("build embeddings request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+e.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	if e.httpReferer != "" {
+		req.Header.Set("HTTP-Referer", e.httpReferer)
+	}
+	if e.appTitle != "" {
+		req.Header.Set("X-Title", e.appTitle)
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request OpenRouter embeddings: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read OpenRouter embeddings response: %w", err)
+	}
+
+	var payload embeddingsResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode OpenRouter embeddings response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if payload.Error != nil && strings.TrimSpace(payload.Error.Message) != "" {
+			return nil, fmt.Errorf("OpenRouter embeddings request failed: %s", strings.TrimSpace(payload.Error.Message))
+		}
+		return nil, fmt.Errorf("OpenRouter embeddings request failed: status %s", resp.Status)
+	}
+	if payload.Error != nil && strings.TrimSpace(payload.Error.Message) != "" {
+		return nil, fmt.Errorf("OpenRouter embeddings request failed: %s", strings.TrimSpace(payload.Error.Message))
+	}
+	if len(payload.Data) == 0 || len(payload.Data[0].Embedding) == 0 {
+		return nil, fmt.Errorf("OpenRouter embeddings response did not contain an embedding")
+	}
+	if e.dim > 0 && len(payload.Data[0].Embedding) != e.dim {
+		return nil, fmt.Errorf("unexpected OpenRouter embedding dimension: got=%d want=%d", len(payload.Data[0].Embedding), e.dim)
+	}
+
+	vector := make([]float32, len(payload.Data[0].Embedding))
+	copy(vector, payload.Data[0].Embedding)
+	return vector, nil
+}

--- a/internal/embed/provider.go
+++ b/internal/embed/provider.go
@@ -1,0 +1,33 @@
+package embed
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Provider string
+
+const (
+	ProviderLlamaCPP  Provider = "llama.cpp"
+	ProviderOpenRouter Provider = "openrouter"
+)
+
+func DefaultProvider() Provider {
+	return ProviderLlamaCPP
+}
+
+func ParseProvider(value string) (Provider, error) {
+	token := strings.ToLower(strings.TrimSpace(value))
+	switch token {
+	case "", string(ProviderLlamaCPP), "llama", "llamacpp":
+		return ProviderLlamaCPP, nil
+	case string(ProviderOpenRouter):
+		return ProviderOpenRouter, nil
+	default:
+		return "", fmt.Errorf("unknown embedding provider %q; expected llama.cpp or openrouter", value)
+	}
+}
+
+func (p Provider) String() string {
+	return string(p)
+}

--- a/internal/filehashdb/sqlite.go
+++ b/internal/filehashdb/sqlite.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 )
 
-const SchemaVersion = 2
+const SchemaVersion = 3
 
 type Store struct {
 	db *sql.DB
@@ -18,6 +18,7 @@ type Store struct {
 
 type State struct {
 	Version            int64
+	Provider           string
 	ModelID            string
 	ScannerFingerprint string
 	Files              map[string]string
@@ -60,7 +61,7 @@ func (s *Store) init(ctx context.Context) error {
 
 	switch userVersion {
 	case 0, SchemaVersion:
-	case 1:
+	case 1, 2:
 		if err := s.resetSchema(ctx); err != nil {
 			return fmt.Errorf("reset legacy schema: %w", err)
 		}
@@ -72,19 +73,22 @@ func (s *Store) init(ctx context.Context) error {
 		`
 		CREATE TABLE IF NOT EXISTS file_hash_states (
 			state_version INTEGER PRIMARY KEY AUTOINCREMENT,
+			provider TEXT NOT NULL,
 			model_id TEXT NOT NULL,
 			scanner_fingerprint TEXT NOT NULL,
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);
 		`,
 		`
-		CREATE INDEX IF NOT EXISTS idx_file_hash_states_model_id
-		ON file_hash_states(model_id, state_version);
+		CREATE INDEX IF NOT EXISTS idx_file_hash_states_provider_model_id
+		ON file_hash_states(provider, model_id, state_version);
 		`,
 		`
 		CREATE TABLE IF NOT EXISTS current_model_states (
-			model_id TEXT PRIMARY KEY,
-			state_version INTEGER NOT NULL
+			provider TEXT NOT NULL,
+			model_id TEXT NOT NULL,
+			state_version INTEGER NOT NULL,
+			PRIMARY KEY (provider, model_id)
 		);
 		`,
 		`
@@ -126,8 +130,9 @@ func (s *Store) resetSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *Store) Current(ctx context.Context, modelID string) (State, bool, error) {
+func (s *Store) Current(ctx context.Context, provider string, modelID string) (State, bool, error) {
 	var state State
+	state.Provider = provider
 	state.ModelID = modelID
 
 	err := s.db.QueryRowContext(
@@ -136,8 +141,13 @@ func (s *Store) Current(ctx context.Context, modelID string) (State, bool, error
 		 FROM current_model_states cms
 		 JOIN file_hash_states fs
 		   ON fs.state_version = cms.state_version
-		 WHERE cms.model_id = ? AND fs.model_id = ?`,
+		 WHERE cms.provider = ?
+		   AND cms.model_id = ?
+		   AND fs.provider = ?
+		   AND fs.model_id = ?`,
+		provider,
 		modelID,
+		provider,
 		modelID,
 	).Scan(&state.ScannerFingerprint, &state.Version)
 	if err != nil {
@@ -175,8 +185,8 @@ func (s *Store) Current(ctx context.Context, modelID string) (State, bool, error
 	return state, true, nil
 }
 
-func (s *Store) Matches(ctx context.Context, modelID string, scannerFingerprint string, files map[string]string) (bool, int64, error) {
-	state, ok, err := s.Current(ctx, modelID)
+func (s *Store) Matches(ctx context.Context, provider string, modelID string, scannerFingerprint string, files map[string]string) (bool, int64, error) {
+	state, ok, err := s.Current(ctx, provider, modelID)
 	if err != nil {
 		return false, 0, err
 	}
@@ -197,10 +207,11 @@ func (s *Store) Matches(ctx context.Context, modelID string, scannerFingerprint 
 	return true, state.Version, nil
 }
 
-func (s *Store) BeginState(ctx context.Context, modelID string, scannerFingerprint string) (int64, error) {
+func (s *Store) BeginState(ctx context.Context, provider string, modelID string, scannerFingerprint string) (int64, error) {
 	result, err := s.db.ExecContext(
 		ctx,
-		`INSERT INTO file_hash_states(model_id, scanner_fingerprint) VALUES (?, ?)`,
+		`INSERT INTO file_hash_states(provider, model_id, scanner_fingerprint) VALUES (?, ?, ?)`,
+		provider,
 		modelID,
 		scannerFingerprint,
 	)
@@ -229,7 +240,7 @@ func (s *Store) InsertFileHash(ctx context.Context, stateVersion int64, path str
 	return nil
 }
 
-func (s *Store) StageState(ctx context.Context, modelID string, scannerFingerprint string, files map[string]string) (int64, error) {
+func (s *Store) StageState(ctx context.Context, provider string, modelID string, scannerFingerprint string, files map[string]string) (int64, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("begin tx: %w", err)
@@ -242,7 +253,8 @@ func (s *Store) StageState(ctx context.Context, modelID string, scannerFingerpri
 
 	result, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO file_hash_states(model_id, scanner_fingerprint) VALUES (?, ?)`,
+		`INSERT INTO file_hash_states(provider, model_id, scanner_fingerprint) VALUES (?, ?, ?)`,
+		provider,
 		modelID,
 		scannerFingerprint,
 	)
@@ -285,28 +297,37 @@ func (s *Store) StageState(ctx context.Context, modelID string, scannerFingerpri
 	return stateVersion, nil
 }
 
-func (s *Store) ActivateState(ctx context.Context, modelID string, stateVersion int64) error {
+func (s *Store) ActivateState(ctx context.Context, provider string, modelID string, stateVersion int64) error {
+	var storedProvider string
 	var storedModelID string
 	err := s.db.QueryRowContext(
 		ctx,
-		`SELECT model_id FROM file_hash_states WHERE state_version = ?`,
+		`SELECT provider, model_id FROM file_hash_states WHERE state_version = ?`,
 		stateVersion,
-	).Scan(&storedModelID)
+	).Scan(&storedProvider, &storedModelID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("unknown state version %d", stateVersion)
 		}
 		return fmt.Errorf("select staged state: %w", err)
 	}
-	if storedModelID != modelID {
-		return fmt.Errorf("state version %d belongs to model %q, not %q", stateVersion, storedModelID, modelID)
+	if storedProvider != provider || storedModelID != modelID {
+		return fmt.Errorf(
+			"state version %d belongs to provider/model %q/%q, not %q/%q",
+			stateVersion,
+			storedProvider,
+			storedModelID,
+			provider,
+			modelID,
+		)
 	}
 
 	if _, err := s.db.ExecContext(
 		ctx,
-		`INSERT INTO current_model_states(model_id, state_version)
-		 VALUES (?, ?)
-		 ON CONFLICT(model_id) DO UPDATE SET state_version = excluded.state_version`,
+		`INSERT INTO current_model_states(provider, model_id, state_version)
+		 VALUES (?, ?, ?)
+		 ON CONFLICT(provider, model_id) DO UPDATE SET state_version = excluded.state_version`,
+		provider,
 		modelID,
 		stateVersion,
 	); err != nil {

--- a/internal/filehashdb/sqlite_test.go
+++ b/internal/filehashdb/sqlite_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+const testProvider = "llama.cpp"
+
 func TestStoreStageActivateAndCurrent(t *testing.T) {
 	t.Parallel()
 
@@ -17,7 +19,7 @@ func TestStoreStageActivateAndCurrent(t *testing.T) {
 		_ = store.Close()
 	}()
 
-	version, err := store.StageState(context.Background(), "embeddinggemma", "scan-v1", map[string]string{
+	version, err := store.StageState(context.Background(), testProvider, "embeddinggemma", "scan-v1", map[string]string{
 		"a.go": "aaa",
 		"b.go": "bbb",
 	})
@@ -28,17 +30,17 @@ func TestStoreStageActivateAndCurrent(t *testing.T) {
 		t.Fatalf("StageState() version = %d, want 1", version)
 	}
 
-	if _, ok, err := store.Current(context.Background(), "embeddinggemma"); err != nil {
+	if _, ok, err := store.Current(context.Background(), testProvider, "embeddinggemma"); err != nil {
 		t.Fatalf("Current(before activate) error: %v", err)
 	} else if ok {
 		t.Fatalf("Current(before activate) ok = true, want false")
 	}
 
-	if err := store.ActivateState(context.Background(), "embeddinggemma", version); err != nil {
+	if err := store.ActivateState(context.Background(), testProvider, "embeddinggemma", version); err != nil {
 		t.Fatalf("ActivateState() error: %v", err)
 	}
 
-	state, ok, err := store.Current(context.Background(), "embeddinggemma")
+	state, ok, err := store.Current(context.Background(), testProvider, "embeddinggemma")
 	if err != nil {
 		t.Fatalf("Current() error: %v", err)
 	}
@@ -67,17 +69,17 @@ func TestStoreMatchesAndCleanupInactiveStates(t *testing.T) {
 		_ = store.Close()
 	}()
 
-	firstVersion, err := store.StageState(context.Background(), "embeddinggemma", "scan-v1", map[string]string{
+	firstVersion, err := store.StageState(context.Background(), testProvider, "embeddinggemma", "scan-v1", map[string]string{
 		"a.go": "aaa",
 	})
 	if err != nil {
 		t.Fatalf("first StageState() error: %v", err)
 	}
-	if err := store.ActivateState(context.Background(), "embeddinggemma", firstVersion); err != nil {
+	if err := store.ActivateState(context.Background(), testProvider, "embeddinggemma", firstVersion); err != nil {
 		t.Fatalf("ActivateState(first) error: %v", err)
 	}
 
-	match, version, err := store.Matches(context.Background(), "embeddinggemma", "scan-v1", map[string]string{
+	match, version, err := store.Matches(context.Background(), testProvider, "embeddinggemma", "scan-v1", map[string]string{
 		"a.go": "aaa",
 	})
 	if err != nil {
@@ -87,7 +89,7 @@ func TestStoreMatchesAndCleanupInactiveStates(t *testing.T) {
 		t.Fatalf("Matches() = (%v, %d), want (true, 1)", match, version)
 	}
 
-	match, version, err = store.Matches(context.Background(), "embeddinggemma", "scan-v2", map[string]string{
+	match, version, err = store.Matches(context.Background(), testProvider, "embeddinggemma", "scan-v2", map[string]string{
 		"a.go": "aaa",
 	})
 	if err != nil {
@@ -97,7 +99,7 @@ func TestStoreMatchesAndCleanupInactiveStates(t *testing.T) {
 		t.Fatalf("Matches(fingerprint mismatch) = (%v, %d), want (false, 1)", match, version)
 	}
 
-	secondVersion, err := store.StageState(context.Background(), "embeddinggemma", "scan-v2", map[string]string{
+	secondVersion, err := store.StageState(context.Background(), testProvider, "embeddinggemma", "scan-v2", map[string]string{
 		"a.go": "aaa",
 		"b.go": "bbb",
 	})
@@ -108,14 +110,14 @@ func TestStoreMatchesAndCleanupInactiveStates(t *testing.T) {
 		t.Fatalf("second StageState() version = %d, want 2", secondVersion)
 	}
 
-	if err := store.ActivateState(context.Background(), "embeddinggemma", secondVersion); err != nil {
+	if err := store.ActivateState(context.Background(), testProvider, "embeddinggemma", secondVersion); err != nil {
 		t.Fatalf("ActivateState(second) error: %v", err)
 	}
 	if err := store.CleanupInactiveStates(context.Background()); err != nil {
 		t.Fatalf("CleanupInactiveStates(after activate) error: %v", err)
 	}
 
-	state, ok, err := store.Current(context.Background(), "embeddinggemma")
+	state, ok, err := store.Current(context.Background(), testProvider, "embeddinggemma")
 	if err != nil {
 		t.Fatalf("Current() error: %v", err)
 	}
@@ -141,17 +143,17 @@ func TestCleanupInactiveStatesDropsUnactivatedState(t *testing.T) {
 		_ = store.Close()
 	}()
 
-	firstVersion, err := store.StageState(context.Background(), "embeddinggemma", "scan-v1", map[string]string{
+	firstVersion, err := store.StageState(context.Background(), testProvider, "embeddinggemma", "scan-v1", map[string]string{
 		"a.go": "aaa",
 	})
 	if err != nil {
 		t.Fatalf("first StageState() error: %v", err)
 	}
-	if err := store.ActivateState(context.Background(), "embeddinggemma", firstVersion); err != nil {
+	if err := store.ActivateState(context.Background(), testProvider, "embeddinggemma", firstVersion); err != nil {
 		t.Fatalf("ActivateState(first) error: %v", err)
 	}
 
-	secondVersion, err := store.StageState(context.Background(), "embeddinggemma", "scan-v2", map[string]string{
+	secondVersion, err := store.StageState(context.Background(), testProvider, "embeddinggemma", "scan-v2", map[string]string{
 		"a.go": "aaa",
 		"b.go": "bbb",
 	})
@@ -163,11 +165,11 @@ func TestCleanupInactiveStatesDropsUnactivatedState(t *testing.T) {
 		t.Fatalf("CleanupInactiveStates() error: %v", err)
 	}
 
-	if err := store.ActivateState(context.Background(), "embeddinggemma", secondVersion); err == nil {
+	if err := store.ActivateState(context.Background(), testProvider, "embeddinggemma", secondVersion); err == nil {
 		t.Fatalf("ActivateState() succeeded for cleaned-up inactive state")
 	}
 
-	state, ok, err := store.Current(context.Background(), "embeddinggemma")
+	state, ok, err := store.Current(context.Background(), testProvider, "embeddinggemma")
 	if err != nil {
 		t.Fatalf("Current() error: %v", err)
 	}
@@ -187,12 +189,12 @@ func TestActivateStateRejectsWrongModel(t *testing.T) {
 		_ = store.Close()
 	}()
 
-	version, err := store.StageState(context.Background(), "embeddinggemma", "scan-v1", map[string]string{"a.go": "aaa"})
+	version, err := store.StageState(context.Background(), testProvider, "embeddinggemma", "scan-v1", map[string]string{"a.go": "aaa"})
 	if err != nil {
 		t.Fatalf("StageState() error: %v", err)
 	}
 
-	if err := store.ActivateState(context.Background(), "qwen3", version); err == nil {
+	if err := store.ActivateState(context.Background(), testProvider, "qwen3", version); err == nil {
 		t.Fatalf("ActivateState() succeeded with wrong model")
 	}
 }

--- a/internal/indexdb/hash.go
+++ b/internal/indexdb/hash.go
@@ -34,6 +34,7 @@ func LogicalHash(ctx context.Context, dbPath string) (string, error) {
 	rows, err := db.QueryContext(
 		ctx,
 		`SELECT
+			cs.provider,
 			cs.model_id,
 			s.path,
 			s.line,
@@ -49,12 +50,14 @@ func LogicalHash(ctx context.Context, dbPath string) (string, error) {
 			e.embedding
 		FROM current_model_snapshots cs
 		JOIN snapshot_symbols s
-		  ON s.model_id = cs.model_id
+		  ON s.provider = cs.provider
+		 AND s.model_id = cs.model_id
 		 AND s.snapshot_id = cs.snapshot_id
 		JOIN snapshot_embeddings e
-		  ON e.model_id = s.model_id
+		  ON e.provider = s.provider
+		 AND e.model_id = s.model_id
 		 AND e.embedding_hash = s.embedding_hash
-		ORDER BY cs.model_id ASC, s.path ASC, s.line ASC, s.symbol_id ASC`,
+		ORDER BY cs.provider ASC, cs.model_id ASC, s.path ASC, s.line ASC, s.symbol_id ASC`,
 	)
 	if err != nil {
 		if isSchemaQueryError(err) {
@@ -67,9 +70,10 @@ func LogicalHash(ctx context.Context, dbPath string) (string, error) {
 	}()
 
 	sum := sha256.New()
-	writeHashBytes(sum, []byte("semsearch-logical-index-v2"))
+	writeHashBytes(sum, []byte("semsearch-logical-index-v3"))
 
 	for rows.Next() {
+		var provider string
 		var modelID string
 		var path string
 		var line int64
@@ -84,6 +88,7 @@ func LogicalHash(ctx context.Context, dbPath string) (string, error) {
 		var embeddingHash string
 		var embedding []byte
 		if err := rows.Scan(
+			&provider,
 			&modelID,
 			&path,
 			&line,
@@ -101,6 +106,7 @@ func LogicalHash(ctx context.Context, dbPath string) (string, error) {
 			return "", fmt.Errorf("scan logical hash row: %w", err)
 		}
 
+		writeHashString(sum, provider)
 		writeHashString(sum, modelID)
 		writeHashString(sum, path)
 		writeHashInt64(sum, line)

--- a/internal/indexdb/sqlite.go
+++ b/internal/indexdb/sqlite.go
@@ -10,6 +10,8 @@ import (
 	"github.com/uchebnick/unch/internal/search"
 )
 
+const SchemaVersion = 1
+
 var ErrNoActiveSnapshot = errors.New("no active snapshot for model")
 
 // Store wraps the SQLite connection and vector dimension used by the index database.
@@ -49,27 +51,52 @@ func (s *Store) Close() error {
 }
 
 func (s *Store) init(ctx context.Context) error {
+	var userVersion int
+	if err := s.db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&userVersion); err != nil {
+		return fmt.Errorf("read schema version: %w", err)
+	}
+
+	switch userVersion {
+	case 0:
+		hasSchema, err := s.hasSchemaObjects(ctx)
+		if err != nil {
+			return err
+		}
+		if hasSchema {
+			if err := s.resetSchema(ctx); err != nil {
+				return fmt.Errorf("reset legacy schema: %w", err)
+			}
+		}
+	case SchemaVersion:
+	default:
+		return fmt.Errorf("unsupported schema version %d", userVersion)
+	}
+
 	stmts := []string{
 		`
 		CREATE TABLE IF NOT EXISTS index_snapshots (
 			snapshot_id INTEGER PRIMARY KEY AUTOINCREMENT,
+			provider TEXT NOT NULL,
 			model_id TEXT NOT NULL,
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);
 		`,
 		`
-		CREATE INDEX IF NOT EXISTS idx_index_snapshots_model_id
-		ON index_snapshots(model_id, snapshot_id);
+		CREATE INDEX IF NOT EXISTS idx_index_snapshots_provider_model_id
+		ON index_snapshots(provider, model_id, snapshot_id);
 		`,
 		`
 		CREATE TABLE IF NOT EXISTS current_model_snapshots (
-			model_id TEXT PRIMARY KEY,
-			snapshot_id INTEGER NOT NULL
+			provider TEXT NOT NULL,
+			model_id TEXT NOT NULL,
+			snapshot_id INTEGER NOT NULL,
+			PRIMARY KEY (provider, model_id)
 		);
 		`,
 		`
 		CREATE TABLE IF NOT EXISTS snapshot_symbols (
 			snapshot_id INTEGER NOT NULL,
+			provider TEXT NOT NULL,
 			model_id TEXT NOT NULL,
 			path TEXT NOT NULL,
 			line INTEGER NOT NULL,
@@ -90,17 +117,18 @@ func (s *Store) init(ctx context.Context) error {
 		ON snapshot_symbols(snapshot_id);
 		`,
 		`
-		CREATE INDEX IF NOT EXISTS idx_snapshot_symbols_model_id
-		ON snapshot_symbols(model_id, snapshot_id);
+		CREATE INDEX IF NOT EXISTS idx_snapshot_symbols_provider_model_id
+		ON snapshot_symbols(provider, model_id, snapshot_id);
 		`,
 		`
 		CREATE INDEX IF NOT EXISTS idx_snapshot_symbols_embedding_hash
-		ON snapshot_symbols(model_id, embedding_hash);
+		ON snapshot_symbols(provider, model_id, embedding_hash);
 		`,
 		`
 		CREATE INDEX IF NOT EXISTS idx_snapshot_symbols_qualified_name
-		ON snapshot_symbols(model_id, qualified_name);
+		ON snapshot_symbols(provider, model_id, qualified_name);
 		`,
+		fmt.Sprintf(`PRAGMA user_version = %d`, SchemaVersion),
 	}
 
 	for _, stmt := range stmts {
@@ -112,6 +140,7 @@ func (s *Store) init(ctx context.Context) error {
 	vecStmt := fmt.Sprintf(`
 		CREATE VIRTUAL TABLE IF NOT EXISTS snapshot_embeddings USING vec0(
 			embedding_key TEXT PRIMARY KEY,
+			provider TEXT NOT NULL,
 			model_id TEXT NOT NULL,
 			embedding_hash TEXT NOT NULL,
 			embedding FLOAT[%d]
@@ -124,9 +153,39 @@ func (s *Store) init(ctx context.Context) error {
 	return nil
 }
 
-// BeginSnapshot creates a new immutable snapshot id for one model family.
-func (s *Store) BeginSnapshot(ctx context.Context, modelID string) (int64, error) {
-	result, err := s.db.ExecContext(ctx, `INSERT INTO index_snapshots(model_id) VALUES (?)`, modelID)
+func (s *Store) hasSchemaObjects(ctx context.Context) (bool, error) {
+	var count int
+	if err := s.db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(1)
+		 FROM sqlite_master
+		 WHERE type = 'table'
+		   AND name IN ('index_snapshots', 'current_model_snapshots', 'snapshot_symbols', 'snapshot_embeddings')`,
+	).Scan(&count); err != nil {
+		return false, fmt.Errorf("inspect schema: %w", err)
+	}
+	return count > 0, nil
+}
+
+func (s *Store) resetSchema(ctx context.Context) error {
+	stmts := []string{
+		`DROP TABLE IF EXISTS current_model_snapshots;`,
+		`DROP TABLE IF EXISTS snapshot_symbols;`,
+		`DROP TABLE IF EXISTS snapshot_embeddings;`,
+		`DROP TABLE IF EXISTS index_snapshots;`,
+		`PRAGMA user_version = 0`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.db.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// BeginSnapshot creates a new immutable snapshot id for one provider/model family.
+func (s *Store) BeginSnapshot(ctx context.Context, provider string, modelID string) (int64, error) {
+	result, err := s.db.ExecContext(ctx, `INSERT INTO index_snapshots(provider, model_id) VALUES (?, ?)`, provider, modelID)
 	if err != nil {
 		return 0, fmt.Errorf("insert snapshot: %w", err)
 	}
@@ -137,26 +196,27 @@ func (s *Store) BeginSnapshot(ctx context.Context, modelID string) (int64, error
 	return snapshotID, nil
 }
 
-// CurrentSnapshot returns the active snapshot for one model family.
-func (s *Store) CurrentSnapshot(ctx context.Context, modelID string) (int64, error) {
+// CurrentSnapshot returns the active snapshot for one provider/model family.
+func (s *Store) CurrentSnapshot(ctx context.Context, provider string, modelID string) (int64, error) {
 	var snapshotID int64
 	err := s.db.QueryRowContext(
 		ctx,
-		`SELECT snapshot_id FROM current_model_snapshots WHERE model_id = ?`,
+		`SELECT snapshot_id FROM current_model_snapshots WHERE provider = ? AND model_id = ?`,
+		provider,
 		modelID,
 	).Scan(&snapshotID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return 0, fmt.Errorf("%w: %s", ErrNoActiveSnapshot, modelID)
+			return 0, fmt.Errorf("%w: %s/%s", ErrNoActiveSnapshot, provider, modelID)
 		}
 		return 0, fmt.Errorf("select current snapshot: %w", err)
 	}
 	return snapshotID, nil
 }
 
-// CurrentSnapshotIfAny returns the active snapshot for one model family when present.
-func (s *Store) CurrentSnapshotIfAny(ctx context.Context, modelID string) (int64, bool, error) {
-	snapshotID, err := s.CurrentSnapshot(ctx, modelID)
+// CurrentSnapshotIfAny returns the active snapshot for one provider/model family when present.
+func (s *Store) CurrentSnapshotIfAny(ctx context.Context, provider string, modelID string) (int64, bool, error) {
+	snapshotID, err := s.CurrentSnapshot(ctx, provider, modelID)
 	if err != nil {
 		if errors.Is(err, ErrNoActiveSnapshot) {
 			return 0, false, nil
@@ -166,13 +226,14 @@ func (s *Store) CurrentSnapshotIfAny(ctx context.Context, modelID string) (int64
 	return snapshotID, true, nil
 }
 
-// ActivateSnapshot marks one snapshot as the active searchable snapshot for its model family.
-func (s *Store) ActivateSnapshot(ctx context.Context, modelID string, snapshotID int64) error {
+// ActivateSnapshot marks one snapshot as the active searchable snapshot for its provider/model family.
+func (s *Store) ActivateSnapshot(ctx context.Context, provider string, modelID string, snapshotID int64) error {
 	_, err := s.db.ExecContext(
 		ctx,
-		`INSERT INTO current_model_snapshots(model_id, snapshot_id)
-		VALUES (?, ?)
-		ON CONFLICT(model_id) DO UPDATE SET snapshot_id = excluded.snapshot_id`,
+		`INSERT INTO current_model_snapshots(provider, model_id, snapshot_id)
+		VALUES (?, ?, ?)
+		ON CONFLICT(provider, model_id) DO UPDATE SET snapshot_id = excluded.snapshot_id`,
+		provider,
 		modelID,
 		snapshotID,
 	)
@@ -182,13 +243,13 @@ func (s *Store) ActivateSnapshot(ctx context.Context, modelID string, snapshotID
 	return nil
 }
 
-// EmbeddingExists reports whether the vector table already contains the given embedding hash for one model.
-func (s *Store) EmbeddingExists(ctx context.Context, modelID string, embeddingHash string) (bool, error) {
+// EmbeddingExists reports whether the vector table already contains the given embedding hash for one provider/model family.
+func (s *Store) EmbeddingExists(ctx context.Context, provider string, modelID string, embeddingHash string) (bool, error) {
 	var exists int
 	err := s.db.QueryRowContext(
 		ctx,
 		`SELECT 1 FROM snapshot_embeddings WHERE embedding_key = ? LIMIT 1`,
-		embeddingKey(modelID, embeddingHash),
+		embeddingKey(provider, modelID, embeddingHash),
 	).Scan(&exists)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -199,8 +260,8 @@ func (s *Store) EmbeddingExists(ctx context.Context, modelID string, embeddingHa
 	return true, nil
 }
 
-// AddEmbedding stores a new embedding vector under its content hash for one model family.
-func (s *Store) AddEmbedding(ctx context.Context, modelID string, embeddingHash string, embedding []float32) error {
+// AddEmbedding stores a new embedding vector under its content hash for one provider/model family.
+func (s *Store) AddEmbedding(ctx context.Context, provider string, modelID string, embeddingHash string, embedding []float32) error {
 	if len(embedding) != s.dim {
 		return fmt.Errorf("invalid embedding dimension: got=%d want=%d", len(embedding), s.dim)
 	}
@@ -212,8 +273,9 @@ func (s *Store) AddEmbedding(ctx context.Context, modelID string, embeddingHash 
 
 	_, err = s.db.ExecContext(
 		ctx,
-		`INSERT INTO snapshot_embeddings(embedding_key, model_id, embedding_hash, embedding) VALUES (?, ?, ?, ?)`,
-		embeddingKey(modelID, embeddingHash),
+		`INSERT INTO snapshot_embeddings(embedding_key, provider, model_id, embedding_hash, embedding) VALUES (?, ?, ?, ?, ?)`,
+		embeddingKey(provider, modelID, embeddingHash),
+		provider,
 		modelID,
 		embeddingHash,
 		vec,
@@ -225,11 +287,12 @@ func (s *Store) AddEmbedding(ctx context.Context, modelID string, embeddingHash 
 }
 
 // InsertSymbol stores one symbol row inside a building snapshot without mutating active snapshots.
-func (s *Store) InsertSymbol(ctx context.Context, snapshotID int64, modelID string, path string, symbol indexing.IndexedSymbol, embeddingHash string) error {
+func (s *Store) InsertSymbol(ctx context.Context, snapshotID int64, provider string, modelID string, path string, symbol indexing.IndexedSymbol, embeddingHash string) error {
 	_, err := s.db.ExecContext(
 		ctx,
 		`INSERT INTO snapshot_symbols(
 			snapshot_id,
+			provider,
 			model_id,
 			path,
 			line,
@@ -243,8 +306,9 @@ func (s *Store) InsertSymbol(ctx context.Context, snapshotID int64, modelID stri
 			body,
 			embedding_hash
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		snapshotID,
+		provider,
 		modelID,
 		path,
 		symbol.Line,
@@ -265,11 +329,12 @@ func (s *Store) InsertSymbol(ctx context.Context, snapshotID int64, modelID stri
 }
 
 // CopyPathFromSnapshot copies all symbol rows for one path from an existing snapshot into a building snapshot.
-func (s *Store) CopyPathFromSnapshot(ctx context.Context, modelID string, srcSnapshotID, dstSnapshotID int64, path string) (int, error) {
+func (s *Store) CopyPathFromSnapshot(ctx context.Context, provider string, modelID string, srcSnapshotID, dstSnapshotID int64, path string) (int, error) {
 	result, err := s.db.ExecContext(
 		ctx,
 		`INSERT INTO snapshot_symbols(
 			snapshot_id,
+			provider,
 			model_id,
 			path,
 			line,
@@ -285,6 +350,7 @@ func (s *Store) CopyPathFromSnapshot(ctx context.Context, modelID string, srcSna
 		)
 		SELECT
 			?,
+			provider,
 			model_id,
 			path,
 			line,
@@ -298,10 +364,12 @@ func (s *Store) CopyPathFromSnapshot(ctx context.Context, modelID string, srcSna
 			body,
 			embedding_hash
 		FROM snapshot_symbols
-		WHERE model_id = ?
+		WHERE provider = ?
+		  AND model_id = ?
 		  AND snapshot_id = ?
 		  AND path = ?`,
 		dstSnapshotID,
+		provider,
 		modelID,
 		srcSnapshotID,
 		path,
@@ -341,7 +409,7 @@ func (s *Store) CleanupUnusedEmbeddings(ctx context.Context) error {
 		ctx,
 		`DELETE FROM snapshot_embeddings
 		WHERE embedding_key NOT IN (
-			SELECT DISTINCT model_id || ':' || embedding_hash FROM snapshot_symbols
+			SELECT DISTINCT provider || '|' || model_id || '|' || embedding_hash FROM snapshot_symbols
 		)`,
 	)
 	if err != nil {
@@ -351,7 +419,7 @@ func (s *Store) CleanupUnusedEmbeddings(ctx context.Context) error {
 }
 
 // SearchBySnapshot performs semantic nearest-neighbor search against one immutable snapshot.
-func (s *Store) SearchBySnapshot(ctx context.Context, modelID string, snapshotID int64, queryEmbedding []float32, limit int) ([]search.SearchResult, error) {
+func (s *Store) SearchBySnapshot(ctx context.Context, provider string, modelID string, snapshotID int64, queryEmbedding []float32, limit int) ([]search.SearchResult, error) {
 	if len(queryEmbedding) != s.dim {
 		return nil, fmt.Errorf("invalid query dimension: got=%d want=%d", len(queryEmbedding), s.dim)
 	}
@@ -380,15 +448,18 @@ func (s *Store) SearchBySnapshot(ctx context.Context, modelID string, snapshotID
 			e.distance
 		FROM snapshot_embeddings e
 		JOIN snapshot_symbols s
-		  ON s.model_id = e.model_id
+		  ON s.provider = e.provider
+		 AND s.model_id = e.model_id
 		 AND s.embedding_hash = e.embedding_hash
 		WHERE e.embedding MATCH ?
 		  AND k = ?
+		  AND s.provider = ?
 		  AND s.model_id = ?
 		  AND s.snapshot_id = ?
 		ORDER BY e.distance ASC`,
 		queryVec,
 		limit,
+		provider,
 		modelID,
 		snapshotID,
 	)
@@ -426,17 +497,17 @@ func (s *Store) SearchBySnapshot(ctx context.Context, modelID string, snapshotID
 	return results, nil
 }
 
-// SearchCurrent performs semantic nearest-neighbor search against the active snapshot for one model.
-func (s *Store) SearchCurrent(ctx context.Context, modelID string, queryEmbedding []float32, limit int) ([]search.SearchResult, error) {
-	snapshotID, err := s.CurrentSnapshot(ctx, modelID)
+// SearchCurrent performs semantic nearest-neighbor search against the active snapshot for one provider/model family.
+func (s *Store) SearchCurrent(ctx context.Context, provider string, modelID string, queryEmbedding []float32, limit int) ([]search.SearchResult, error) {
+	snapshotID, err := s.CurrentSnapshot(ctx, provider, modelID)
 	if err != nil {
 		return nil, err
 	}
-	return s.SearchBySnapshot(ctx, modelID, snapshotID, queryEmbedding, limit)
+	return s.SearchBySnapshot(ctx, provider, modelID, snapshotID, queryEmbedding, limit)
 }
 
 // ListSymbolsBySnapshot returns all symbols stored in one immutable snapshot.
-func (s *Store) ListSymbolsBySnapshot(ctx context.Context, modelID string, snapshotID int64) ([]search.SearchResult, error) {
+func (s *Store) ListSymbolsBySnapshot(ctx context.Context, provider string, modelID string, snapshotID int64) ([]search.SearchResult, error) {
 	rows, err := s.db.QueryContext(
 		ctx,
 		`SELECT
@@ -451,9 +522,11 @@ func (s *Store) ListSymbolsBySnapshot(ctx context.Context, modelID string, snaps
 			documentation,
 			body
 		FROM snapshot_symbols
-		WHERE model_id = ?
+		WHERE provider = ?
+		  AND model_id = ?
 		  AND snapshot_id = ?
 		ORDER BY path ASC, line ASC, qualified_name ASC`,
+		provider,
 		modelID,
 		snapshotID,
 	)
@@ -489,15 +562,15 @@ func (s *Store) ListSymbolsBySnapshot(ctx context.Context, modelID string, snaps
 	return results, nil
 }
 
-// ListCurrentSymbols returns all symbols from the active snapshot for one model family.
-func (s *Store) ListCurrentSymbols(ctx context.Context, modelID string) ([]search.SearchResult, error) {
-	snapshotID, err := s.CurrentSnapshot(ctx, modelID)
+// ListCurrentSymbols returns all symbols from the active snapshot for one provider/model family.
+func (s *Store) ListCurrentSymbols(ctx context.Context, provider string, modelID string) ([]search.SearchResult, error) {
+	snapshotID, err := s.CurrentSnapshot(ctx, provider, modelID)
 	if err != nil {
 		return nil, err
 	}
-	return s.ListSymbolsBySnapshot(ctx, modelID, snapshotID)
+	return s.ListSymbolsBySnapshot(ctx, provider, modelID, snapshotID)
 }
 
-func embeddingKey(modelID string, embeddingHash string) string {
-	return modelID + ":" + embeddingHash
+func embeddingKey(provider string, modelID string, embeddingHash string) string {
+	return provider + "|" + modelID + "|" + embeddingHash
 }

--- a/internal/indexdb/sqlite_test.go
+++ b/internal/indexdb/sqlite_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/uchebnick/unch/internal/indexing"
 )
 
+const testProvider = "llama.cpp"
+
 func TestStoreLifecycle(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "index.db")
@@ -24,23 +26,23 @@ func TestStoreLifecycle(t *testing.T) {
 
 	const modelID = "embeddinggemma"
 
-	snapshot1, err := store.BeginSnapshot(ctx, modelID)
+	snapshot1, err := store.BeginSnapshot(ctx, testProvider, modelID)
 	if err != nil {
 		t.Fatalf("BeginSnapshot() error: %v", err)
 	}
-	snapshot2, err := store.BeginSnapshot(ctx, "qwen3")
+	snapshot2, err := store.BeginSnapshot(ctx, testProvider, "qwen3")
 	if err != nil {
 		t.Fatalf("BeginSnapshot(qwen3) error: %v", err)
 	}
 
 	vec := []float32{1, 0, 0}
-	if err := store.AddEmbedding(ctx, modelID, "hash1", vec); err != nil {
+	if err := store.AddEmbedding(ctx, testProvider, modelID, "hash1", vec); err != nil {
 		t.Fatalf("AddEmbedding(hash1) error: %v", err)
 	}
-	if err := store.AddEmbedding(ctx, "qwen3", "hash2", []float32{0, 1, 0}); err != nil {
+	if err := store.AddEmbedding(ctx, testProvider, "qwen3", "hash2", []float32{0, 1, 0}); err != nil {
 		t.Fatalf("AddEmbedding(hash2) error: %v", err)
 	}
-	if err := store.InsertSymbol(ctx, snapshot1, modelID, "a.go", indexing.IndexedSymbol{
+	if err := store.InsertSymbol(ctx, snapshot1, testProvider, modelID, "a.go", indexing.IndexedSymbol{
 		Line:          10,
 		Kind:          "function",
 		Name:          "A",
@@ -50,7 +52,7 @@ func TestStoreLifecycle(t *testing.T) {
 	}, "hash1"); err != nil {
 		t.Fatalf("InsertSymbol(hash1) error: %v", err)
 	}
-	if err := store.InsertSymbol(ctx, snapshot2, "qwen3", "b.go", indexing.IndexedSymbol{
+	if err := store.InsertSymbol(ctx, snapshot2, testProvider, "qwen3", "b.go", indexing.IndexedSymbol{
 		Line:          20,
 		Kind:          "function",
 		Name:          "B",
@@ -60,21 +62,21 @@ func TestStoreLifecycle(t *testing.T) {
 	}, "hash2"); err != nil {
 		t.Fatalf("InsertSymbol(hash2) error: %v", err)
 	}
-	if err := store.ActivateSnapshot(ctx, modelID, snapshot1); err != nil {
+	if err := store.ActivateSnapshot(ctx, testProvider, modelID, snapshot1); err != nil {
 		t.Fatalf("ActivateSnapshot() error: %v", err)
 	}
 
-	currentSnapshot, err := store.CurrentSnapshot(ctx, modelID)
+	currentSnapshot, err := store.CurrentSnapshot(ctx, testProvider, modelID)
 	if err != nil || currentSnapshot != snapshot1 {
 		t.Fatalf("CurrentSnapshot() = (%d, %v), want (%d, nil)", currentSnapshot, err, snapshot1)
 	}
 
-	exists, err := store.EmbeddingExists(ctx, modelID, "hash1")
+	exists, err := store.EmbeddingExists(ctx, testProvider, modelID, "hash1")
 	if err != nil || !exists {
 		t.Fatalf("EmbeddingExists(hash1) = (%v, %v)", exists, err)
 	}
 
-	listed, err := store.ListCurrentSymbols(ctx, modelID)
+	listed, err := store.ListCurrentSymbols(ctx, testProvider, modelID)
 	if err != nil {
 		t.Fatalf("ListCurrentSymbols() error: %v", err)
 	}
@@ -82,7 +84,7 @@ func TestStoreLifecycle(t *testing.T) {
 		t.Fatalf("ListCurrentSymbols() = %+v", listed)
 	}
 
-	results, err := store.SearchCurrent(ctx, modelID, vec, 5)
+	results, err := store.SearchCurrent(ctx, testProvider, modelID, vec, 5)
 	if err != nil {
 		t.Fatalf("SearchCurrent() error: %v", err)
 	}
@@ -90,7 +92,7 @@ func TestStoreLifecycle(t *testing.T) {
 		t.Fatalf("SearchCurrent() = %+v", results)
 	}
 
-	if _, err := store.ListCurrentSymbols(ctx, "qwen3"); !errors.Is(err, ErrNoActiveSnapshot) {
+	if _, err := store.ListCurrentSymbols(ctx, testProvider, "qwen3"); !errors.Is(err, ErrNoActiveSnapshot) {
 		t.Fatalf("ListCurrentSymbols(qwen3) error = %v, want ErrNoActiveSnapshot", err)
 	}
 
@@ -100,7 +102,7 @@ func TestStoreLifecycle(t *testing.T) {
 	if err := store.CleanupUnusedEmbeddings(ctx); err != nil {
 		t.Fatalf("CleanupUnusedEmbeddings() error: %v", err)
 	}
-	exists, err = store.EmbeddingExists(ctx, "qwen3", "hash2")
+	exists, err = store.EmbeddingExists(ctx, testProvider, "qwen3", "hash2")
 	if err != nil {
 		t.Fatalf("EmbeddingExists(hash2) error: %v", err)
 	}
@@ -121,14 +123,14 @@ func TestActiveSnapshotIsolationAcrossModels(t *testing.T) {
 		_ = store.Close()
 	}()
 
-	if err := store.AddEmbedding(ctx, "embeddinggemma", "hash-gemma", []float32{1, 0, 0}); err != nil {
+	if err := store.AddEmbedding(ctx, testProvider, "embeddinggemma", "hash-gemma", []float32{1, 0, 0}); err != nil {
 		t.Fatalf("AddEmbedding(gemma) error: %v", err)
 	}
-	gemmaSnapshot, err := store.BeginSnapshot(ctx, "embeddinggemma")
+	gemmaSnapshot, err := store.BeginSnapshot(ctx, testProvider, "embeddinggemma")
 	if err != nil {
 		t.Fatalf("BeginSnapshot(gemma) error: %v", err)
 	}
-	if err := store.InsertSymbol(ctx, gemmaSnapshot, "embeddinggemma", "a.go", indexing.IndexedSymbol{
+	if err := store.InsertSymbol(ctx, gemmaSnapshot, testProvider, "embeddinggemma", "a.go", indexing.IndexedSymbol{
 		Line:          10,
 		Kind:          "function",
 		Name:          "A",
@@ -136,18 +138,18 @@ func TestActiveSnapshotIsolationAcrossModels(t *testing.T) {
 	}, "hash-gemma"); err != nil {
 		t.Fatalf("InsertSymbol(gemma) error: %v", err)
 	}
-	if err := store.ActivateSnapshot(ctx, "embeddinggemma", gemmaSnapshot); err != nil {
+	if err := store.ActivateSnapshot(ctx, testProvider, "embeddinggemma", gemmaSnapshot); err != nil {
 		t.Fatalf("ActivateSnapshot(gemma) error: %v", err)
 	}
 
-	qwenSnapshot, err := store.BeginSnapshot(ctx, "qwen3")
+	qwenSnapshot, err := store.BeginSnapshot(ctx, testProvider, "qwen3")
 	if err != nil {
 		t.Fatalf("BeginSnapshot(qwen3) error: %v", err)
 	}
-	if err := store.AddEmbedding(ctx, "qwen3", "hash-qwen", []float32{0, 1, 0}); err != nil {
+	if err := store.AddEmbedding(ctx, testProvider, "qwen3", "hash-qwen", []float32{0, 1, 0}); err != nil {
 		t.Fatalf("AddEmbedding(qwen3) error: %v", err)
 	}
-	if err := store.InsertSymbol(ctx, qwenSnapshot, "qwen3", "b.go", indexing.IndexedSymbol{
+	if err := store.InsertSymbol(ctx, qwenSnapshot, testProvider, "qwen3", "b.go", indexing.IndexedSymbol{
 		Line:          20,
 		Kind:          "function",
 		Name:          "B",
@@ -156,7 +158,7 @@ func TestActiveSnapshotIsolationAcrossModels(t *testing.T) {
 		t.Fatalf("InsertSymbol(qwen3) error: %v", err)
 	}
 
-	listed, err := store.ListCurrentSymbols(ctx, "embeddinggemma")
+	listed, err := store.ListCurrentSymbols(ctx, testProvider, "embeddinggemma")
 	if err != nil {
 		t.Fatalf("ListCurrentSymbols(gemma) error: %v", err)
 	}
@@ -179,7 +181,7 @@ func TestLogicalHashIgnoresSnapshotOnlyChanges(t *testing.T) {
 
 	modelID := "embeddinggemma"
 	vec := []float32{1, 0, 0}
-	if err := store.AddEmbedding(ctx, modelID, "hash1", vec); err != nil {
+	if err := store.AddEmbedding(ctx, testProvider, modelID, "hash1", vec); err != nil {
 		t.Fatalf("AddEmbedding() error: %v", err)
 	}
 	symbol := indexing.IndexedSymbol{
@@ -191,14 +193,14 @@ func TestLogicalHashIgnoresSnapshotOnlyChanges(t *testing.T) {
 		Documentation: "A docs",
 	}
 
-	firstSnapshot, err := store.BeginSnapshot(ctx, modelID)
+	firstSnapshot, err := store.BeginSnapshot(ctx, testProvider, modelID)
 	if err != nil {
 		t.Fatalf("BeginSnapshot(first) error: %v", err)
 	}
-	if err := store.InsertSymbol(ctx, firstSnapshot, modelID, "a.go", symbol, "hash1"); err != nil {
+	if err := store.InsertSymbol(ctx, firstSnapshot, testProvider, modelID, "a.go", symbol, "hash1"); err != nil {
 		t.Fatalf("InsertSymbol(first) error: %v", err)
 	}
-	if err := store.ActivateSnapshot(ctx, modelID, firstSnapshot); err != nil {
+	if err := store.ActivateSnapshot(ctx, testProvider, modelID, firstSnapshot); err != nil {
 		t.Fatalf("ActivateSnapshot(first) error: %v", err)
 	}
 
@@ -207,14 +209,14 @@ func TestLogicalHashIgnoresSnapshotOnlyChanges(t *testing.T) {
 		t.Fatalf("LogicalHash(first) error: %v", err)
 	}
 
-	secondSnapshot, err := store.BeginSnapshot(ctx, modelID)
+	secondSnapshot, err := store.BeginSnapshot(ctx, testProvider, modelID)
 	if err != nil {
 		t.Fatalf("BeginSnapshot(second) error: %v", err)
 	}
-	if err := store.InsertSymbol(ctx, secondSnapshot, modelID, "a.go", symbol, "hash1"); err != nil {
+	if err := store.InsertSymbol(ctx, secondSnapshot, testProvider, modelID, "a.go", symbol, "hash1"); err != nil {
 		t.Fatalf("InsertSymbol(second) error: %v", err)
 	}
-	if err := store.ActivateSnapshot(ctx, modelID, secondSnapshot); err != nil {
+	if err := store.ActivateSnapshot(ctx, testProvider, modelID, secondSnapshot); err != nil {
 		t.Fatalf("ActivateSnapshot(second) error: %v", err)
 	}
 
@@ -282,15 +284,15 @@ func TestCopyPathFromSnapshot(t *testing.T) {
 	}()
 
 	modelID := "embeddinggemma"
-	if err := store.AddEmbedding(ctx, modelID, "hash-a", []float32{1, 0, 0}); err != nil {
+	if err := store.AddEmbedding(ctx, testProvider, modelID, "hash-a", []float32{1, 0, 0}); err != nil {
 		t.Fatalf("AddEmbedding() error: %v", err)
 	}
 
-	srcSnapshot, err := store.BeginSnapshot(ctx, modelID)
+	srcSnapshot, err := store.BeginSnapshot(ctx, testProvider, modelID)
 	if err != nil {
 		t.Fatalf("BeginSnapshot(src) error: %v", err)
 	}
-	if err := store.InsertSymbol(ctx, srcSnapshot, modelID, "a.go", indexing.IndexedSymbol{
+	if err := store.InsertSymbol(ctx, srcSnapshot, testProvider, modelID, "a.go", indexing.IndexedSymbol{
 		Line:          10,
 		Kind:          "function",
 		Name:          "A",
@@ -298,15 +300,15 @@ func TestCopyPathFromSnapshot(t *testing.T) {
 	}, "hash-a"); err != nil {
 		t.Fatalf("InsertSymbol(src) error: %v", err)
 	}
-	if err := store.ActivateSnapshot(ctx, modelID, srcSnapshot); err != nil {
+	if err := store.ActivateSnapshot(ctx, testProvider, modelID, srcSnapshot); err != nil {
 		t.Fatalf("ActivateSnapshot(src) error: %v", err)
 	}
 
-	dstSnapshot, err := store.BeginSnapshot(ctx, modelID)
+	dstSnapshot, err := store.BeginSnapshot(ctx, testProvider, modelID)
 	if err != nil {
 		t.Fatalf("BeginSnapshot(dst) error: %v", err)
 	}
-	copied, err := store.CopyPathFromSnapshot(ctx, modelID, srcSnapshot, dstSnapshot, "a.go")
+	copied, err := store.CopyPathFromSnapshot(ctx, testProvider, modelID, srcSnapshot, dstSnapshot, "a.go")
 	if err != nil {
 		t.Fatalf("CopyPathFromSnapshot() error: %v", err)
 	}
@@ -314,7 +316,7 @@ func TestCopyPathFromSnapshot(t *testing.T) {
 		t.Fatalf("CopyPathFromSnapshot() copied = %d, want 1", copied)
 	}
 
-	listed, err := store.ListSymbolsBySnapshot(ctx, modelID, dstSnapshot)
+	listed, err := store.ListSymbolsBySnapshot(ctx, testProvider, modelID, dstSnapshot)
 	if err != nil {
 		t.Fatalf("ListSymbolsBySnapshot(dst) error: %v", err)
 	}

--- a/internal/indexing/service.go
+++ b/internal/indexing/service.go
@@ -15,13 +15,13 @@ type Scanner interface {
 }
 
 type Repository interface {
-	BeginSnapshot(ctx context.Context, modelID string) (int64, error)
-	CurrentSnapshotIfAny(ctx context.Context, modelID string) (int64, bool, error)
-	ActivateSnapshot(ctx context.Context, modelID string, snapshotID int64) error
-	EmbeddingExists(ctx context.Context, modelID string, embeddingHash string) (bool, error)
-	AddEmbedding(ctx context.Context, modelID string, embeddingHash string, embedding []float32) error
-	InsertSymbol(ctx context.Context, snapshotID int64, modelID string, path string, symbol IndexedSymbol, embeddingHash string) error
-	CopyPathFromSnapshot(ctx context.Context, modelID string, srcSnapshotID, dstSnapshotID int64, path string) (int, error)
+	BeginSnapshot(ctx context.Context, provider string, modelID string) (int64, error)
+	CurrentSnapshotIfAny(ctx context.Context, provider string, modelID string) (int64, bool, error)
+	ActivateSnapshot(ctx context.Context, provider string, modelID string, snapshotID int64) error
+	EmbeddingExists(ctx context.Context, provider string, modelID string, embeddingHash string) (bool, error)
+	AddEmbedding(ctx context.Context, provider string, modelID string, embeddingHash string, embedding []float32) error
+	InsertSymbol(ctx context.Context, snapshotID int64, provider string, modelID string, path string, symbol IndexedSymbol, embeddingHash string) error
+	CopyPathFromSnapshot(ctx context.Context, provider string, modelID string, srcSnapshotID, dstSnapshotID int64, path string) (int, error)
 	CleanupInactiveSnapshots(ctx context.Context) error
 	CleanupUnusedEmbeddings(ctx context.Context) error
 }
@@ -41,6 +41,7 @@ type Params struct {
 	Excludes             []string
 	ContextPrefix        string
 	CommentPrefix        string
+	Provider             string
 	ModelID              string
 	CurrentFileHashes    map[string]string
 	FileHashStateVersion int64
@@ -64,6 +65,7 @@ type runState struct {
 	ctx                context.Context
 	params             Params
 	reporter           Reporter
+	provider           string
 	modelID            string
 	currentSnapshotID  int64
 	hasCurrentSnapshot bool
@@ -77,21 +79,26 @@ type runState struct {
 
 // Run scans the repository, embeds extracted symbols, and activates the new index version.
 func (s Service) Run(ctx context.Context, params Params, reporter Reporter) (Result, error) {
+	provider := params.Provider
+	if provider == "" {
+		provider = "llama.cpp"
+	}
 	modelID := params.ModelID
 	if modelID == "" {
 		modelID = "embeddinggemma"
 	}
 
-	currentSnapshotID, hasCurrentSnapshot, err := s.Repo.CurrentSnapshotIfAny(ctx, modelID)
+	currentSnapshotID, hasCurrentSnapshot, err := s.Repo.CurrentSnapshotIfAny(ctx, provider, modelID)
 	if err != nil {
 		return Result{}, fmt.Errorf("read current snapshot: %w", err)
 	}
 
-	snapshotID, err := s.Repo.BeginSnapshot(ctx, modelID)
+	snapshotID, err := s.Repo.BeginSnapshot(ctx, provider, modelID)
 	if err != nil {
 		return Result{}, fmt.Errorf("begin snapshot: %w", err)
 	}
 	if reporter != nil {
+		reporter.Logf("provider=%s", provider)
 		reporter.Logf("model=%s", modelID)
 		reporter.Logf("snapshot id=%d", snapshotID)
 	}
@@ -101,6 +108,7 @@ func (s Service) Run(ctx context.Context, params Params, reporter Reporter) (Res
 		ctx:                ctx,
 		params:             params,
 		reporter:           reporter,
+		provider:           provider,
 		modelID:            modelID,
 		currentSnapshotID:  currentSnapshotID,
 		hasCurrentSnapshot: hasCurrentSnapshot,
@@ -162,7 +170,7 @@ func (r *runState) canReuseFile(rel string, contentHash string) bool {
 }
 
 func (r *runState) reuseFile(rel string) error {
-	copiedSymbols, err := r.service.Repo.CopyPathFromSnapshot(r.ctx, r.modelID, r.currentSnapshotID, r.snapshotID, rel)
+	copiedSymbols, err := r.service.Repo.CopyPathFromSnapshot(r.ctx, r.provider, r.modelID, r.currentSnapshotID, r.snapshotID, rel)
 	if err != nil {
 		return fmt.Errorf("copy unchanged file %s: %w", rel, err)
 	}
@@ -207,7 +215,7 @@ func (r *runState) indexJob(job FileJob) error {
 	for _, symbol := range job.Symbols {
 		hash := r.service.Embedder.IndexedSymbolHash(job.Path, symbol)
 
-		exists, err := r.service.Repo.EmbeddingExists(r.ctx, r.modelID, hash)
+		exists, err := r.service.Repo.EmbeddingExists(r.ctx, r.provider, r.modelID, hash)
 		if err != nil {
 			return fmt.Errorf("check embedding exists: %w", err)
 		}
@@ -216,12 +224,12 @@ func (r *runState) indexJob(job FileJob) error {
 			if err != nil {
 				return fmt.Errorf("embed symbol at %s:%d: %w", job.Path, symbol.Line, err)
 			}
-			if err := r.service.Repo.AddEmbedding(r.ctx, r.modelID, hash, vec); err != nil {
+			if err := r.service.Repo.AddEmbedding(r.ctx, r.provider, r.modelID, hash, vec); err != nil {
 				return fmt.Errorf("store embedding: %w", err)
 			}
 		}
 
-		if err := r.service.Repo.InsertSymbol(r.ctx, r.snapshotID, r.modelID, job.Path, symbol, hash); err != nil {
+		if err := r.service.Repo.InsertSymbol(r.ctx, r.snapshotID, r.provider, r.modelID, job.Path, symbol, hash); err != nil {
 			return fmt.Errorf("insert symbol: %w", err)
 		}
 	}
@@ -242,7 +250,7 @@ func (r *runState) finalize() error {
 	if r.processedFiles > 0 && r.reporter != nil {
 		r.reporter.CountProgress("Indexing", r.processedFiles, r.processedFiles)
 	}
-	if err := r.service.Repo.ActivateSnapshot(r.ctx, r.modelID, r.snapshotID); err != nil {
+	if err := r.service.Repo.ActivateSnapshot(r.ctx, r.provider, r.modelID, r.snapshotID); err != nil {
 		return fmt.Errorf("activate snapshot: %w", err)
 	}
 	if err := r.service.Repo.CleanupInactiveSnapshots(r.ctx); err != nil {

--- a/internal/indexing/service_test.go
+++ b/internal/indexing/service_test.go
@@ -33,33 +33,33 @@ type testRepo struct {
 	cleaned           bool
 }
 
-func (r *testRepo) BeginSnapshot(ctx context.Context, modelID string) (int64, error) {
-	r.models = append(r.models, modelID)
+func (r *testRepo) BeginSnapshot(ctx context.Context, provider string, modelID string) (int64, error) {
+	r.models = append(r.models, provider+"/"+modelID)
 	return r.snapshotID, nil
 }
-func (r *testRepo) CurrentSnapshotIfAny(ctx context.Context, modelID string) (int64, bool, error) {
+func (r *testRepo) CurrentSnapshotIfAny(ctx context.Context, provider string, modelID string) (int64, bool, error) {
 	if r.currentSnapshotID == 0 {
 		return 0, false, nil
 	}
 	return r.currentSnapshotID, true, nil
 }
-func (r *testRepo) ActivateSnapshot(ctx context.Context, modelID string, snapshotID int64) error {
-	r.models = append(r.models, modelID)
+func (r *testRepo) ActivateSnapshot(ctx context.Context, provider string, modelID string, snapshotID int64) error {
+	r.models = append(r.models, provider+"/"+modelID)
 	r.activated = snapshotID
 	return nil
 }
-func (r *testRepo) EmbeddingExists(ctx context.Context, modelID string, commentHash string) (bool, error) {
+func (r *testRepo) EmbeddingExists(ctx context.Context, provider string, modelID string, commentHash string) (bool, error) {
 	return r.existing[commentHash], nil
 }
-func (r *testRepo) AddEmbedding(ctx context.Context, modelID string, commentHash string, embedding []float32) error {
+func (r *testRepo) AddEmbedding(ctx context.Context, provider string, modelID string, commentHash string, embedding []float32) error {
 	r.added = append(r.added, commentHash)
 	return nil
 }
-func (r *testRepo) InsertSymbol(ctx context.Context, snapshotID int64, modelID string, path string, symbol IndexedSymbol, commentHash string) error {
+func (r *testRepo) InsertSymbol(ctx context.Context, snapshotID int64, provider string, modelID string, path string, symbol IndexedSymbol, commentHash string) error {
 	r.inserts = append(r.inserts, path)
 	return nil
 }
-func (r *testRepo) CopyPathFromSnapshot(ctx context.Context, modelID string, srcSnapshotID, dstSnapshotID int64, path string) (int, error) {
+func (r *testRepo) CopyPathFromSnapshot(ctx context.Context, provider string, modelID string, srcSnapshotID, dstSnapshotID int64, path string) (int, error) {
 	r.copies = append(r.copies, path)
 	if r.copyCounts != nil {
 		return r.copyCounts[path], nil
@@ -172,7 +172,7 @@ func TestServiceRunIndexesComments(t *testing.T) {
 	if repo.activated != 2 || !repo.cleaned {
 		t.Fatalf("expected version activation and cleanup, got activated=%d cleaned=%v", repo.activated, repo.cleaned)
 	}
-	if len(repo.models) < 2 || repo.models[0] != "qwen3" || repo.models[len(repo.models)-1] != "qwen3" {
+	if len(repo.models) < 2 || repo.models[0] != "llama.cpp/qwen3" || repo.models[len(repo.models)-1] != "llama.cpp/qwen3" {
 		t.Fatalf("expected model tracking for qwen3, got %v", repo.models)
 	}
 	if reporter.progressCalls == 0 {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,1064 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	jsonRPCVersion       = "2.0"
+	legacyProtocol       = "2024-11-05"
+	toolsProtocol        = "2025-03-26"
+	rootsProtocol        = "2025-06-18"
+	latestKnownProtocol  = "2025-11-25"
+	defaultProtocol      = latestKnownProtocol
+	errCodeParse         = -32700
+	errCodeInvalidReq    = -32600
+	errCodeMethodMissing = -32601
+	errCodeInvalidParams = -32602
+	errCodeInternal      = -32603
+	errCodeNotFound      = -32002
+)
+
+var supportedProtocols = map[string]struct{}{
+	legacyProtocol:      {},
+	toolsProtocol:       {},
+	rootsProtocol:       {},
+	latestKnownProtocol: {},
+}
+
+type Service interface {
+	Version() string
+	WorkspaceStatus(context.Context) (WorkspaceStatusResult, error)
+	SearchCode(context.Context, SearchCodeParams) (SearchCodeResult, error)
+	IndexRepository(context.Context, IndexRepositoryParams) (IndexRepositoryResult, error)
+}
+
+type SearchCodeParams struct {
+	Query       string   `json:"query"`
+	Limit       int      `json:"limit,omitempty"`
+	Mode        string   `json:"mode,omitempty"`
+	MaxDistance *float64 `json:"max_distance,omitempty"`
+	Details     bool     `json:"details,omitempty"`
+}
+
+type SearchHit struct {
+	Path          string  `json:"path"`
+	Line          int     `json:"line"`
+	Metric        string  `json:"metric"`
+	Kind          string  `json:"kind,omitempty"`
+	Name          string  `json:"name,omitempty"`
+	QualifiedName string  `json:"qualified_name,omitempty"`
+	Signature     string  `json:"signature,omitempty"`
+	Documentation string  `json:"documentation,omitempty"`
+	Body          string  `json:"body,omitempty"`
+	Distance      float64 `json:"distance,omitempty"`
+}
+
+type SearchCodeResult struct {
+	Query       string      `json:"query"`
+	Mode        string      `json:"mode"`
+	Provider    string      `json:"provider,omitempty"`
+	ModelID     string      `json:"model_id"`
+	StateDir    string      `json:"state_dir"`
+	ResultCount int         `json:"result_count"`
+	Hits        []SearchHit `json:"hits"`
+}
+
+type IndexRepositoryParams struct {
+	Excludes      []string `json:"excludes,omitempty"`
+	Gitignore     string   `json:"gitignore,omitempty"`
+	CommentPrefix string   `json:"comment_prefix,omitempty"`
+	ContextPrefix string   `json:"context_prefix,omitempty"`
+}
+
+type IndexRepositoryResult struct {
+	Provider              string `json:"provider,omitempty"`
+	ModelID               string `json:"model_id"`
+	StateDir              string `json:"state_dir"`
+	Version               int64  `json:"version"`
+	IndexedFiles          int    `json:"indexed_files"`
+	IndexedSymbols        int    `json:"indexed_symbols"`
+	DetachedRemoteBinding bool   `json:"detached_remote_binding,omitempty"`
+}
+
+type WorkspaceStatusResult struct {
+	Root              string `json:"root"`
+	StateDir          string `json:"state_dir"`
+	IndexDB           string `json:"index_db"`
+	RequestedProvider string `json:"requested_provider,omitempty"`
+	RequestedModel    string `json:"requested_model,omitempty"`
+	RequestedLib      string `json:"requested_lib,omitempty"`
+	ContextSize       int    `json:"ctx_size,omitempty"`
+	IndexPresent      bool   `json:"index_present"`
+	ManifestVersion   int64  `json:"manifest_version,omitempty"`
+	ManifestSource    string `json:"manifest_source,omitempty"`
+	RemoteCIURL       string `json:"remote_ci_url,omitempty"`
+	Provider          string `json:"provider,omitempty"`
+	ModelID           string `json:"model_id,omitempty"`
+	ResolvedModel     string `json:"resolved_model,omitempty"`
+	ResolvedLib       string `json:"resolved_lib,omitempty"`
+}
+
+type Server struct {
+	service Service
+	writer  io.Writer
+	writeMu sync.Mutex
+	format  transportFormat
+}
+
+type transportFormat int
+
+const (
+	transportFormatUnknown transportFormat = iota
+	transportFormatNewline
+	transportFormatContentLength
+)
+
+func NewServer(service Service) *Server {
+	return &Server{service: service}
+}
+
+func (s *Server) Serve(ctx context.Context, r io.Reader, w io.Writer) error {
+	s.writer = w
+	reader := bufio.NewReader(r)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		payload, err := s.readMessage(reader)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+
+		if bytes.HasPrefix(bytes.TrimSpace(payload), []byte("[")) {
+			if err := s.handleBatch(ctx, payload); err != nil {
+				return err
+			}
+			continue
+		}
+
+		var req requestEnvelope
+		if err := json.Unmarshal(payload, &req); err != nil {
+			if writeErr := s.writeError(nil, errCodeParse, "failed to decode JSON request"); writeErr != nil {
+				return writeErr
+			}
+			continue
+		}
+
+		if strings.TrimSpace(req.JSONRPC) != jsonRPCVersion || strings.TrimSpace(req.Method) == "" {
+			if req.ID != nil {
+				if err := s.writeError(req.ID, errCodeInvalidReq, "invalid JSON-RPC request"); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		if req.ID == nil {
+			continue
+		}
+
+		if err := s.handleRequest(ctx, req); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *Server) handleBatch(ctx context.Context, payload []byte) error {
+	var batch []json.RawMessage
+	if err := json.Unmarshal(payload, &batch); err != nil {
+		return s.writeError(nil, errCodeParse, "failed to decode JSON request")
+	}
+	if len(batch) == 0 {
+		return s.writeError(nil, errCodeInvalidReq, "invalid JSON-RPC request")
+	}
+
+	responses := make([]responseEnvelope, 0, len(batch))
+	for _, item := range batch {
+		var req requestEnvelope
+		if err := json.Unmarshal(item, &req); err != nil {
+			responses = append(responses, s.errorEnvelope(nil, errCodeInvalidReq, "invalid JSON-RPC request"))
+			continue
+		}
+		if strings.TrimSpace(req.JSONRPC) != jsonRPCVersion || strings.TrimSpace(req.Method) == "" {
+			responses = append(responses, s.errorEnvelope(req.ID, errCodeInvalidReq, "invalid JSON-RPC request"))
+			continue
+		}
+		if req.ID == nil {
+			continue
+		}
+
+		responses = append(responses, s.buildResponse(ctx, req))
+	}
+
+	if len(responses) == 0 {
+		return nil
+	}
+	return s.writeBatchResponses(responses)
+}
+
+func (s *Server) handleRequest(ctx context.Context, req requestEnvelope) error {
+	return s.writeEnvelope(s.buildResponse(ctx, req))
+}
+
+func (s *Server) buildResponse(ctx context.Context, req requestEnvelope) responseEnvelope {
+	switch req.Method {
+	case "initialize":
+		var params initializeParams
+		if len(req.Params) > 0 {
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				return s.errorEnvelope(req.ID, errCodeInvalidParams, "invalid initialize params")
+			}
+		}
+		result := initializeResult{
+			ProtocolVersion: negotiatedProtocol(params.ProtocolVersion),
+			Capabilities: map[string]any{
+				"tools": map[string]any{
+					"listChanged": false,
+				},
+				"resources": map[string]any{},
+			},
+			ServerInfo: serverInfo{
+				Name:    "unch",
+				Version: s.service.Version(),
+			},
+			Instructions: "Use workspace_status to inspect the configured repository, search_code to retrieve symbol matches, and index_repository to rebuild the local semantic index.",
+		}
+		return s.resultEnvelope(req.ID, result)
+	case "ping":
+		return s.resultEnvelope(req.ID, map[string]any{})
+	case "tools/list":
+		return s.resultEnvelope(req.ID, listToolsResult{Tools: toolDefinitions()})
+	case "resources/list":
+		return s.resultEnvelope(req.ID, listResourcesResult{Resources: resourceDefinitions()})
+	case "resources/templates/list":
+		return s.resultEnvelope(req.ID, listResourceTemplatesResult{ResourceTemplates: resourceTemplateDefinitions()})
+	case "resources/read":
+		var params resourceReadParams
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return s.errorEnvelope(req.ID, errCodeInvalidParams, "invalid resources/read params")
+		}
+		result, err := s.readResource(ctx, params)
+		if err != nil {
+			var rpcErr rpcError
+			if errors.As(err, &rpcErr) {
+				return s.errorEnvelope(req.ID, rpcErr.Code, rpcErr.Message)
+			}
+			return s.errorEnvelope(req.ID, errCodeInternal, err.Error())
+		}
+		return s.resultEnvelope(req.ID, result)
+	case "tools/call":
+		var params toolCallParams
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return s.errorEnvelope(req.ID, errCodeInvalidParams, "invalid tools/call params")
+		}
+		result, err := s.callTool(ctx, params)
+		if err != nil {
+			var rpcErr rpcError
+			if errors.As(err, &rpcErr) {
+				return s.errorEnvelope(req.ID, rpcErr.Code, rpcErr.Message)
+			}
+			return s.errorEnvelope(req.ID, errCodeInternal, err.Error())
+		}
+		return s.resultEnvelope(req.ID, result)
+	default:
+		return s.errorEnvelope(req.ID, errCodeMethodMissing, fmt.Sprintf("method %q is not supported", req.Method))
+	}
+}
+
+func (s *Server) readResource(ctx context.Context, params resourceReadParams) (readResourceResult, error) {
+	uri := strings.TrimSpace(params.URI)
+	if uri == "" {
+		return readResourceResult{}, invalidParamsError("resources/read requires a non-empty uri")
+	}
+
+	var text string
+	switch uri {
+	case docsOverviewResourceURI:
+		text = renderDocsOverview()
+	case workspaceOverviewResourceURI:
+		status, err := s.service.WorkspaceStatus(ctx)
+		if err != nil {
+			return readResourceResult{}, err
+		}
+		text = renderWorkspaceOverviewResource(status)
+	default:
+		if strings.HasPrefix(uri, toolResourcePrefix) {
+			content, err := renderToolResource(strings.TrimPrefix(uri, toolResourcePrefix))
+			if err != nil {
+				return readResourceResult{}, err
+			}
+			text = content
+			break
+		}
+		return readResourceResult{}, rpcError{Code: errCodeNotFound, Message: "Resource not found"}
+	}
+
+	return readResourceResult{
+		Contents: []textResourceContents{{
+			URI:      uri,
+			MimeType: "text/markdown",
+			Text:     text,
+		}},
+	}, nil
+}
+
+func (s *Server) callTool(ctx context.Context, params toolCallParams) (toolCallResult, error) {
+	switch params.Name {
+	case "workspace_status":
+		result, err := s.service.WorkspaceStatus(ctx)
+		if err != nil {
+			return toolErrorResult(err), nil
+		}
+		return toolCallResult{
+			Content:           []toolContent{{Type: "text", Text: renderWorkspaceStatus(result)}},
+			StructuredContent: result,
+		}, nil
+	case "search_code":
+		var args SearchCodeParams
+		if err := decodeToolArgs(params.Arguments, &args); err != nil {
+			return toolCallResult{}, err
+		}
+		if strings.TrimSpace(args.Query) == "" {
+			return toolCallResult{}, invalidParamsError("search_code requires a non-empty query")
+		}
+		result, err := s.service.SearchCode(ctx, args)
+		if err != nil {
+			return toolErrorResult(err), nil
+		}
+		return toolCallResult{
+			Content:           []toolContent{{Type: "text", Text: renderSearchResults(result, args.Details)}},
+			StructuredContent: result,
+		}, nil
+	case "index_repository":
+		var args IndexRepositoryParams
+		if err := decodeToolArgs(params.Arguments, &args); err != nil {
+			return toolCallResult{}, err
+		}
+		result, err := s.service.IndexRepository(ctx, args)
+		if err != nil {
+			return toolErrorResult(err), nil
+		}
+		return toolCallResult{
+			Content:           []toolContent{{Type: "text", Text: renderIndexResult(result)}},
+			StructuredContent: result,
+		}, nil
+	default:
+		return toolErrorResult(fmt.Errorf("unknown tool %q", params.Name)), nil
+	}
+}
+
+func decodeToolArgs(raw json.RawMessage, target any) error {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return invalidParamsError("invalid tool arguments")
+	}
+	return nil
+}
+
+func toolErrorResult(err error) toolCallResult {
+	return toolCallResult{
+		Content: []toolContent{{
+			Type: "text",
+			Text: err.Error(),
+		}},
+		IsError: true,
+	}
+}
+
+func invalidParamsError(message string) error {
+	return rpcError{Code: errCodeInvalidParams, Message: message}
+}
+
+func negotiatedProtocol(requested string) string {
+	requested = strings.TrimSpace(requested)
+	if _, ok := supportedProtocols[requested]; ok {
+		return requested
+	}
+	return defaultProtocol
+}
+
+func (s *Server) resultEnvelope(id json.RawMessage, result any) responseEnvelope {
+	return responseEnvelope{
+		JSONRPC: jsonRPCVersion,
+		ID:      id,
+		Result:  result,
+	}
+}
+
+func (s *Server) errorEnvelope(id json.RawMessage, code int, message string) responseEnvelope {
+	return responseEnvelope{
+		JSONRPC: jsonRPCVersion,
+		ID:      id,
+		Error: &responseError{
+			Code:    code,
+			Message: message,
+		},
+	}
+}
+
+func (s *Server) writeResult(id json.RawMessage, result any) error {
+	return s.writeEnvelope(s.resultEnvelope(id, result))
+}
+
+func (s *Server) writeError(id json.RawMessage, code int, message string) error {
+	return s.writeEnvelope(s.errorEnvelope(id, code, message))
+}
+
+func (s *Server) writeEnvelope(envelope responseEnvelope) error {
+	payload, err := json.Marshal(envelope)
+	if err != nil {
+		return err
+	}
+	return s.writePayload(payload)
+}
+
+func (s *Server) writeBatchResponses(envelopes []responseEnvelope) error {
+	payload, err := json.Marshal(envelopes)
+	if err != nil {
+		return err
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.writePayloadLocked(payload)
+}
+
+func (s *Server) readMessage(r *bufio.Reader) ([]byte, error) {
+	switch s.format {
+	case transportFormatContentLength:
+		return readContentLengthMessage(r, "")
+	case transportFormatNewline:
+		return readNewlineMessage(r)
+	default:
+		payload, format, err := detectAndReadMessage(r)
+		if err == nil {
+			s.format = format
+		}
+		return payload, err
+	}
+}
+
+func (s *Server) writePayload(payload []byte) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.writePayloadLocked(payload)
+}
+
+func (s *Server) writePayloadLocked(payload []byte) error {
+	switch s.format {
+	case transportFormatContentLength:
+		return writeContentLengthMessage(s.writer, payload)
+	case transportFormatUnknown, transportFormatNewline:
+		return writeNewlineMessage(s.writer, payload)
+	default:
+		return writeNewlineMessage(s.writer, payload)
+	}
+}
+
+func detectAndReadMessage(r *bufio.Reader) ([]byte, transportFormat, error) {
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				trimmed := bytes.TrimRight(line, "\r\n")
+				if len(trimmed) == 0 {
+					return nil, transportFormatUnknown, io.EOF
+				}
+				return trimmed, transportFormatNewline, nil
+			}
+			return nil, transportFormatUnknown, err
+		}
+
+		trimmed := bytes.TrimRight(line, "\r\n")
+		if len(trimmed) == 0 {
+			continue
+		}
+		if isContentLengthHeader(trimmed) {
+			payload, err := readContentLengthMessage(r, string(trimmed))
+			return payload, transportFormatContentLength, err
+		}
+		return trimmed, transportFormatNewline, nil
+	}
+}
+
+func readNewlineMessage(r *bufio.Reader) ([]byte, error) {
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				trimmed := bytes.TrimRight(line, "\r\n")
+				if len(trimmed) == 0 {
+					return nil, io.EOF
+				}
+				return trimmed, nil
+			}
+			return nil, err
+		}
+
+		trimmed := bytes.TrimRight(line, "\r\n")
+		if len(trimmed) == 0 {
+			continue
+		}
+		return trimmed, nil
+	}
+}
+
+func readContentLengthMessage(r *bufio.Reader, firstLine string) ([]byte, error) {
+	contentLength := -1
+	if firstLine != "" {
+		if n, ok, err := parseContentLengthHeader(firstLine); err != nil {
+			return nil, err
+		} else if ok {
+			contentLength = n
+		}
+	}
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) && line == "" {
+				return nil, io.EOF
+			}
+			return nil, err
+		}
+
+		trimmed := strings.TrimRight(line, "\r\n")
+		if trimmed == "" {
+			break
+		}
+		if n, ok, err := parseContentLengthHeader(trimmed); err != nil {
+			return nil, err
+		} else if ok {
+			contentLength = n
+		}
+	}
+
+	if contentLength < 0 {
+		return nil, fmt.Errorf("missing Content-Length header")
+	}
+
+	payload := make([]byte, contentLength)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func parseContentLengthHeader(line string) (int, bool, error) {
+	key, value, ok := strings.Cut(line, ":")
+	if !ok {
+		return 0, false, fmt.Errorf("invalid MCP header line %q", line)
+	}
+	if !strings.EqualFold(strings.TrimSpace(key), "Content-Length") {
+		return 0, false, nil
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || n < 0 {
+		return 0, false, fmt.Errorf("invalid Content-Length %q", value)
+	}
+	return n, true, nil
+}
+
+func isContentLengthHeader(line []byte) bool {
+	return bytes.HasPrefix(bytes.ToLower(bytes.TrimSpace(line)), []byte("content-length:"))
+}
+
+func writeContentLengthMessage(w io.Writer, payload []byte) error {
+	if _, err := fmt.Fprintf(w, "Content-Length: %d\r\n\r\n", len(payload)); err != nil {
+		return err
+	}
+	_, err := w.Write(payload)
+	return err
+}
+
+func writeNewlineMessage(w io.Writer, payload []byte) error {
+	if _, err := w.Write(payload); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte{'\n'})
+	return err
+}
+
+const (
+	docsOverviewResourceURI      = "unch://docs/overview"
+	workspaceOverviewResourceURI = "unch://workspace/overview"
+	toolResourceTemplateURI      = "unch://tool/{name}"
+	toolResourcePrefix           = "unch://tool/"
+)
+
+func toolDefinitions() []toolDefinition {
+	return []toolDefinition{
+		{
+			Name:        "workspace_status",
+			Description: "Describe the repository, .semsearch state directory, index manifest, and currently configured model/runtime settings.",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		{
+			Name:        "search_code",
+			Description: "Search the configured repository index for relevant code symbols using semantic, lexical, or mixed retrieval.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"query": map[string]any{
+						"type":        "string",
+						"description": "Natural-language or lexical search query.",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"minimum":     1,
+						"maximum":     50,
+						"default":     10,
+						"description": "Maximum number of matches to return.",
+					},
+					"mode": map[string]any{
+						"type":        "string",
+						"enum":        []string{"auto", "semantic", "lexical"},
+						"default":     "auto",
+						"description": "Retrieval mode.",
+					},
+					"max_distance": map[string]any{
+						"type":        "number",
+						"default":     0.85,
+						"description": "Maximum semantic distance in auto and semantic modes; values <= 0 disable filtering.",
+					},
+					"details": map[string]any{
+						"type":        "boolean",
+						"default":     false,
+						"description": "Include compact symbol metadata in the textual result.",
+					},
+				},
+				"required": []string{"query"},
+			},
+		},
+		{
+			Name:        "index_repository",
+			Description: "Build or refresh the configured repository index using the server's root, state directory, model, and yzma runtime settings.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"excludes": map[string]any{
+						"type":        "array",
+						"items":       map[string]any{"type": "string"},
+						"description": "Extra exclude globs passed to the indexer.",
+					},
+					"gitignore": map[string]any{
+						"type":        "string",
+						"description": "Optional path to a custom .gitignore file.",
+					},
+					"comment_prefix": map[string]any{
+						"type":        "string",
+						"description": "Legacy fallback comment prefix for unsupported files.",
+						"default":     "@search:",
+					},
+					"context_prefix": map[string]any{
+						"type":        "string",
+						"description": "Legacy fallback file-context prefix for unsupported files.",
+						"default":     "@filectx:",
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceDefinitions() []resourceDefinition {
+	return []resourceDefinition{
+		{
+			URI:         docsOverviewResourceURI,
+			Name:        "overview",
+			Title:       "unch Overview",
+			Description: "Quick start and server capabilities for using unch through MCP.",
+			MimeType:    "text/markdown",
+		},
+		{
+			URI:         workspaceOverviewResourceURI,
+			Name:        "workspace",
+			Title:       "unch Workspace Context",
+			Description: "Current repository, index, and model configuration snapshot for this unch server.",
+			MimeType:    "text/markdown",
+		},
+	}
+}
+
+func resourceTemplateDefinitions() []resourceTemplateDefinition {
+	return []resourceTemplateDefinition{
+		{
+			URITemplate: toolResourceTemplateURI,
+			Name:        "tool-docs",
+			Title:       "unch Tool Reference",
+			Description: "Short markdown reference for a specific unch MCP tool.",
+			MimeType:    "text/markdown",
+		},
+	}
+}
+
+func renderDocsOverview() string {
+	return strings.Join([]string{
+		"# unch MCP",
+		"",
+		"`unch` exposes semantic code search as MCP tools and resources.",
+		"",
+		"## Available tools",
+		"- `workspace_status`: inspect the configured repository, index files, and runtime/model settings.",
+		"- `search_code`: search the indexed repository with a natural-language or lexical query.",
+		"- `index_repository`: build or refresh the local semantic index for the current workspace.",
+		"",
+		"## Quick start",
+		"1. Read `unch://workspace/overview` for the current repo and index context.",
+		"2. Call `workspace_status` when you need the same data as structured JSON.",
+		"3. Call `search_code` with a short query like `mcp server`, `workspace status`, or `cli start`.",
+		"4. Open `unch://tool/{name}` for argument-level docs, for example `unch://tool/search_code`.",
+		"",
+		"## Notes",
+		"- `search_code` requires a non-empty `query`.",
+		"- `index_repository` updates the local `.semsearch` state for this workspace.",
+	}, "\n")
+}
+
+func renderWorkspaceOverviewResource(result WorkspaceStatusResult) string {
+	lines := []string{
+		"# unch Workspace Context",
+		"",
+		"## Current workspace",
+		fmt.Sprintf("- root: `%s`", result.Root),
+		fmt.Sprintf("- state_dir: `%s`", result.StateDir),
+		fmt.Sprintf("- index_db: `%s`", result.IndexDB),
+	}
+	if result.ManifestSource != "" || result.ManifestVersion > 0 {
+		lines = append(lines, fmt.Sprintf("- manifest: `%s v%d`", fallbackString(result.ManifestSource, "local"), result.ManifestVersion))
+	}
+	if result.RemoteCIURL != "" {
+		lines = append(lines, fmt.Sprintf("- remote_ci: `%s`", result.RemoteCIURL))
+	}
+	if result.RequestedModel != "" {
+		lines = append(lines, fmt.Sprintf("- requested_model: `%s`", result.RequestedModel))
+	}
+	if result.ModelID != "" {
+		lines = append(lines, fmt.Sprintf("- model_id: `%s`", result.ModelID))
+	}
+	if result.ResolvedModel != "" {
+		lines = append(lines, fmt.Sprintf("- resolved_model: `%s`", result.ResolvedModel))
+	}
+	if result.RequestedLib != "" {
+		lines = append(lines, fmt.Sprintf("- requested_lib: `%s`", result.RequestedLib))
+	}
+	if result.ResolvedLib != "" {
+		lines = append(lines, fmt.Sprintf("- resolved_lib: `%s`", result.ResolvedLib))
+	}
+	if result.ContextSize > 0 {
+		lines = append(lines, fmt.Sprintf("- ctx_size: `%d`", result.ContextSize))
+	}
+	if result.IndexPresent {
+		lines = append(lines, "- index_present: `yes`")
+	} else {
+		lines = append(lines, "- index_present: `no`")
+	}
+	lines = append(lines,
+		"",
+		"## Available docs",
+		"- `unch://docs/overview`",
+		"- `unch://tool/workspace_status`",
+		"- `unch://tool/search_code`",
+		"- `unch://tool/index_repository`",
+	)
+	return strings.Join(lines, "\n")
+}
+
+func renderToolResource(name string) (string, error) {
+	switch name {
+	case "workspace_status":
+		return strings.Join([]string{
+			"# `workspace_status`",
+			"",
+			"Returns a structured snapshot of the current repository, `.semsearch` state, manifest, and model/runtime configuration.",
+			"",
+			"## Arguments",
+			"- none",
+			"",
+			"## Returns",
+			"- `root`, `state_dir`, `index_db`",
+			"- manifest fields such as `manifest_source` and `manifest_version` when available",
+			"- requested/resolved model or runtime fields when configured",
+			"- `index_present` to show whether a local index already exists",
+		}, "\n"), nil
+	case "search_code":
+		return strings.Join([]string{
+			"# `search_code`",
+			"",
+			"Search the indexed repository for relevant code symbols using semantic, lexical, or mixed retrieval.",
+			"",
+			"## Arguments",
+			"- `query` (required): natural-language or lexical search query",
+			"- `limit`: maximum number of matches, default `10`",
+			"- `mode`: one of `auto`, `semantic`, `lexical`",
+			"- `max_distance`: semantic distance threshold; values `<= 0` disable filtering",
+			"- `details`: include compact symbol metadata in the textual response",
+			"",
+			"## Example",
+			"- query: `mcp server`",
+			"- query: `workspace status`, mode: `lexical`",
+		}, "\n"), nil
+	case "index_repository":
+		return strings.Join([]string{
+			"# `index_repository`",
+			"",
+			"Build or refresh the local `.semsearch` index for the current workspace using the configured model and runtime.",
+			"",
+			"## Arguments",
+			"- `excludes`: extra exclude globs passed to the indexer",
+			"- `gitignore`: optional path to a custom `.gitignore` file",
+			"- `comment_prefix`: legacy fallback comment prefix for unsupported files",
+			"- `context_prefix`: legacy fallback file-context prefix for unsupported files",
+			"",
+			"## Returns",
+			"- indexed file/symbol counts",
+			"- manifest version",
+			"- state directory and active model ID",
+		}, "\n"), nil
+	default:
+		return "", rpcError{Code: errCodeNotFound, Message: "Resource not found"}
+	}
+}
+
+func renderWorkspaceStatus(result WorkspaceStatusResult) string {
+	lines := []string{
+		"unch MCP workspace",
+		fmt.Sprintf("root: %s", result.Root),
+		fmt.Sprintf("state_dir: %s", result.StateDir),
+		fmt.Sprintf("index_db: %s", result.IndexDB),
+	}
+	if result.ManifestSource != "" || result.ManifestVersion > 0 {
+		lines = append(lines, fmt.Sprintf("manifest: %s v%d", fallbackString(result.ManifestSource, "local"), result.ManifestVersion))
+	}
+	if result.RemoteCIURL != "" {
+		lines = append(lines, fmt.Sprintf("remote_ci: %s", result.RemoteCIURL))
+	}
+	if result.RequestedModel != "" {
+		lines = append(lines, fmt.Sprintf("requested_model: %s", result.RequestedModel))
+	}
+	if result.ModelID != "" {
+		lines = append(lines, fmt.Sprintf("model_id: %s", result.ModelID))
+	}
+	if result.ResolvedModel != "" {
+		lines = append(lines, fmt.Sprintf("resolved_model: %s", result.ResolvedModel))
+	}
+	if result.RequestedLib != "" {
+		lines = append(lines, fmt.Sprintf("requested_lib: %s", result.RequestedLib))
+	}
+	if result.ResolvedLib != "" {
+		lines = append(lines, fmt.Sprintf("resolved_lib: %s", result.ResolvedLib))
+	}
+	if result.ContextSize > 0 {
+		lines = append(lines, fmt.Sprintf("ctx_size: %d", result.ContextSize))
+	}
+	if result.IndexPresent {
+		lines = append(lines, "index_present: yes")
+	} else {
+		lines = append(lines, "index_present: no")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderSearchResults(result SearchCodeResult, details bool) string {
+	if len(result.Hits) == 0 {
+		return fmt.Sprintf("No matches found for %q.", result.Query)
+	}
+
+	lines := []string{
+		fmt.Sprintf("Found %d matches for %q (%s).", result.ResultCount, result.Query, result.Mode),
+	}
+	for i, hit := range result.Hits {
+		lines = append(lines, fmt.Sprintf("%2d. %s:%d  %s", i+1, hit.Path, hit.Line, hit.Metric))
+		if details {
+			if value := compactField(hit.Kind, 80); value != "" {
+				lines = append(lines, "    kind: "+value)
+			}
+			if value := compactField(hit.Name, 120); value != "" {
+				lines = append(lines, "    name: "+value)
+			}
+			if value := compactField(hit.QualifiedName, 160); value != "" {
+				lines = append(lines, "    qualified: "+value)
+			}
+			if value := compactField(hit.Signature, 200); value != "" {
+				lines = append(lines, "    signature: "+value)
+			}
+			if value := compactField(hit.Documentation, 220); value != "" {
+				lines = append(lines, "    docs: "+value)
+			}
+			if value := compactField(hit.Body, 220); value != "" {
+				lines = append(lines, "    body: "+value)
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderIndexResult(result IndexRepositoryResult) string {
+	lines := []string{
+		fmt.Sprintf("Indexed %d symbols in %d files.", result.IndexedSymbols, result.IndexedFiles),
+		fmt.Sprintf("manifest version: %d", result.Version),
+		fmt.Sprintf("state_dir: %s", result.StateDir),
+		fmt.Sprintf("model_id: %s", result.ModelID),
+	}
+	if result.DetachedRemoteBinding {
+		lines = append(lines, "note: local indexing detached the previous remote CI binding and switched the manifest back to local mode")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func compactField(text string, maxRunes int) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	text = strings.Join(strings.Fields(text), " ")
+	if maxRunes <= 0 {
+		return text
+	}
+
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	if maxRunes <= 3 {
+		return string(runes[:maxRunes])
+	}
+	return string(runes[:maxRunes-3]) + "..."
+}
+
+func fallbackString(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+type requestEnvelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type responseEnvelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *responseError  `json:"error,omitempty"`
+}
+
+type responseError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type initializeParams struct {
+	ProtocolVersion string `json:"protocolVersion,omitempty"`
+}
+
+type initializeResult struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities"`
+	ServerInfo      serverInfo     `json:"serverInfo"`
+	Instructions    string         `json:"instructions,omitempty"`
+}
+
+type serverInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type toolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+type resourceReadParams struct {
+	URI string `json:"uri"`
+}
+
+type toolCallResult struct {
+	Content           []toolContent `json:"content"`
+	StructuredContent any           `json:"structuredContent,omitempty"`
+	IsError           bool          `json:"isError,omitempty"`
+}
+
+type toolContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type toolDefinition struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+type listToolsResult struct {
+	Tools      []toolDefinition `json:"tools"`
+	NextCursor string           `json:"nextCursor,omitempty"`
+}
+
+type resourceDefinition struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	MimeType    string `json:"mimeType,omitempty"`
+}
+
+type listResourcesResult struct {
+	Resources  []resourceDefinition `json:"resources"`
+	NextCursor string               `json:"nextCursor,omitempty"`
+}
+
+type resourceTemplateDefinition struct {
+	URITemplate string `json:"uriTemplate"`
+	Name        string `json:"name"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	MimeType    string `json:"mimeType,omitempty"`
+}
+
+type listResourceTemplatesResult struct {
+	ResourceTemplates []resourceTemplateDefinition `json:"resourceTemplates"`
+	NextCursor        string                       `json:"nextCursor,omitempty"`
+}
+
+type textResourceContents struct {
+	URI      string `json:"uri"`
+	MimeType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+}
+
+type readResourceResult struct {
+	Contents []textResourceContents `json:"contents"`
+}
+
+type rpcError struct {
+	Code    int
+	Message string
+}
+
+func (e rpcError) Error() string {
+	return e.Message
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -414,10 +414,6 @@ func (s *Server) errorEnvelope(id json.RawMessage, code int, message string) res
 	}
 }
 
-func (s *Server) writeResult(id json.RawMessage, result any) error {
-	return s.writeEnvelope(s.resultEnvelope(id, result))
-}
-
 func (s *Server) writeError(id json.RawMessage, code int, message string) error {
 	return s.writeEnvelope(s.errorEnvelope(id, code, message))
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,426 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+type fakeService struct{}
+
+func (fakeService) Version() string { return "vtest" }
+
+func (fakeService) WorkspaceStatus(context.Context) (WorkspaceStatusResult, error) {
+	return WorkspaceStatusResult{
+		Root:           "/repo",
+		StateDir:       "/repo/.semsearch",
+		IndexDB:        "/repo/.semsearch/index.db",
+		RequestedModel: "embeddinggemma",
+		IndexPresent:   true,
+	}, nil
+}
+
+func (fakeService) SearchCode(_ context.Context, params SearchCodeParams) (SearchCodeResult, error) {
+	return SearchCodeResult{
+		Query:       params.Query,
+		Mode:        fallbackString(params.Mode, "auto"),
+		ModelID:     "embeddinggemma",
+		StateDir:    "/repo/.semsearch",
+		ResultCount: 1,
+		Hits: []SearchHit{{
+			Path:   "internal/cli/root.go",
+			Line:   12,
+			Metric: "0.1234",
+			Kind:   "function",
+			Name:   "Run",
+		}},
+	}, nil
+}
+
+func (fakeService) IndexRepository(context.Context, IndexRepositoryParams) (IndexRepositoryResult, error) {
+	return IndexRepositoryResult{
+		ModelID:        "embeddinggemma",
+		StateDir:       "/repo/.semsearch",
+		Version:        4,
+		IndexedFiles:   7,
+		IndexedSymbols: 42,
+	}, nil
+}
+
+func TestServerInitializeAndToolsList(t *testing.T) {
+	t.Parallel()
+
+	input := bytes.NewBuffer(nil)
+	writeTestFrame(t, input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": latestKnownProtocol,
+		},
+	})
+	writeTestFrame(t, input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+	})
+
+	output := bytes.NewBuffer(nil)
+	server := NewServer(fakeService{})
+	if err := server.Serve(context.Background(), input, output); err != nil {
+		t.Fatalf("Serve() error: %v", err)
+	}
+
+	reader := bufio.NewReader(output)
+	first := readTestFrame(t, reader)
+	if first["jsonrpc"] != "2.0" {
+		t.Fatalf("initialize response jsonrpc = %v", first["jsonrpc"])
+	}
+	result := first["result"].(map[string]any)
+	if got := result["protocolVersion"]; got != latestKnownProtocol {
+		t.Fatalf("protocolVersion = %v, want %s", got, latestKnownProtocol)
+	}
+	capabilities := result["capabilities"].(map[string]any)
+	if _, ok := capabilities["resources"]; !ok {
+		t.Fatalf("initialize capabilities missing resources: %#v", capabilities)
+	}
+
+	second := readTestFrame(t, reader)
+	tools := second["result"].(map[string]any)["tools"].([]any)
+	if len(tools) != 3 {
+		t.Fatalf("tools/list returned %d tools, want 3", len(tools))
+	}
+}
+
+func TestServerBatchInitializeAndToolsList(t *testing.T) {
+	t.Parallel()
+
+	input := bytes.NewBuffer(nil)
+	payload, err := json.Marshal([]map[string]any{
+		{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "initialize",
+			"params": map[string]any{
+				"protocolVersion": latestKnownProtocol,
+			},
+		},
+		{
+			"jsonrpc": "2.0",
+			"method":  "notifications/initialized",
+			"params":  map[string]any{},
+		},
+		{
+			"jsonrpc": "2.0",
+			"id":      2,
+			"method":  "tools/list",
+			"params":  map[string]any{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal batch request: %v", err)
+	}
+	if err := writeNewlineMessage(input, payload); err != nil {
+		t.Fatalf("write batch message: %v", err)
+	}
+
+	output := bytes.NewBuffer(nil)
+	server := NewServer(fakeService{})
+	if err := server.Serve(context.Background(), input, output); err != nil {
+		t.Fatalf("Serve() error: %v", err)
+	}
+
+	raw := readRawFrame(t, bufio.NewReader(output))
+	var responses []map[string]any
+	if err := json.Unmarshal(raw, &responses); err != nil {
+		t.Fatalf("unmarshal batch response: %v", err)
+	}
+	if len(responses) != 2 {
+		t.Fatalf("batch response count = %d, want 2", len(responses))
+	}
+
+	first := responses[0]["result"].(map[string]any)
+	if got := first["protocolVersion"]; got != latestKnownProtocol {
+		t.Fatalf("protocolVersion = %v, want %s", got, latestKnownProtocol)
+	}
+
+	second := responses[1]["result"].(map[string]any)
+	tools := second["tools"].([]any)
+	if len(tools) != 3 {
+		t.Fatalf("tools/list returned %d tools, want 3", len(tools))
+	}
+}
+
+func TestServerInitializeFallsBackToLatestKnownProtocol(t *testing.T) {
+	t.Parallel()
+
+	input := bytes.NewBuffer(nil)
+	writeTestFrame(t, input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2026-04-01",
+		},
+	})
+
+	output := bytes.NewBuffer(nil)
+	server := NewServer(fakeService{})
+	if err := server.Serve(context.Background(), input, output); err != nil {
+		t.Fatalf("Serve() error: %v", err)
+	}
+
+	resp := readTestFrame(t, bufio.NewReader(output))
+	result := resp["result"].(map[string]any)
+	if got := result["protocolVersion"]; got != latestKnownProtocol {
+		t.Fatalf("protocolVersion = %v, want %s", got, latestKnownProtocol)
+	}
+}
+
+func TestServerSupportsLegacyContentLengthMessages(t *testing.T) {
+	t.Parallel()
+
+	input := bytes.NewBuffer(nil)
+	writeLegacyTestFrame(t, input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": rootsProtocol,
+		},
+	})
+	writeLegacyTestFrame(t, input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+		"params":  map[string]any{},
+	})
+
+	output := bytes.NewBuffer(nil)
+	server := NewServer(fakeService{})
+	if err := server.Serve(context.Background(), input, output); err != nil {
+		t.Fatalf("Serve() error: %v", err)
+	}
+
+	reader := bufio.NewReader(output)
+	first := readLegacyTestFrame(t, reader)
+	if got := first["result"].(map[string]any)["protocolVersion"]; got != rootsProtocol {
+		t.Fatalf("protocolVersion = %v, want %s", got, rootsProtocol)
+	}
+
+	second := readLegacyTestFrame(t, reader)
+	tools := second["result"].(map[string]any)["tools"].([]any)
+	if len(tools) != 3 {
+		t.Fatalf("tools/list returned %d tools, want 3", len(tools))
+	}
+}
+
+func TestServerSearchToolCall(t *testing.T) {
+	t.Parallel()
+
+	input := bytes.NewBuffer(nil)
+	writeTestFrame(t, input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "search-1",
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "search_code",
+			"arguments": map[string]any{
+				"query":   "run cli",
+				"details": true,
+			},
+		},
+	})
+
+	output := bytes.NewBuffer(nil)
+	server := NewServer(fakeService{})
+	if err := server.Serve(context.Background(), input, output); err != nil {
+		t.Fatalf("Serve() error: %v", err)
+	}
+
+	resp := readTestFrame(t, bufio.NewReader(output))
+	result := resp["result"].(map[string]any)
+	content := result["content"].([]any)
+	text := content[0].(map[string]any)["text"].(string)
+	if !strings.Contains(text, "Found 1 matches") {
+		t.Fatalf("search_code text = %q", text)
+	}
+	structured := result["structuredContent"].(map[string]any)
+	if got := structured["query"]; got != "run cli" {
+		t.Fatalf("structuredContent.query = %v", got)
+	}
+}
+
+func TestServerResourcesListAndTemplatesList(t *testing.T) {
+	t.Parallel()
+
+	input := bytes.NewBuffer(nil)
+	writeTestFrame(t, input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "resources/list",
+	})
+	writeTestFrame(t, input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "resources/templates/list",
+	})
+
+	output := bytes.NewBuffer(nil)
+	server := NewServer(fakeService{})
+	if err := server.Serve(context.Background(), input, output); err != nil {
+		t.Fatalf("Serve() error: %v", err)
+	}
+
+	reader := bufio.NewReader(output)
+	first := readTestFrame(t, reader)
+	resources := first["result"].(map[string]any)["resources"].([]any)
+	if len(resources) != 2 {
+		t.Fatalf("resources/list returned %d resources, want 2", len(resources))
+	}
+	firstResource := resources[0].(map[string]any)
+	if got := firstResource["uri"]; got != docsOverviewResourceURI {
+		t.Fatalf("first resource uri = %v, want %s", got, docsOverviewResourceURI)
+	}
+
+	second := readTestFrame(t, reader)
+	templates := second["result"].(map[string]any)["resourceTemplates"].([]any)
+	if len(templates) != 1 {
+		t.Fatalf("resources/templates/list returned %d templates, want 1", len(templates))
+	}
+	firstTemplate := templates[0].(map[string]any)
+	if got := firstTemplate["uriTemplate"]; got != toolResourceTemplateURI {
+		t.Fatalf("template uri = %v, want %s", got, toolResourceTemplateURI)
+	}
+}
+
+func TestServerResourcesReadOverviewAndToolDoc(t *testing.T) {
+	t.Parallel()
+
+	input := bytes.NewBuffer(nil)
+	writeTestFrame(t, input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "resources/read",
+		"params": map[string]any{
+			"uri": workspaceOverviewResourceURI,
+		},
+	})
+	writeTestFrame(t, input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "resources/read",
+		"params": map[string]any{
+			"uri": "unch://tool/search_code",
+		},
+	})
+
+	output := bytes.NewBuffer(nil)
+	server := NewServer(fakeService{})
+	if err := server.Serve(context.Background(), input, output); err != nil {
+		t.Fatalf("Serve() error: %v", err)
+	}
+
+	reader := bufio.NewReader(output)
+	first := readTestFrame(t, reader)
+	firstContents := first["result"].(map[string]any)["contents"].([]any)
+	overview := firstContents[0].(map[string]any)["text"].(string)
+	if !strings.Contains(overview, "/repo") {
+		t.Fatalf("workspace overview text missing root: %q", overview)
+	}
+	if !strings.Contains(overview, "unch://tool/search_code") {
+		t.Fatalf("workspace overview missing tool doc reference: %q", overview)
+	}
+
+	second := readTestFrame(t, reader)
+	secondContents := second["result"].(map[string]any)["contents"].([]any)
+	toolDoc := secondContents[0].(map[string]any)["text"].(string)
+	if !strings.Contains(toolDoc, "`query`") {
+		t.Fatalf("tool doc missing query argument: %q", toolDoc)
+	}
+}
+
+func TestServerInvalidToolArgumentsReturnJSONRPCError(t *testing.T) {
+	t.Parallel()
+
+	input := bytes.NewBuffer(nil)
+	writeTestFrame(t, input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      7,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "search_code",
+			"arguments": "not-an-object",
+		},
+	})
+
+	output := bytes.NewBuffer(nil)
+	server := NewServer(fakeService{})
+	if err := server.Serve(context.Background(), input, output); err != nil {
+		t.Fatalf("Serve() error: %v", err)
+	}
+
+	resp := readTestFrame(t, bufio.NewReader(output))
+	errObj := resp["error"].(map[string]any)
+	if code := int(errObj["code"].(float64)); code != errCodeInvalidParams {
+		t.Fatalf("error.code = %d, want %d", code, errCodeInvalidParams)
+	}
+}
+
+func writeTestFrame(t *testing.T, w io.Writer, body any) {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal test frame: %v", err)
+	}
+	if err := writeNewlineMessage(w, payload); err != nil {
+		t.Fatalf("writeNewlineMessage() error: %v", err)
+	}
+}
+
+func writeLegacyTestFrame(t *testing.T, w io.Writer, body any) {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal legacy test frame: %v", err)
+	}
+	if err := writeContentLengthMessage(w, payload); err != nil {
+		t.Fatalf("writeContentLengthMessage() error: %v", err)
+	}
+}
+
+func readTestFrame(t *testing.T, r *bufio.Reader) map[string]any {
+	t.Helper()
+	payload := readRawFrame(t, r)
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal frame: %v", err)
+	}
+	return decoded
+}
+
+func readRawFrame(t *testing.T, r *bufio.Reader) []byte {
+	t.Helper()
+	payload, err := readNewlineMessage(r)
+	if err != nil {
+		t.Fatalf("readNewlineMessage() error: %v", err)
+	}
+	return payload
+}
+
+func readLegacyTestFrame(t *testing.T, r *bufio.Reader) map[string]any {
+	t.Helper()
+	payload, err := readContentLengthMessage(r, "")
+	if err != nil {
+		t.Fatalf("readContentLengthMessage() error: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal legacy frame: %v", err)
+	}
+	return decoded
+}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -14,8 +14,8 @@ type Reporter interface {
 }
 
 type Repository interface {
-	SearchCurrent(ctx context.Context, modelID string, queryEmbedding []float32, limit int) ([]SearchResult, error)
-	ListCurrentSymbols(ctx context.Context, modelID string) ([]SearchResult, error)
+	SearchCurrent(ctx context.Context, provider string, modelID string, queryEmbedding []float32, limit int) ([]SearchResult, error)
+	ListCurrentSymbols(ctx context.Context, provider string, modelID string) ([]SearchResult, error)
 }
 
 type Embedder interface {
@@ -39,6 +39,7 @@ type Params struct {
 	Limit       int
 	Mode        string
 	MaxDistance float64
+	Provider    string
 	ModelID     string
 }
 
@@ -128,8 +129,12 @@ func (s Service) searchSemanticCurrent(ctx context.Context, params Params, _ Rep
 	if modelID == "" {
 		modelID = "embeddinggemma"
 	}
+	provider := params.Provider
+	if provider == "" {
+		provider = "llama.cpp"
+	}
 
-	candidates, err := s.Repo.SearchCurrent(ctx, modelID, queryVec, candidateLimit)
+	candidates, err := s.Repo.SearchCurrent(ctx, provider, modelID, queryVec, candidateLimit)
 	if err != nil {
 		return nil, fmt.Errorf("search current index: %w", err)
 	}
@@ -180,8 +185,12 @@ func (s Service) searchLexicalCurrent(ctx context.Context, params Params, _ Repo
 	if modelID == "" {
 		modelID = "embeddinggemma"
 	}
+	provider := params.Provider
+	if provider == "" {
+		provider = "llama.cpp"
+	}
 
-	candidates, err := s.Repo.ListCurrentSymbols(ctx, modelID)
+	candidates, err := s.Repo.ListCurrentSymbols(ctx, provider, modelID)
 	if err != nil {
 		return nil, fmt.Errorf("list current symbols: %w", err)
 	}

--- a/internal/search/service_run_test.go
+++ b/internal/search/service_run_test.go
@@ -20,11 +20,11 @@ type mockRepo struct {
 	lexical  []SearchResult
 }
 
-func (m mockRepo) SearchCurrent(ctx context.Context, modelID string, queryEmbedding []float32, limit int) ([]SearchResult, error) {
+func (m mockRepo) SearchCurrent(ctx context.Context, provider string, modelID string, queryEmbedding []float32, limit int) ([]SearchResult, error) {
 	return m.semantic, nil
 }
 
-func (m mockRepo) ListCurrentSymbols(ctx context.Context, modelID string) ([]SearchResult, error) {
+func (m mockRepo) ListCurrentSymbols(ctx context.Context, provider string, modelID string) ([]SearchResult, error) {
 	return m.lexical, nil
 }
 

--- a/internal/semsearch/testdb_test.go
+++ b/internal/semsearch/testdb_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/uchebnick/unch/internal/indexing"
 )
 
+const testProvider = "llama.cpp"
+
 func writeTestIndexDB(t *testing.T, dbPath string, version int64, path string, line int, commentHash string, embedding []float32) string {
 	t.Helper()
 	_ = version
@@ -28,14 +30,14 @@ func writeTestIndexDB(t *testing.T, dbPath string, version int64, path string, l
 
 	const modelID = "embeddinggemma"
 
-	snapshotID, err := store.BeginSnapshot(ctx, modelID)
+	snapshotID, err := store.BeginSnapshot(ctx, testProvider, modelID)
 	if err != nil {
 		t.Fatalf("BeginSnapshot() error: %v", err)
 	}
-	if err := store.AddEmbedding(ctx, modelID, commentHash, embedding); err != nil {
+	if err := store.AddEmbedding(ctx, testProvider, modelID, commentHash, embedding); err != nil {
 		t.Fatalf("AddEmbedding() error: %v", err)
 	}
-	if err := store.InsertSymbol(ctx, snapshotID, modelID, path, indexing.IndexedSymbol{
+	if err := store.InsertSymbol(ctx, snapshotID, testProvider, modelID, path, indexing.IndexedSymbol{
 		Line:          line,
 		Kind:          "function",
 		Name:          "TestSymbol",
@@ -45,7 +47,7 @@ func writeTestIndexDB(t *testing.T, dbPath string, version int64, path string, l
 	}, commentHash); err != nil {
 		t.Fatalf("InsertSymbol() error: %v", err)
 	}
-	if err := store.ActivateSnapshot(ctx, modelID, snapshotID); err != nil {
+	if err := store.ActivateSnapshot(ctx, testProvider, modelID, snapshotID); err != nil {
 		t.Fatalf("ActivateSnapshot() error: %v", err)
 	}
 

--- a/internal/semsearch/tokens.go
+++ b/internal/semsearch/tokens.go
@@ -13,11 +13,11 @@ func LocalTokensPath(localDir string) string {
 }
 
 func GlobalTokensPath() (string, error) {
-	globalDir, err := globalSemsearchDir()
+	configDir, err := globalConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(globalDir, "tokens.json"), nil
+	return filepath.Join(configDir, "tokens.json"), nil
 }
 
 func ResolveProviderToken(localDir string, provider string) (string, error) {
@@ -116,4 +116,22 @@ func providerTokenEnv(provider string) string {
 	default:
 		return ""
 	}
+}
+
+func globalConfigDir() (string, error) {
+	if custom := strings.TrimSpace(os.Getenv("UNCH_CONFIG_HOME")); custom != "" {
+		return filepath.Abs(custom)
+	}
+
+	configDir, err := os.UserConfigDir()
+	if err == nil && strings.TrimSpace(configDir) != "" {
+		return filepath.Join(configDir, "unch"), nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(homeDir) == "" {
+		return "", fmt.Errorf("resolve global config dir: %w", err)
+	}
+
+	return filepath.Join(homeDir, ".config", "unch"), nil
 }

--- a/internal/semsearch/tokens.go
+++ b/internal/semsearch/tokens.go
@@ -1,0 +1,137 @@
+package semsearch
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func LocalTokensPath(localDir string) string {
+	return filepath.Join(localDir, "tokens.json")
+}
+
+func GlobalTokensPath() (string, error) {
+	configDir, err := globalConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "tokens.json"), nil
+}
+
+func ResolveProviderToken(localDir string, provider string) (string, error) {
+	if envName := providerTokenEnv(provider); envName != "" {
+		if token := strings.TrimSpace(os.Getenv(envName)); token != "" {
+			return token, nil
+		}
+	}
+
+	paths := make([]string, 0, 2)
+	if globalPath, err := GlobalTokensPath(); err == nil {
+		paths = append(paths, globalPath)
+	} else {
+		return "", err
+	}
+	if strings.TrimSpace(localDir) != "" {
+		paths = append(paths, LocalTokensPath(localDir))
+	}
+
+	for _, path := range paths {
+		tokens, err := loadTokensFile(path)
+		if err != nil {
+			return "", err
+		}
+		if token := strings.TrimSpace(tokens[provider]); token != "" {
+			return token, nil
+		}
+	}
+
+	globalPath, err := GlobalTokensPath()
+	if err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("missing token for provider %q; set %s or add %q to %s or %s", provider, providerTokenEnv(provider), provider, globalPath, LocalTokensPath(localDir))
+}
+
+func SaveProviderToken(path string, provider string, token string) error {
+	path = strings.TrimSpace(path)
+	provider = strings.TrimSpace(strings.ToLower(provider))
+	token = strings.TrimSpace(token)
+
+	if path == "" {
+		return fmt.Errorf("token path is required")
+	}
+	if provider == "" {
+		return fmt.Errorf("provider is required")
+	}
+	if token == "" {
+		return fmt.Errorf("token is required")
+	}
+
+	tokens, err := loadTokensFile(path)
+	if err != nil {
+		return err
+	}
+	tokens[provider] = token
+
+	data, err := json.MarshalIndent(tokens, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", path, err)
+	}
+	data = append(data, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func loadTokensFile(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var tokens map[string]string
+	if err := json.Unmarshal(data, &tokens); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if tokens == nil {
+		return map[string]string{}, nil
+	}
+	return tokens, nil
+}
+
+func providerTokenEnv(provider string) string {
+	switch strings.TrimSpace(strings.ToLower(provider)) {
+	case "openrouter":
+		return "OPENROUTER_API_KEY"
+	default:
+		return ""
+	}
+}
+
+func globalConfigDir() (string, error) {
+	if custom := strings.TrimSpace(os.Getenv("UNCH_CONFIG_HOME")); custom != "" {
+		return filepath.Abs(custom)
+	}
+
+	configDir, err := os.UserConfigDir()
+	if err == nil && strings.TrimSpace(configDir) != "" {
+		return filepath.Join(configDir, "unch"), nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(homeDir) == "" {
+		return "", fmt.Errorf("resolve global config dir: %w", err)
+	}
+
+	return filepath.Join(homeDir, ".config", "unch"), nil
+}

--- a/internal/semsearch/tokens.go
+++ b/internal/semsearch/tokens.go
@@ -13,11 +13,11 @@ func LocalTokensPath(localDir string) string {
 }
 
 func GlobalTokensPath() (string, error) {
-	configDir, err := globalConfigDir()
+	globalDir, err := globalSemsearchDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(configDir, "tokens.json"), nil
+	return filepath.Join(globalDir, "tokens.json"), nil
 }
 
 func ResolveProviderToken(localDir string, provider string) (string, error) {
@@ -116,22 +116,4 @@ func providerTokenEnv(provider string) string {
 	default:
 		return ""
 	}
-}
-
-func globalConfigDir() (string, error) {
-	if custom := strings.TrimSpace(os.Getenv("UNCH_CONFIG_HOME")); custom != "" {
-		return filepath.Abs(custom)
-	}
-
-	configDir, err := os.UserConfigDir()
-	if err == nil && strings.TrimSpace(configDir) != "" {
-		return filepath.Join(configDir, "unch"), nil
-	}
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil || strings.TrimSpace(homeDir) == "" {
-		return "", fmt.Errorf("resolve global config dir: %w", err)
-	}
-
-	return filepath.Join(homeDir, ".config", "unch"), nil
 }

--- a/internal/semsearch/tokens_test.go
+++ b/internal/semsearch/tokens_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestResolveProviderTokenPrefersEnv(t *testing.T) {
 	t.Setenv("OPENROUTER_API_KEY", "env-token")
-	t.Setenv("SEMSEARCH_HOME", t.TempDir())
+	t.Setenv("UNCH_CONFIG_HOME", t.TempDir())
 
 	root := t.TempDir()
 	token, err := ResolveProviderToken(filepath.Join(root, ".semsearch"), "openrouter")
@@ -22,7 +22,7 @@ func TestResolveProviderTokenPrefersEnv(t *testing.T) {
 }
 
 func TestResolveProviderTokenFallsBackToLocalFile(t *testing.T) {
-	t.Setenv("SEMSEARCH_HOME", t.TempDir())
+	t.Setenv("UNCH_CONFIG_HOME", t.TempDir())
 
 	localDir := filepath.Join(t.TempDir(), ".semsearch")
 	if err := os.MkdirAll(localDir, 0o755); err != nil {
@@ -42,8 +42,8 @@ func TestResolveProviderTokenFallsBackToLocalFile(t *testing.T) {
 }
 
 func TestResolveProviderTokenFallsBackToGlobalFile(t *testing.T) {
-	semsearchHome := t.TempDir()
-	t.Setenv("SEMSEARCH_HOME", semsearchHome)
+	configHome := t.TempDir()
+	t.Setenv("UNCH_CONFIG_HOME", configHome)
 
 	globalPath, err := GlobalTokensPath()
 	if err != nil {
@@ -89,8 +89,8 @@ func TestSaveProviderTokenMergesExistingProviders(t *testing.T) {
 }
 
 func TestResolveProviderTokenPrefersGlobalBeforeLocalFile(t *testing.T) {
-	semsearchHome := t.TempDir()
-	t.Setenv("SEMSEARCH_HOME", semsearchHome)
+	configHome := t.TempDir()
+	t.Setenv("UNCH_CONFIG_HOME", configHome)
 
 	globalPath, err := GlobalTokensPath()
 	if err != nil {

--- a/internal/semsearch/tokens_test.go
+++ b/internal/semsearch/tokens_test.go
@@ -1,0 +1,121 @@
+package semsearch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveProviderTokenPrefersEnv(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "env-token")
+	t.Setenv("UNCH_CONFIG_HOME", t.TempDir())
+
+	root := t.TempDir()
+	token, err := ResolveProviderToken(filepath.Join(root, ".semsearch"), "openrouter")
+	if err != nil {
+		t.Fatalf("ResolveProviderToken() error: %v", err)
+	}
+	if token != "env-token" {
+		t.Fatalf("ResolveProviderToken() = %q", token)
+	}
+}
+
+func TestResolveProviderTokenFallsBackToLocalFile(t *testing.T) {
+	t.Setenv("UNCH_CONFIG_HOME", t.TempDir())
+
+	localDir := filepath.Join(t.TempDir(), ".semsearch")
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	if err := os.WriteFile(LocalTokensPath(localDir), []byte("{\"openrouter\":\"local-token\"}"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	token, err := ResolveProviderToken(localDir, "openrouter")
+	if err != nil {
+		t.Fatalf("ResolveProviderToken() error: %v", err)
+	}
+	if token != "local-token" {
+		t.Fatalf("ResolveProviderToken() = %q", token)
+	}
+}
+
+func TestResolveProviderTokenFallsBackToGlobalFile(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("UNCH_CONFIG_HOME", configHome)
+
+	globalPath, err := GlobalTokensPath()
+	if err != nil {
+		t.Fatalf("GlobalTokensPath() error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	if err := os.WriteFile(globalPath, []byte("{\"openrouter\":\"global-token\"}"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	token, err := ResolveProviderToken(filepath.Join(t.TempDir(), ".semsearch"), "openrouter")
+	if err != nil {
+		t.Fatalf("ResolveProviderToken() error: %v", err)
+	}
+	if token != "global-token" {
+		t.Fatalf("ResolveProviderToken() = %q", token)
+	}
+}
+
+func TestSaveProviderTokenMergesExistingProviders(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	if err := os.WriteFile(path, []byte("{\"other\":\"keep-me\"}\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	if err := SaveProviderToken(path, "openrouter", "saved-token"); err != nil {
+		t.Fatalf("SaveProviderToken() error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "\"other\": \"keep-me\"") {
+		t.Fatalf("tokens file = %q, want preserved provider", text)
+	}
+	if !strings.Contains(text, "\"openrouter\": \"saved-token\"") {
+		t.Fatalf("tokens file = %q, want saved provider", text)
+	}
+}
+
+func TestResolveProviderTokenPrefersGlobalBeforeLocalFile(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("UNCH_CONFIG_HOME", configHome)
+
+	globalPath, err := GlobalTokensPath()
+	if err != nil {
+		t.Fatalf("GlobalTokensPath() error: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	if err := os.WriteFile(globalPath, []byte("{\"openrouter\":\"global-token\"}"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	localDir := filepath.Join(t.TempDir(), ".semsearch")
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	if err := os.WriteFile(LocalTokensPath(localDir), []byte("{\"openrouter\":\"local-token\"}"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	token, err := ResolveProviderToken(localDir, "openrouter")
+	if err != nil {
+		t.Fatalf("ResolveProviderToken() error: %v", err)
+	}
+	if token != "global-token" {
+		t.Fatalf("ResolveProviderToken() = %q", token)
+	}
+}

--- a/internal/semsearch/tokens_test.go
+++ b/internal/semsearch/tokens_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestResolveProviderTokenPrefersEnv(t *testing.T) {
 	t.Setenv("OPENROUTER_API_KEY", "env-token")
-	t.Setenv("UNCH_CONFIG_HOME", t.TempDir())
+	t.Setenv("SEMSEARCH_HOME", t.TempDir())
 
 	root := t.TempDir()
 	token, err := ResolveProviderToken(filepath.Join(root, ".semsearch"), "openrouter")
@@ -22,7 +22,7 @@ func TestResolveProviderTokenPrefersEnv(t *testing.T) {
 }
 
 func TestResolveProviderTokenFallsBackToLocalFile(t *testing.T) {
-	t.Setenv("UNCH_CONFIG_HOME", t.TempDir())
+	t.Setenv("SEMSEARCH_HOME", t.TempDir())
 
 	localDir := filepath.Join(t.TempDir(), ".semsearch")
 	if err := os.MkdirAll(localDir, 0o755); err != nil {
@@ -42,8 +42,8 @@ func TestResolveProviderTokenFallsBackToLocalFile(t *testing.T) {
 }
 
 func TestResolveProviderTokenFallsBackToGlobalFile(t *testing.T) {
-	configHome := t.TempDir()
-	t.Setenv("UNCH_CONFIG_HOME", configHome)
+	semsearchHome := t.TempDir()
+	t.Setenv("SEMSEARCH_HOME", semsearchHome)
 
 	globalPath, err := GlobalTokensPath()
 	if err != nil {
@@ -89,8 +89,8 @@ func TestSaveProviderTokenMergesExistingProviders(t *testing.T) {
 }
 
 func TestResolveProviderTokenPrefersGlobalBeforeLocalFile(t *testing.T) {
-	configHome := t.TempDir()
-	t.Setenv("UNCH_CONFIG_HOME", configHome)
+	semsearchHome := t.TempDir()
+	t.Setenv("SEMSEARCH_HOME", semsearchHome)
 
 	globalPath, err := GlobalTokensPath()
 	if err != nil {

--- a/mintlify/commands.mdx
+++ b/mintlify/commands.mdx
@@ -3,13 +3,17 @@ title: Commands
 description: Overview of the main unch CLI commands.
 ---
 
-`unch` is centered around three main command families:
+`unch` is centered around four main command families:
 
+- `unch auth` to save provider credentials such as an OpenRouter API key
 - [`unch index`](/commands/index) to build or refresh a local index
 - [`unch search`](/commands/search) to query the current index
 - [`unch remote`](/commands/remote) to sync or download published remote state
 
-<CardGroup cols={3}>
+<CardGroup cols={4}>
+  <Card title="Auth" icon="key">
+    Save provider credentials without keeping tokens in your shell environment.
+  </Card>
   <Card title="Index" icon="database" href="/commands/index">
     Build or refresh `.semsearch` for a repository.
   </Card>
@@ -28,6 +32,7 @@ description: Overview of the main unch CLI commands.
 ## Typical local flow
 
 ```bash
+unch auth openrouter --token sk-or-...
 unch index --root .
 unch search "sqlite schema"
 unch search --details "get path variables from a request"

--- a/mintlify/commands/index.mdx
+++ b/mintlify/commands/index.mdx
@@ -142,7 +142,7 @@ unch index --state-dir /tmp/project.semsearch
 ## Notes
 
 - The first run may download the default embedding model and local `yzma` runtime libraries.
-- OpenRouter token lookup checks `OPENROUTER_API_KEY`, then the global `unch` `tokens.json`, then `.semsearch/tokens.json`.
+- OpenRouter token lookup checks `OPENROUTER_API_KEY`, then `~/.config/unch/tokens.json`, then `.semsearch/tokens.json`.
 - If the repository is currently bound to remote CI, a local reindex detaches that binding and returns the manifest to local mode.
 - Use the same provider and model family for `index` and `search`, otherwise ranking quality will be wrong.
 

--- a/mintlify/commands/index.mdx
+++ b/mintlify/commands/index.mdx
@@ -142,7 +142,7 @@ unch index --state-dir /tmp/project.semsearch
 ## Notes
 
 - The first run may download the default embedding model and local `yzma` runtime libraries.
-- OpenRouter token lookup checks `OPENROUTER_API_KEY`, then `~/.config/unch/tokens.json`, then `.semsearch/tokens.json`.
+- OpenRouter token lookup checks `OPENROUTER_API_KEY`, then the global `unch` `tokens.json`, then `.semsearch/tokens.json`.
 - If the repository is currently bound to remote CI, a local reindex detaches that binding and returns the manifest to local mode.
 - Use the same provider and model family for `index` and `search`, otherwise ranking quality will be wrong.
 

--- a/mintlify/commands/index.mdx
+++ b/mintlify/commands/index.mdx
@@ -16,8 +16,8 @@ unch index [flags]
   <Card title="Custom state dir" icon="folder-open">
     Use `--state-dir` when you want the index somewhere other than `<root>/.semsearch`.
   </Card>
-  <Card title="Model-aware snapshots" icon="brain">
-    Each embedding model keeps its own active snapshot.
+  <Card title="Provider-aware snapshots" icon="brain">
+    Each provider and model pair keeps its own active snapshot.
   </Card>
 </CardGroup>
 
@@ -32,6 +32,12 @@ unch index [flags]
   <Step title="Optionally pick a model or external state dir">
     ```bash
     unch index --model qwen3 --state-dir /tmp/project.semsearch
+    ```
+  </Step>
+  <Step title="Or use OpenRouter embeddings">
+    ```bash
+    unch auth openrouter --token sk-or-...
+    unch index --provider openrouter --model openai/text-embedding-3-small
     ```
   </Step>
   <Step title="Reuse warm state when possible">
@@ -60,6 +66,14 @@ Embedding model to use. Accepts:
 - `embeddinggemma`
 - `qwen3`
 - a direct path to a `.gguf` file
+- an OpenRouter model id when `--provider openrouter` is selected
+
+### `--provider`
+
+Embedding provider to use. Accepted values:
+
+- `llama.cpp`
+- `openrouter`
 
 ### `--exclude`
 
@@ -76,10 +90,6 @@ Path to a `.gitignore` file. Defaults to `<root>/.gitignore`.
 ### `--ctx-size`
 
 llama context size. `0` uses the selected model default.
-
-### `--batch-size`
-
-llama batch size. `0` uses the selected model default.
 
 ### `--verbose`
 
@@ -99,6 +109,8 @@ Legacy fallback file-context prefix for unsupported files or parser failures.
 unch index --root .
 unch index --exclude node_modules --exclude dist
 unch index --model qwen3
+unch auth openrouter --token sk-or-...
+unch index --provider openrouter --model openai/text-embedding-3-small
 unch index --model ~/.semsearch/models/Qwen3-Embedding-0.6B-Q8_0.gguf
 unch index --state-dir /tmp/project.semsearch
 ```
@@ -119,13 +131,20 @@ unch index --state-dir /tmp/project.semsearch
     unch index --root . --model qwen3
     ```
   </Tab>
+  <Tab title="OpenRouter">
+    ```bash
+    unch auth openrouter --token sk-or-...
+    unch index --root . --provider openrouter --model openai/text-embedding-3-small
+    ```
+  </Tab>
 </Tabs>
 
 ## Notes
 
 - The first run may download the default embedding model and local `yzma` runtime libraries.
+- OpenRouter token lookup checks `OPENROUTER_API_KEY`, then `~/.config/unch/tokens.json`, then `.semsearch/tokens.json`.
 - If the repository is currently bound to remote CI, a local reindex detaches that binding and returns the manifest to local mode.
-- Use the same model family for `index` and `search`, otherwise ranking quality will be wrong.
+- Use the same provider and model family for `index` and `search`, otherwise ranking quality will be wrong.
 
 <AccordionGroup>
   <Accordion title="Why is --db deprecated?">

--- a/mintlify/commands/search.mdx
+++ b/mintlify/commands/search.mdx
@@ -121,7 +121,7 @@ unch search --state-dir /tmp/project.semsearch "router middleware"
 
 - `auto` stays semantic-first for natural-language queries.
 - If the manifest is bound to remote CI, `unch search` can refresh from remote automatically before running the query.
-- OpenRouter token lookup checks `OPENROUTER_API_KEY`, then the global `unch` `tokens.json`, then `.semsearch/tokens.json`.
+- OpenRouter token lookup checks `OPENROUTER_API_KEY`, then `~/.config/unch/tokens.json`, then `.semsearch/tokens.json`.
 - If no active snapshot exists for the requested provider and model, `unch` tells you to run `unch index --provider <provider> --model <model>` first.
 
 <AccordionGroup>

--- a/mintlify/commands/search.mdx
+++ b/mintlify/commands/search.mdx
@@ -121,7 +121,7 @@ unch search --state-dir /tmp/project.semsearch "router middleware"
 
 - `auto` stays semantic-first for natural-language queries.
 - If the manifest is bound to remote CI, `unch search` can refresh from remote automatically before running the query.
-- OpenRouter token lookup checks `OPENROUTER_API_KEY`, then `~/.config/unch/tokens.json`, then `.semsearch/tokens.json`.
+- OpenRouter token lookup checks `OPENROUTER_API_KEY`, then the global `unch` `tokens.json`, then `.semsearch/tokens.json`.
 - If no active snapshot exists for the requested provider and model, `unch` tells you to run `unch index --provider <provider> --model <model>` first.
 
 <AccordionGroup>

--- a/mintlify/commands/search.mdx
+++ b/mintlify/commands/search.mdx
@@ -78,6 +78,10 @@ Show symbol kind, name, signature, docs, and body context for each result.
 
 Query embedding model. Must match the model used when the index was built.
 
+### `--provider`
+
+Embedding provider. Must match the provider used when the index was built.
+
 ### `--root`
 
 Root directory used to render result paths relative to the repository.
@@ -98,10 +102,6 @@ Path to a `yzma` library directory, or one of its shared library files.
 
 llama context size. `0` uses the selected model default.
 
-### `--batch-size`
-
-llama batch size. `0` uses the selected model default.
-
 ### `--verbose`
 
 Enable verbose `yzma` logging.
@@ -113,6 +113,7 @@ unch search "sqlite schema"
 unch search --mode lexical "Run"
 unch search --details "get path variables from a request"
 unch search --model qwen3 "search query"
+unch search --provider openrouter --model openai/text-embedding-3-small "search query"
 unch search --state-dir /tmp/project.semsearch "router middleware"
 ```
 
@@ -120,7 +121,8 @@ unch search --state-dir /tmp/project.semsearch "router middleware"
 
 - `auto` stays semantic-first for natural-language queries.
 - If the manifest is bound to remote CI, `unch search` can refresh from remote automatically before running the query.
-- If no active snapshot exists for the requested model, `unch` tells you to run `unch index --model <model>` first.
+- OpenRouter token lookup checks `OPENROUTER_API_KEY`, then `~/.config/unch/tokens.json`, then `.semsearch/tokens.json`.
+- If no active snapshot exists for the requested provider and model, `unch` tells you to run `unch index --provider <provider> --model <model>` first.
 
 <AccordionGroup>
   <Accordion title="When should I force lexical mode?">
@@ -130,8 +132,8 @@ unch search --state-dir /tmp/project.semsearch "router middleware"
     Force semantic mode when the query is about behavior or intent and exact string overlap is weak.
   </Accordion>
   <Accordion title="Why should index and search use the same model?">
-    Ranking quality depends on query and document embeddings living in the same model space.
+    Ranking quality depends on query and document embeddings living in the same provider and model space.
 
-    If you indexed with one model and search with another, the results may degrade or fail entirely.
+    If you indexed with one provider or model and search with another, the results may degrade or fail entirely.
   </Accordion>
 </AccordionGroup>

--- a/mintlify/concepts/models.mdx
+++ b/mintlify/concepts/models.mdx
@@ -1,9 +1,29 @@
 ---
 title: Embedding models
-description: How unch uses local GGUF embedding models and which built-in profiles are available.
+description: How unch uses local GGUF models or OpenRouter embedding models, and how snapshots stay isolated per provider.
 ---
 
-`unch` computes embeddings locally from GGUF models. The model used for `index` and `search` must match.
+`unch` supports two embedding providers:
+
+- `llama.cpp` for local GGUF models
+- `openrouter` for remote embedding APIs
+
+The provider and model used for `index` and `search` must match.
+
+## Providers
+
+### `llama.cpp`
+
+- default provider
+- works with built-in model ids such as `embeddinggemma` and `qwen3`
+- also accepts a direct `.gguf` path
+- may download a default embedding model and local `yzma` runtime on first run
+
+### `openrouter`
+
+- remote provider
+- uses an OpenRouter embedding model id such as `openai/text-embedding-3-small`
+- token can be stored with `unch auth openrouter --token ...`
 
 ## Known model ids
 
@@ -26,16 +46,20 @@ unch index --model embeddinggemma
 unch index --model qwen3
 unch search --model qwen3 "create a new router"
 unch index --model /path/to/model.gguf
+unch auth openrouter --token sk-or-...
+unch index --provider openrouter --model openai/text-embedding-3-small
+unch search --provider openrouter --model openai/text-embedding-3-small "create a new router"
 ```
 
-## Model-scoped snapshots
+## Provider-scoped snapshots
 
-Each model keeps its own active snapshot in the local index state.
+Each provider and model pair keeps its own active snapshot in the local index state.
 
 That means:
 
 - rebuilding `qwen3` does not replace the active `embeddinggemma` snapshot
-- switching models does require a matching reindex before search
+- rebuilding `openrouter/openai/text-embedding-3-small` does not replace the active `llama.cpp/embeddinggemma` snapshot
+- switching providers or models does require a matching reindex before search
 
 ## Default cache location
 
@@ -47,6 +71,20 @@ $SEMSEARCH_HOME/models
 
 Otherwise `unch` uses the system user cache directory for the current platform.
 
+## Token storage for OpenRouter
+
+`unch auth openrouter` writes to:
+
+```text
+~/.config/unch/tokens.json
+```
+
+At runtime, token lookup order is:
+
+1. `OPENROUTER_API_KEY`
+2. `~/.config/unch/tokens.json`
+3. `.semsearch/tokens.json`
+
 ## Practical rule
 
-Always use the same model family for both `unch index` and `unch search`. If they differ, ranking quality will be wrong.
+Always use the same provider and model family for both `unch index` and `unch search`. If they differ, ranking quality will be wrong.

--- a/mintlify/concepts/models.mdx
+++ b/mintlify/concepts/models.mdx
@@ -76,15 +76,13 @@ Otherwise `unch` uses the system user cache directory for the current platform.
 `unch auth openrouter` writes to:
 
 ```text
-$SEMSEARCH_HOME/tokens.json
+~/.config/unch/tokens.json
 ```
-
-If `SEMSEARCH_HOME` is not set, `unch` uses the platform user cache directory and stores the token there as `unch/tokens.json`.
 
 At runtime, token lookup order is:
 
 1. `OPENROUTER_API_KEY`
-2. global `unch` `tokens.json`
+2. `~/.config/unch/tokens.json`
 3. `.semsearch/tokens.json`
 
 ## Practical rule

--- a/mintlify/concepts/models.mdx
+++ b/mintlify/concepts/models.mdx
@@ -76,13 +76,15 @@ Otherwise `unch` uses the system user cache directory for the current platform.
 `unch auth openrouter` writes to:
 
 ```text
-~/.config/unch/tokens.json
+$SEMSEARCH_HOME/tokens.json
 ```
+
+If `SEMSEARCH_HOME` is not set, `unch` uses the platform user cache directory and stores the token there as `unch/tokens.json`.
 
 At runtime, token lookup order is:
 
 1. `OPENROUTER_API_KEY`
-2. `~/.config/unch/tokens.json`
+2. global `unch` `tokens.json`
 3. `.semsearch/tokens.json`
 
 ## Practical rule

--- a/mintlify/index.mdx
+++ b/mintlify/index.mdx
@@ -36,6 +36,13 @@ Everything stays local by default. Remote publishing is optional.
     unch search --details "get path variables from a request"
     ```
   </Tab>
+  <Tab title="OpenRouter">
+    ```bash
+    unch auth openrouter --token sk-or-...
+    unch index --root . --provider openrouter --model openai/text-embedding-3-small
+    unch search --provider openrouter --model openai/text-embedding-3-small "create a new router"
+    ```
+  </Tab>
   <Tab title="Shared via CI">
     ```bash
     unch create ci

--- a/mintlify/installation.mdx
+++ b/mintlify/installation.mdx
@@ -136,11 +136,13 @@ unch auth openrouter --token sk-or-...
 unch index --provider openrouter --model openai/text-embedding-3-small
 ```
 
-By default `unch auth openrouter` stores the token in:
+By default `unch auth openrouter` stores the token in the global `unch` state directory:
 
 ```text
-~/.config/unch/tokens.json
+$SEMSEARCH_HOME/tokens.json
 ```
+
+If `SEMSEARCH_HOME` is not set, `unch` uses the platform user cache directory and keeps the token there as `unch/tokens.json`.
 
 That keeps the token out of your project checkout and out of your shell environment.
 

--- a/mintlify/installation.mdx
+++ b/mintlify/installation.mdx
@@ -127,6 +127,35 @@ unch --version
 unch --help
 ```
 
+## Configure OpenRouter
+
+If you want to use OpenRouter for embeddings instead of the local `llama.cpp` runtime:
+
+```bash
+unch auth openrouter --token sk-or-...
+unch index --provider openrouter --model openai/text-embedding-3-small
+```
+
+By default `unch auth openrouter` stores the token in:
+
+```text
+~/.config/unch/tokens.json
+```
+
+That keeps the token out of your project checkout and out of your shell environment.
+
+For one repository only, use:
+
+```bash
+unch auth openrouter --token sk-or-... --local
+```
+
+That writes:
+
+```text
+.semsearch/tokens.json
+```
+
 <AccordionGroup>
   <Accordion title="When should I prefer release installers?">
     Prefer the release installers when your platform has a matching published archive and you just want a working binary quickly.

--- a/mintlify/installation.mdx
+++ b/mintlify/installation.mdx
@@ -136,13 +136,11 @@ unch auth openrouter --token sk-or-...
 unch index --provider openrouter --model openai/text-embedding-3-small
 ```
 
-By default `unch auth openrouter` stores the token in the global `unch` state directory:
+By default `unch auth openrouter` stores the token in:
 
 ```text
-$SEMSEARCH_HOME/tokens.json
+~/.config/unch/tokens.json
 ```
-
-If `SEMSEARCH_HOME` is not set, `unch` uses the platform user cache directory and keeps the token there as `unch/tokens.json`.
 
 That keeps the token out of your project checkout and out of your shell environment.
 

--- a/mintlify/quickstart.mdx
+++ b/mintlify/quickstart.mdx
@@ -47,6 +47,28 @@ description: Index a repository and run your first search in under a minute.
   </Step>
 </Steps>
 
+## OpenRouter flow
+
+<Steps>
+  <Step title="Save the token once">
+    ```bash
+    unch auth openrouter --token sk-or-...
+    ```
+  </Step>
+
+  <Step title="Index with OpenRouter embeddings">
+    ```bash
+    unch index --root . --provider openrouter --model openai/text-embedding-3-small
+    ```
+  </Step>
+
+  <Step title="Search with the same provider and model">
+    ```bash
+    unch search --provider openrouter --model openai/text-embedding-3-small "create a new router"
+    ```
+  </Step>
+</Steps>
+
 ## Search modes in practice
 
 <Tabs>
@@ -75,13 +97,13 @@ description: Index a repository and run your first search in under a minute.
 
 ## What happens on first run
 
-The first `unch index` may:
+The first local `llama.cpp` index may:
 
 - download the default embedding model
 - fetch local `yzma` runtime libraries
 - create `./.semsearch/`
 
-Each model keeps its own active index snapshot. Rebuilding `qwen3` does not replace the active `embeddinggemma` snapshot until the new run finishes successfully.
+Each provider and model pair keeps its own active index snapshot. Rebuilding `openrouter/openai/text-embedding-3-small` does not replace the active `llama.cpp/embeddinggemma` snapshot until the new run finishes successfully.
 
 <Tip>
   If you want to keep state somewhere other than `./.semsearch`, use `--state-dir`.

--- a/mintlify/reference/compatibility.mdx
+++ b/mintlify/reference/compatibility.mdx
@@ -25,7 +25,7 @@ description: Support matrix, upgrade rules, and versioning contract for unch.
 ## Index compatibility
 
 - `index.db` is a rebuildable cache artifact, not a durable user database
-- Active index state is model-scoped
+- Active index state is provider-scoped and model-scoped
 - When the current binary cannot use a database layout, the fix is to rebuild the index
 
 ## Remote and CI compatibility


### PR DESCRIPTION
## What changed

This adds OpenRouter as a first-class embedding provider alongside `llama.cpp`.

The CLI now has a provider-aware embedding layer, an `unch auth openrouter` command for saving tokens, provider-scoped index state, and matching support across local indexing, search, and MCP.

## Why

Until now `unch` only supported local GGUF embeddings through `llama.cpp`.

This change makes it possible to use remote embedding models through OpenRouter without keeping API keys in the shell environment, while still keeping provider/model snapshots isolated in local state.

## User impact

Users can now:

- save an OpenRouter token with `unch auth openrouter --token ...`
- index with `--provider openrouter --model <remote-model-id>`
- search with the same provider/model pair
- use the same provider flow through `start mcp`

By default tokens are stored in `~/.config/unch/tokens.json`, with optional per-repo storage in `.semsearch/tokens.json`.

## Validation

- `go test ./...`
- real OpenRouter smoke using a temporary token:
  - `unch auth openrouter`
  - `unch index --provider openrouter --model openai/text-embedding-3-small`
  - `unch search --provider openrouter --model openai/text-embedding-3-small`
- `git diff --check`
