### PR TITLE
Add v0.3.13 release notes

### DIFF
--- a/.github/releases/v0.3.13.md
+++ b/.github/releases/v0.3.13.md
@@ -1,0 +1,20 @@
+# unch v0.3.13
+
+`v0.3.13` is a workflow expansion release. It adds OpenRouter embeddings, Rust symbol indexing, multi-dimension index snapshots, and a clean MCP server so agents can search a repository through `unch` without reading half the tree first.
+
+## Highlights
+
+- Added `--provider openrouter` for `index`, `search`, and MCP, with `unch auth openrouter --token ...` for storing API keys outside the project tree
+- Added Rust Tree-sitter indexing for functions, methods, structs, traits, impl blocks, enums, modules, and attached docs
+- Upgraded the local index schema to isolate snapshots by provider, model, and embedding dimension, so local `llama.cpp` models and remote OpenRouter models can coexist in the same `.semsearch` state
+- Added `unch start mcp`, a stdio MCP server exposing `workspace_status`, `search_code`, and `index_repository`
+- Added MCP initialize instructions that tell agents to check workspace status first, search before broad file reads, and rebuild the index only when needed
+- Split the Tree-sitter implementation into per-language files, making new language support easier to add and test
+- Refreshed README and Mintlify docs for OpenRouter credentials, provider/model selection, MCP usage, and index storage behavior
+
+## Upgrade notes
+
+- Local index storage moves to schema version 2. Existing v1 indexes are reset automatically, so run `unch index --root .` once after upgrading
+- OpenRouter credentials can be saved globally in `~/.config/unch/tokens.json`; use `unch auth openrouter --local --token ...` only when you intentionally want repository-local credentials in `.semsearch/tokens.json`
+- MCP uses stdio only in this release. Configure clients with command `unch` and arguments `start mcp`, or run `unch start mcp` directly from the repository root
+- If you install from source, use `go install github.com/uchebnick/unch/cmd/unch@v0.3.13`


### PR DESCRIPTION
## Summary

Adds release notes for `v0.3.13`.

## Covered changes

- OpenRouter embedding provider and token storage
- Rust Tree-sitter indexing
- multi-dimension provider/model index snapshots
- clean stdio MCP server and agent instructions
- documentation updates for the new workflows

## Validation

- Reviewed `git log v0.3.12..origin/main`
- Reviewed `git diff --stat v0.3.12..origin/main`
- Markdown-only change; no code tests required
