### PR TITLE
Add npm MCP installer wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,141 @@ jobs:
           export CC="${{ matrix.cc }}"
           go test $PORTABLE_TEST_PACKAGES
 
+  npm-wrapper:
+    name: npm-wrapper (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-x86_64
+            asset_name: unch_Linux_x86_64.tar.gz
+          - os: ubuntu-24.04-arm
+            label: linux-arm64
+            asset_name: unch_Linux_arm64.tar.gz
+          - os: macos-15-intel
+            label: macos-x86_64
+            asset_name: unch_Darwin_x86_64.tar.gz
+          - os: macos-14
+            label: macos-arm64
+            asset_name: unch_Darwin_arm64.tar.gz
+          - os: windows-latest
+            label: windows-x86_64
+            asset_name: unch_Windows_x86_64.zip
+            msystem: UCRT64
+            msys_pkg: mingw-w64-ucrt-x86_64-gcc
+            cc: gcc
+            msys_release: true
+            msys_update: true
+            msys_cache: true
+          - os: windows-11-arm
+            label: windows-arm64
+            asset_name: unch_Windows_arm64.zip
+            msystem: CLANGARM64
+            msys_pkg: mingw-w64-clang-aarch64-clang
+            cc: clang
+            msys_release: true
+            msys_update: false
+            msys_cache: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Setup MSYS2 toolchain
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          path-type: inherit
+          release: ${{ matrix.msys_release }}
+          update: ${{ matrix.msys_update }}
+          cache: ${{ matrix.msys_cache }}
+          install: ${{ matrix.msys_pkg }}
+
+      - name: Test npm wrapper metadata
+        if: matrix.label == 'linux-x86_64'
+        working-directory: npm/unch
+        run: |
+          set -euo pipefail
+          npm test
+          npm pack --dry-run
+
+      - name: Build local Unix asset for npm wrapper
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset_dir="${RUNNER_TEMP}/npm-wrapper-assets"
+          build_dir="${RUNNER_TEMP}/npm-wrapper-build"
+          mkdir -p "${asset_dir}" "${build_dir}"
+          CGO_ENABLED=1 go build -trimpath \
+            -ldflags "-X github.com/uchebnick/unch/internal/cli.buildVersion=vci-test" \
+            -o "${build_dir}/unch" ./cmd/unch
+          tar -C "${build_dir}" -czf "${asset_dir}/${{ matrix.asset_name }}" unch
+
+      - name: Build local Windows asset for npm wrapper
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          build_dir="$(cygpath -u "$RUNNER_TEMP")/npm-wrapper-build"
+          mkdir -p "${build_dir}"
+          export CGO_ENABLED=1
+          export CC="${{ matrix.cc }}"
+          go build -trimpath \
+            -ldflags "-X github.com/uchebnick/unch/internal/cli.buildVersion=vci-test" \
+            -o "${build_dir}/unch.exe" ./cmd/unch
+
+      - name: Archive local Windows asset for npm wrapper
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $assetDir = Join-Path $env:RUNNER_TEMP "npm-wrapper-assets"
+          $buildDir = Join-Path $env:RUNNER_TEMP "npm-wrapper-build"
+          New-Item -ItemType Directory -Force -Path $assetDir | Out-Null
+          Compress-Archive -Path (Join-Path $buildDir "unch.exe") -DestinationPath (Join-Path $assetDir "${{ matrix.asset_name }}") -Force
+
+      - name: Install npm wrapper from local Unix asset
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          UNCH_BINARY_URL: ${{ runner.temp }}/npm-wrapper-assets/${{ matrix.asset_name }}
+        run: |
+          set -euo pipefail
+          install_dir="$(mktemp -d)"
+          npm install --prefix "${install_dir}" "${GITHUB_WORKSPACE}/npm/unch"
+          "${install_dir}/node_modules/.bin/unch" --version | grep -F "vci-test"
+          "${install_dir}/node_modules/.bin/unch" --help >/dev/null
+          UNCH_MCP_COMMAND="${install_dir}/node_modules/.bin/unch-mcp" node "${GITHUB_WORKSPACE}/npm/unch/scripts/mcp-smoke.js"
+
+      - name: Install npm wrapper from local Windows asset
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $installDir = Join-Path $env:RUNNER_TEMP "npm-wrapper-install"
+          $env:UNCH_BINARY_URL = Join-Path (Join-Path $env:RUNNER_TEMP "npm-wrapper-assets") "${{ matrix.asset_name }}"
+          npm install --prefix $installDir "$env:GITHUB_WORKSPACE\npm\unch"
+          $version = & (Join-Path $installDir "node_modules\.bin\unch.cmd") --version
+          if ($version -notmatch "vci-test") {
+            throw "unexpected version output: $version"
+          }
+          & (Join-Path $installDir "node_modules\.bin\unch.cmd") --help | Out-Null
+          $env:UNCH_MCP_COMMAND = Join-Path $installDir "node_modules\.bin\unch-mcp.cmd"
+          node (Join-Path $env:GITHUB_WORKSPACE "npm\unch\scripts\mcp-smoke.js")
+
   install-smoke:
     name: install-smoke (${{ matrix.label }})
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Homebrew on macOS:
 brew install uchebnick/tap/unch
 ```
 
+npm wrapper:
+
+```bash
+npm install -g @uchebnick/unch
+```
+
+The npm package also installs `unch-mcp`, a zero-argument launcher for MCP clients. Add it as an MCP stdio server with command `unch-mcp` and working directory set to the repository you want to search. MCP clients that expose prompts as slash commands can show the built-in `unch` prompt as `/unch`.
+
 Release installer on macOS and Linux:
 
 ```bash

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -1,0 +1,89 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+)
+
+type promptDefinition struct {
+	Name        string           `json:"name"`
+	Title       string           `json:"title,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Arguments   []promptArgument `json:"arguments,omitempty"`
+}
+
+type promptArgument struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
+type listPromptsResult struct {
+	Prompts    []promptDefinition `json:"prompts"`
+	NextCursor string             `json:"nextCursor,omitempty"`
+}
+
+type promptGetParams struct {
+	Name      string            `json:"name"`
+	Arguments map[string]string `json:"arguments,omitempty"`
+}
+
+type promptGetResult struct {
+	Description string          `json:"description,omitempty"`
+	Messages    []promptMessage `json:"messages"`
+}
+
+type promptMessage struct {
+	Role    string        `json:"role"`
+	Content promptContent `json:"content"`
+}
+
+type promptContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func promptDefinitions() []promptDefinition {
+	return []promptDefinition{
+		{
+			Name:        "unch",
+			Title:       "Search this repository with unch",
+			Description: "Use unch semantic code search before broad file reads or grep-style exploration.",
+			Arguments: []promptArgument{{
+				Name:        "query",
+				Description: "Optional task, feature, bug, identifier, or concept to search for.",
+			}},
+		},
+	}
+}
+
+func getPrompt(params promptGetParams) (promptGetResult, error) {
+	name := strings.TrimSpace(params.Name)
+	if name != "unch" {
+		return promptGetResult{}, invalidParamsError(fmt.Sprintf("unknown prompt %q", params.Name))
+	}
+
+	query := strings.TrimSpace(params.Arguments["query"])
+	text := strings.Join([]string{
+		"Use the unch MCP tools to understand this repository before opening many files.",
+		"First call workspace_status.",
+		"If there is no active index snapshot, call index_repository once and retry.",
+		"Then call search_code with concise semantic or identifier queries.",
+		"Use details=true when signatures, docs, or body snippets help choose exact files.",
+		"Treat search results as ranked candidates and open returned paths for exact implementation details.",
+	}, "\n")
+	if query != "" {
+		text += "\n\nInitial search/task query: " + query
+	}
+
+	return promptGetResult{
+		Description: "Guide the assistant to use unch semantic code search for this workspace.",
+		Messages: []promptMessage{{
+			Role: "user",
+			Content: promptContent{
+				Type: "text",
+				Text: text,
+			},
+		}},
+	}, nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -80,6 +80,9 @@ func (s *Server) buildResponse(ctx context.Context, req requestEnvelope) respons
 		result := initializeResult{
 			ProtocolVersion: negotiatedProtocol(params.ProtocolVersion),
 			Capabilities: map[string]any{
+				"prompts": map[string]any{
+					"listChanged": false,
+				},
 				"tools": map[string]any{
 					"listChanged": false,
 				},
@@ -101,6 +104,22 @@ func (s *Server) buildResponse(ctx context.Context, req requestEnvelope) respons
 			return s.errorEnvelope(req.ID, errCodeInvalidParams, "invalid tools/call params")
 		}
 		result, err := s.callTool(ctx, params)
+		if err != nil {
+			var rpcErr rpcError
+			if errors.As(err, &rpcErr) {
+				return s.errorEnvelope(req.ID, rpcErr.Code, rpcErr.Message)
+			}
+			return s.errorEnvelope(req.ID, errCodeInternal, err.Error())
+		}
+		return s.resultEnvelope(req.ID, result)
+	case "prompts/list":
+		return s.resultEnvelope(req.ID, listPromptsResult{Prompts: promptDefinitions()})
+	case "prompts/get":
+		var params promptGetParams
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return s.errorEnvelope(req.ID, errCodeInvalidParams, "invalid prompts/get params")
+		}
+		result, err := getPrompt(params)
 		if err != nil {
 			var rpcErr rpcError
 			if errors.As(err, &rpcErr) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -80,6 +80,9 @@ func TestServerInitialize(t *testing.T) {
 	if _, ok := capabilities["tools"]; !ok {
 		t.Fatalf("initialize capabilities missing tools: %#v", capabilities)
 	}
+	if _, ok := capabilities["prompts"]; !ok {
+		t.Fatalf("initialize capabilities missing prompts: %#v", capabilities)
+	}
 	if _, ok := capabilities["resources"]; ok {
 		t.Fatalf("initialize capabilities unexpectedly include resources: %#v", capabilities)
 	}
@@ -140,6 +143,57 @@ func TestServerToolsList(t *testing.T) {
 	}
 	if !strings.Contains(descriptions["index_repository"], "Avoid repeated rebuilds") {
 		t.Fatalf("index_repository description = %q", descriptions["index_repository"])
+	}
+}
+
+func TestServerPromptsList(t *testing.T) {
+	t.Parallel()
+
+	resp := serveOne(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "prompts/list",
+	})
+
+	prompts := resp["result"].(map[string]any)["prompts"].([]any)
+	if len(prompts) != 1 {
+		t.Fatalf("prompts/list returned %d prompts, want 1", len(prompts))
+	}
+	prompt := prompts[0].(map[string]any)
+	if got := prompt["name"]; got != "unch" {
+		t.Fatalf("prompt name = %v, want unch", got)
+	}
+	if !strings.Contains(prompt["description"].(string), "semantic code search") {
+		t.Fatalf("prompt description = %q", prompt["description"])
+	}
+}
+
+func TestServerPromptsGetUnch(t *testing.T) {
+	t.Parallel()
+
+	resp := serveOne(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "prompts/get",
+		"params": map[string]any{
+			"name": "unch",
+			"arguments": map[string]string{
+				"query": "request middleware",
+			},
+		},
+	})
+
+	result := resp["result"].(map[string]any)
+	messages := result["messages"].([]any)
+	if len(messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(messages))
+	}
+	content := messages[0].(map[string]any)["content"].(map[string]any)
+	text := content["text"].(string)
+	for _, want := range []string{"workspace_status", "index_repository once", "search_code", "request middleware"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("prompt text missing %q: %q", want, text)
+		}
 	}
 }
 

--- a/npm/unch/.gitignore
+++ b/npm/unch/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+*.tgz

--- a/npm/unch/README.md
+++ b/npm/unch/README.md
@@ -1,0 +1,36 @@
+# @uchebnick/unch
+
+npm installer wrapper for the [`unch`](https://github.com/uchebnick/unch) semantic code search CLI.
+
+```bash
+npm install -g @uchebnick/unch
+unch --version
+unch --help
+```
+
+The package downloads the matching native binary from GitHub Releases during `postinstall`.
+
+## MCP
+
+For MCP clients, use:
+
+- Name: `unch`
+- Command: `unch-mcp`
+- Arguments: leave empty
+- Working directory: the repository you want to search
+
+`unch-mcp` is a small launcher for `unch start mcp`. The MCP server also exposes a prompt named `unch`, so clients that render MCP prompts as slash commands can show it as `/unch`.
+
+If your client supports MCP prompts, run `/unch` before a codebase question to nudge the assistant to call `workspace_status`, `search_code`, and `index_repository` in the right order.
+
+Supported targets:
+
+- macOS `arm64`, `x64`
+- Linux `arm64`, `x64`
+- Windows `arm64`, `x64`
+
+Environment overrides:
+
+- `UNCH_NPM_TAG=v0.3.12` downloads a specific release tag.
+- `UNCH_BINARY_URL=https://...` or `UNCH_BINARY_URL=file:///...` downloads or reads a custom archive.
+- `UNCH_SKIP_DOWNLOAD=1` skips download for package smoke tests.

--- a/npm/unch/bin/unch-mcp.js
+++ b/npm/unch/bin/unch-mcp.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const binaryName = process.platform === "win32" ? "unch.exe" : "unch";
+const binaryPath = path.join(__dirname, "..", "vendor", binaryName);
+
+if (!fs.existsSync(binaryPath)) {
+  console.error("unch native binary is missing.");
+  console.error("Try reinstalling the package: npm install -g @uchebnick/unch");
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, ["start", "mcp", ...process.argv.slice(2)], {
+  stdio: "inherit",
+  windowsHide: false
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+
+process.exit(result.status ?? 0);

--- a/npm/unch/bin/unch.js
+++ b/npm/unch/bin/unch.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const binaryName = process.platform === "win32" ? "unch.exe" : "unch";
+const binaryPath = path.join(__dirname, "..", "vendor", binaryName);
+
+if (!fs.existsSync(binaryPath)) {
+  console.error("unch native binary is missing.");
+  console.error("Try reinstalling the package: npm install -g @uchebnick/unch");
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), {
+  stdio: "inherit",
+  windowsHide: false
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+
+process.exit(result.status ?? 0);

--- a/npm/unch/package.json
+++ b/npm/unch/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@uchebnick/unch",
+  "version": "0.3.12",
+  "description": "npm installer wrapper for the unch semantic code search CLI",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/uchebnick/unch#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/uchebnick/unch.git",
+    "directory": "npm/unch"
+  },
+  "bugs": {
+    "url": "https://github.com/uchebnick/unch/issues"
+  },
+  "bin": {
+    "unch": "bin/unch.js",
+    "unch-mcp": "bin/unch-mcp.js"
+  },
+  "scripts": {
+    "postinstall": "node scripts/install.js",
+    "test": "node scripts/platform.test.js",
+    "test:mcp": "node scripts/mcp-smoke.js"
+  },
+  "files": [
+    "bin",
+    "scripts",
+    "README.md"
+  ],
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/npm/unch/scripts/install.js
+++ b/npm/unch/scripts/install.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const https = require("node:https");
+const os = require("node:os");
+const path = require("node:path");
+const { fileURLToPath } = require("node:url");
+const { spawnSync } = require("node:child_process");
+const { assetFor, releaseTagForVersion } = require("./platform");
+
+const packageRoot = path.join(__dirname, "..");
+const packageJSON = require(path.join(packageRoot, "package.json"));
+const vendorDir = path.join(packageRoot, "vendor");
+
+async function main() {
+  if (process.env.UNCH_SKIP_DOWNLOAD === "1") {
+    console.error("Skipping unch binary download because UNCH_SKIP_DOWNLOAD=1");
+    return;
+  }
+
+  const asset = assetFor();
+  const tag = process.env.UNCH_NPM_TAG || releaseTagForVersion(packageJSON.version);
+  const url = process.env.UNCH_BINARY_URL || `https://github.com/uchebnick/unch/releases/download/${tag}/${asset.name}`;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "unch-npm-"));
+  const archivePath = path.join(tmpDir, asset.name);
+
+  try {
+    console.error(`Installing unch ${tag} for ${process.platform}/${process.arch}`);
+    await fetchArchive(url, archivePath);
+
+    const extractDir = path.join(tmpDir, "extract");
+    fs.mkdirSync(extractDir, { recursive: true });
+    extractArchive(asset.archive, archivePath, extractDir);
+
+    const extractedBinary = findFile(extractDir, asset.binary);
+    if (!extractedBinary) {
+      throw new Error(`archive did not contain ${asset.binary}`);
+    }
+
+    fs.mkdirSync(vendorDir, { recursive: true });
+    const targetPath = path.join(vendorDir, asset.binary);
+    fs.copyFileSync(extractedBinary, targetPath);
+    if (process.platform !== "win32") {
+      fs.chmodSync(targetPath, 0o755);
+    }
+    console.error(`Installed ${asset.binary}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function fetchArchive(source, destination) {
+  const localPath = localArchivePath(source);
+  if (localPath) {
+    fs.copyFileSync(localPath, destination);
+    return;
+  }
+  await download(source, destination);
+}
+
+function localArchivePath(source) {
+  const value = String(source || "").trim();
+  if (value.startsWith("file://")) {
+    return fileURLToPath(value);
+  }
+  if (/^https:\/\//i.test(value)) {
+    return "";
+  }
+  return value;
+}
+
+function download(url, destination, redirectsLeft = 5) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, (response) => {
+      if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
+        response.resume();
+        if (!response.headers.location || redirectsLeft <= 0) {
+          reject(new Error(`download redirect failed for ${url}`));
+          return;
+        }
+        const nextURL = new URL(response.headers.location, url).toString();
+        download(nextURL, destination, redirectsLeft - 1).then(resolve, reject);
+        return;
+      }
+
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`download failed: ${response.statusCode} ${response.statusMessage}`));
+        return;
+      }
+
+      const file = fs.createWriteStream(destination);
+      response.pipe(file);
+      file.on("finish", () => file.close(resolve));
+      file.on("error", reject);
+    });
+
+    request.on("error", reject);
+  });
+}
+
+function extractArchive(type, archivePath, extractDir) {
+  if (type === "tar.gz") {
+    run("tar", ["-xzf", archivePath, "-C", extractDir]);
+    return;
+  }
+
+  if (type === "zip") {
+    const tarResult = spawnSync("tar", ["-xf", archivePath, "-C", extractDir], {
+      stdio: "ignore",
+      windowsHide: true
+    });
+    if (tarResult.status === 0) {
+      return;
+    }
+
+    if (process.platform === "win32") {
+      run("powershell.exe", [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `Expand-Archive -LiteralPath ${quotePowerShell(archivePath)} -DestinationPath ${quotePowerShell(extractDir)} -Force`
+      ]);
+      return;
+    }
+
+    run("unzip", ["-q", archivePath, "-d", extractDir]);
+    return;
+  }
+
+  throw new Error(`unsupported archive type ${type}`);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    windowsHide: true
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${command} exited with status ${result.status}`);
+  }
+}
+
+function findFile(root, name) {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isFile() && entry.name === name) {
+      return fullPath;
+    }
+    if (entry.isDirectory()) {
+      const found = findFile(fullPath, name);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return "";
+}
+
+function quotePowerShell(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`Failed to install unch: ${error.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  download,
+  extractArchive,
+  findFile
+};

--- a/npm/unch/scripts/mcp-smoke.js
+++ b/npm/unch/scripts/mcp-smoke.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+
+const command = process.env.UNCH_MCP_COMMAND || "unch-mcp";
+
+function frame(message) {
+  const body = Buffer.from(JSON.stringify(message));
+  return Buffer.concat([
+    Buffer.from(`Content-Length: ${body.length}\r\n\r\n`),
+    body
+  ]);
+}
+
+function readFrames(buffer) {
+  const messages = [];
+  let offset = 0;
+  while (offset < buffer.length) {
+    const headerEnd = buffer.indexOf("\r\n\r\n", offset);
+    assert.notEqual(headerEnd, -1, "missing MCP header terminator");
+
+    const header = buffer.slice(offset, headerEnd).toString("utf8");
+    const match = /^Content-Length:\s*(\d+)$/im.exec(header);
+    assert.ok(match, `missing Content-Length header: ${header}`);
+
+    const length = Number(match[1]);
+    const bodyStart = headerEnd + 4;
+    const bodyEnd = bodyStart + length;
+    assert.ok(bodyEnd <= buffer.length, "truncated MCP frame");
+
+    messages.push(JSON.parse(buffer.slice(bodyStart, bodyEnd).toString("utf8")));
+    offset = bodyEnd;
+  }
+  return messages;
+}
+
+async function main() {
+  const child = spawn(command, [], {
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32",
+    windowsHide: true
+  });
+
+  const stdout = [];
+  const stderr = [];
+  child.stdout.on("data", (chunk) => stdout.push(chunk));
+  child.stderr.on("data", (chunk) => stderr.push(chunk));
+
+  child.stdin.write(frame({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: { protocolVersion: "2025-11-25" }
+  }));
+  child.stdin.write(frame({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "prompts/list"
+  }));
+  child.stdin.write(frame({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "prompts/get",
+    params: {
+      name: "unch",
+      arguments: { query: "router middleware" }
+    }
+  }));
+  child.stdin.end();
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", resolve);
+  });
+
+  const stderrText = Buffer.concat(stderr).toString("utf8");
+  assert.equal(exitCode, 0, stderrText);
+  assert.equal(stderrText, "");
+
+  const messages = readFrames(Buffer.concat(stdout));
+  assert.equal(messages.length, 3);
+  assert.ok(messages[0].result.capabilities.prompts);
+  assert.equal(messages[1].result.prompts[0].name, "unch");
+
+  const promptText = messages[2].result.messages[0].content.text;
+  assert.match(promptText, /workspace_status/);
+  assert.match(promptText, /search_code/);
+  assert.match(promptText, /router middleware/);
+
+  console.log("mcp smoke ok");
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/npm/unch/scripts/platform.js
+++ b/npm/unch/scripts/platform.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const platformAssets = {
+  "darwin:arm64": {
+    name: "unch_Darwin_arm64.tar.gz",
+    binary: "unch",
+    archive: "tar.gz"
+  },
+  "darwin:x64": {
+    name: "unch_Darwin_x86_64.tar.gz",
+    binary: "unch",
+    archive: "tar.gz"
+  },
+  "linux:arm64": {
+    name: "unch_Linux_arm64.tar.gz",
+    binary: "unch",
+    archive: "tar.gz"
+  },
+  "linux:x64": {
+    name: "unch_Linux_x86_64.tar.gz",
+    binary: "unch",
+    archive: "tar.gz"
+  },
+  "win32:arm64": {
+    name: "unch_Windows_arm64.zip",
+    binary: "unch.exe",
+    archive: "zip"
+  },
+  "win32:x64": {
+    name: "unch_Windows_x86_64.zip",
+    binary: "unch.exe",
+    archive: "zip"
+  }
+};
+
+function assetFor(platform = process.platform, arch = process.arch) {
+  const key = `${platform}:${arch}`;
+  const asset = platformAssets[key];
+  if (!asset) {
+    const supported = Object.keys(platformAssets).join(", ");
+    throw new Error(`unsupported platform ${key}; supported: ${supported}`);
+  }
+  return asset;
+}
+
+function releaseTagForVersion(version) {
+  const normalized = String(version || "").trim();
+  if (!normalized) {
+    throw new Error("package version is empty");
+  }
+  return normalized.startsWith("v") ? normalized : `v${normalized}`;
+}
+
+module.exports = {
+  assetFor,
+  releaseTagForVersion
+};

--- a/npm/unch/scripts/platform.test.js
+++ b/npm/unch/scripts/platform.test.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { assetFor, releaseTagForVersion } = require("./platform");
+
+assert.equal(assetFor("darwin", "arm64").name, "unch_Darwin_arm64.tar.gz");
+assert.equal(assetFor("darwin", "x64").name, "unch_Darwin_x86_64.tar.gz");
+assert.equal(assetFor("linux", "arm64").name, "unch_Linux_arm64.tar.gz");
+assert.equal(assetFor("linux", "x64").name, "unch_Linux_x86_64.tar.gz");
+assert.equal(assetFor("win32", "arm64").name, "unch_Windows_arm64.zip");
+assert.equal(assetFor("win32", "x64").name, "unch_Windows_x86_64.zip");
+
+assert.equal(releaseTagForVersion("0.3.11"), "v0.3.11");
+assert.equal(releaseTagForVersion("v0.3.11"), "v0.3.11");
+
+assert.throws(() => assetFor("freebsd", "x64"), /unsupported platform/);
+assert.throws(() => releaseTagForVersion(""), /package version is empty/);
+
+console.log("platform mapping ok");


### PR DESCRIPTION
## Summary

Adds npm-based installation for `unch` and a zero-argument MCP launcher for editor/agent integrations.

This is a stacked PR on top of `feat/mcp-clean-rewrite` because the npm `unch-mcp` command depends on `unch start mcp`.

## Changes

- Add npm package under `npm/unch` with `unch` and `unch-mcp` bin entries.
- Download the matching native release archive during npm `postinstall`.
- Support local archive installs through `UNCH_BINARY_URL` so CI can test without publishing a release.
- Add an MCP prompt named `unch`, allowing MCP clients that expose prompts as slash commands to show `/unch`.
- Add cross-platform npm-wrapper CI for Linux, macOS, and Windows on x64 and arm64.

## Validation

- `go test ./internal/mcp`
- `npm test` in `npm/unch`
- `npm pack --dry-run` in `npm/unch`
- Local npm install from a locally built archive
- `unch --version` from the installed npm wrapper
- MCP smoke test through installed `unch-mcp`
- CI workflow YAML parse check
