### PR TITLE
Refresh v0.3.13 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Semantic code search for code symbols and docs.**
 
-`unch` indexes functions, methods, types, classes, interfaces, and attached docs with Tree-sitter, then lets you search them from the terminal. It is useful when you know what the code does, but not the symbol name or file path. Local indexing is the default; remote publishing is optional.
+`unch` indexes functions, methods, types, classes, interfaces, and attached docs with Tree-sitter, then lets you search them from the terminal. It is useful when you know what the code does, but not the symbol name or file path. Local `llama.cpp` embeddings are the default; OpenRouter and remote publishing are opt-in.
 
 <p align="center">
   <img src="docs/assets/unch-demo.gif" alt="Terminal demo of unch indexing gorilla/mux and returning semantic search matches" width="920">
@@ -21,8 +21,8 @@
 
 ## Why `unch`
 
-- **Indexes symbols, not just lines.** `unch` stores top-level API objects and attached docs for `Go`, `TypeScript`, `JavaScript`, and `Python`.
-- **Keeps the local workflow simple.** Build an index once, search from the CLI, and keep everything on your machine unless you explicitly publish a remote index.
+- **Indexes symbols, not just lines.** `unch` stores top-level API objects and attached docs for `Go`, `Rust`, `TypeScript`, `JavaScript`, and `Python`.
+- **Keeps the local workflow simple.** Build an index once, search from the CLI, and keep everything on your machine unless you explicitly choose OpenRouter embeddings or publish a remote index.
 - **Still works with CI.** If you want a shared index, GitHub Actions publishing is available, but it is not required for the normal local flow.
 
 ## Install
@@ -145,9 +145,25 @@ The first local `llama.cpp` run may download the default embedding model, fetch 
 
 Each provider and model pair keeps its own active index snapshot. Rebuilding `openrouter/openai/text-embedding-3-small` does not replace the active `llama.cpp/embeddinggemma` snapshot until the new run finishes successfully.
 
+## MCP
+
+`unch` can run as a stdio MCP server for agents and editors:
+
+```bash
+unch start mcp
+```
+
+Configure MCP clients with command `unch`, arguments `start mcp`, and working directory set to the repository you want to search.
+
+The server exposes:
+
+- `workspace_status` to inspect the repository root, state directory, active provider/model, and index status
+- `search_code` to search indexed code symbols before opening many files
+- `index_repository` to build or refresh the index when needed
+
 ## What It Supports Today
 
-- Tree-sitter indexing for `Go`, `TypeScript`, `JavaScript`, and `Python`
+- Tree-sitter indexing for `Go`, `Rust`, `TypeScript`, `JavaScript`, and `Python`
 - Top-level API objects and attached documentation
 - Local indexing and search first, optional remote publishing through GitHub Actions
 - `auto`, `semantic`, and `lexical` search modes

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -52,6 +52,7 @@ This document describes the current compatibility contract for `unch`.
 | Area | Status | Notes |
 | --- | --- | --- |
 | Go indexing | Supported | Tree-sitter-based symbol extraction |
+| Rust indexing | Supported | Tree-sitter-based symbol extraction |
 | TypeScript indexing | Supported | Tree-sitter-based symbol extraction |
 | JavaScript indexing | Supported | Tree-sitter-based symbol extraction |
 | Python indexing | Supported | Tree-sitter-based symbol extraction |

--- a/mintlify/commands.mdx
+++ b/mintlify/commands.mdx
@@ -3,14 +3,15 @@ title: Commands
 description: Overview of the main unch CLI commands.
 ---
 
-`unch` is centered around four main command families:
+`unch` is centered around these main command families:
 
 - `unch auth` to save provider credentials such as an OpenRouter API key
 - [`unch index`](/commands/index) to build or refresh a local index
 - [`unch search`](/commands/search) to query the current index
 - [`unch remote`](/commands/remote) to sync or download published remote state
+- [`unch start mcp`](/commands/mcp) to expose the index to MCP clients
 
-<CardGroup cols={4}>
+<CardGroup cols={3}>
   <Card title="Auth" icon="key">
     Save provider credentials without keeping tokens in your shell environment.
   </Card>
@@ -22,6 +23,9 @@ description: Overview of the main unch CLI commands.
   </Card>
   <Card title="Remote" icon="cloud-arrow-down" href="/commands/remote">
     Reuse published CI state or download an index for a specific commit.
+  </Card>
+  <Card title="MCP" icon="plug" href="/commands/mcp">
+    Let agents search the repository through stdio MCP tools.
   </Card>
 </CardGroup>
 
@@ -64,3 +68,11 @@ unch remote sync
 ```
 
 Use the command pages for the full flag reference and behavior notes.
+
+## Typical MCP flow
+
+```bash
+unch start mcp
+```
+
+Configure your MCP client with command `unch`, arguments `start mcp`, and working directory set to the repository root.

--- a/mintlify/commands/mcp.mdx
+++ b/mintlify/commands/mcp.mdx
@@ -1,0 +1,102 @@
+---
+title: MCP
+description: Start the unch stdio MCP server for agents and editor integrations.
+---
+
+## Usage
+
+```bash
+unch start mcp [flags]
+```
+
+From the repository root, the common case is:
+
+```bash
+unch start mcp
+```
+
+MCP uses stdio, so stdout is reserved for protocol messages. Run this command as a child process from an MCP client rather than as an interactive terminal command.
+
+## Client configuration
+
+Use:
+
+- Name: `unch`
+- Command: `unch`
+- Arguments: `start`, `mcp`
+- Working directory: the repository you want to search
+
+The server uses:
+
+- root: current working directory
+- state dir: `<root>/.semsearch`
+- provider/model: the same defaults as the CLI
+
+## Tools
+
+### `workspace_status`
+
+Returns the repository root, state directory, selected provider/model, index path, manifest metadata, and whether an index is already present.
+
+Agents should call this first.
+
+### `search_code`
+
+Searches indexed code symbols with `auto`, `semantic`, or `lexical` mode.
+
+Agents should call this before opening many files or running broad grep-style exploration.
+
+### `index_repository`
+
+Builds or refreshes the index for the configured workspace.
+
+Agents should call this when no index exists, when search reports no active snapshot for the selected provider/model, or when the user explicitly asks to rebuild.
+
+## Flags
+
+### `--root`
+
+Repository root served by the MCP process. Defaults to `.`.
+
+### `--state-dir`
+
+Path to a custom `.semsearch` directory. Defaults to `<root>/.semsearch`.
+
+### `--model`
+
+Embedding model to use. Accepts `embeddinggemma`, `qwen3`, a `.gguf` path, or an OpenRouter model id when `--provider openrouter` is selected.
+
+### `--provider`
+
+Embedding provider. Accepted values:
+
+- `llama.cpp`
+- `openrouter`
+
+### `--lib`
+
+Path to a `yzma` library directory, or one of its shared library files.
+
+### `--ctx-size`
+
+llama context size. `0` uses the selected model default.
+
+### `--verbose`
+
+Enable verbose `yzma` logging.
+
+## Examples
+
+```bash
+unch start mcp
+unch start mcp --root ~/src/repo --state-dir ~/src/repo/.semsearch
+unch start mcp --root . --model qwen3
+unch start mcp --provider openrouter --model openai/text-embedding-3-small
+```
+
+## Notes
+
+- Use one MCP process per repository workspace.
+- The process reuses the same provider/model/runtime configuration across tool calls.
+- OpenRouter token lookup checks `OPENROUTER_API_KEY`, then `~/.config/unch/tokens.json`, then `.semsearch/tokens.json`.
+- The MCP server exposes tools only in this release; streamable HTTP is not supported yet.

--- a/mintlify/concepts/how-it-works.mdx
+++ b/mintlify/concepts/how-it-works.mdx
@@ -18,6 +18,7 @@ For supported languages, `unch` uses Tree-sitter to extract top-level symbols an
 That currently covers:
 
 - Go
+- Rust
 - TypeScript
 - JavaScript
 - Python
@@ -26,7 +27,12 @@ For unsupported files or parser failures, `index` can still use the legacy prefi
 
 ## 4. Embedding generation
 
-Each extracted symbol is flattened into an indexed document and embedded locally with a GGUF model through `yzma`.
+Each extracted symbol is flattened into an indexed document and embedded with the selected provider.
+
+Provider options today:
+
+- `llama.cpp` for local GGUF models through `yzma`
+- `openrouter` for remote embedding APIs
 
 Known model ids today:
 
@@ -35,9 +41,11 @@ Known model ids today:
 
 ## 5. Snapshot activation
 
-Embeddings and symbols are written into model-scoped snapshots in `.semsearch/index.db`.
+Embeddings and symbols are written into provider-scoped and model-scoped snapshots in `.semsearch/index.db`.
 
-When indexing succeeds, the new snapshot becomes active for that model. Other model snapshots are left untouched.
+When indexing succeeds, the new snapshot becomes active for that provider/model pair. Other provider/model snapshots are left untouched.
+
+Embedding vector tables are also separated by dimension, so models with different embedding sizes can coexist in one `.semsearch` directory.
 
 ## 6. Search
 

--- a/mintlify/concepts/index-storage.mdx
+++ b/mintlify/concepts/index-storage.mdx
@@ -17,6 +17,8 @@ You can override that with `--state-dir`.
 
 The local search index. This is a rebuildable cache artifact, not durable user data.
 
+It stores immutable snapshots for each provider/model pair. Embedding vectors are kept in dimension-specific vector tables, so a 768-dimension local model and a 1536-dimension OpenRouter model can coexist without replacing each other.
+
 ### `manifest.json`
 
 Tracks local state metadata, schema versioning, and optional remote binding.
@@ -41,6 +43,18 @@ The CLI now treats the state directory as the primary unit:
 - `--db` is a deprecated compatibility alias
 
 That matches the real storage model better, because `index.db` is only one piece of the full local state.
+
+## Provider and model snapshots
+
+Each provider/model pair has its own active snapshot.
+
+Examples:
+
+- rebuilding `llama.cpp/embeddinggemma` does not replace `llama.cpp/qwen3`
+- rebuilding `openrouter/openai/text-embedding-3-small` does not replace `llama.cpp/embeddinggemma`
+- switching provider or model requires indexing once with that same provider/model before searching
+
+`index.db` schema changes may reset old cache data automatically. If local search fails after an upgrade, rebuild with `unch index --root .`.
 
 ## Remote-published state
 

--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -36,6 +36,7 @@
         "pages": [
           "commands/index",
           "commands/search",
+          "commands/mcp",
           "commands/remote"
         ]
       },

--- a/mintlify/introduction.mdx
+++ b/mintlify/introduction.mdx
@@ -5,7 +5,7 @@ description: Local-first semantic code search for functions, methods, types, and
 
 `unch` indexes the API surface of your repository and lets you search it from the terminal using natural language.
 
-It extracts top-level symbols and attached documentation, computes embeddings locally from a GGUF model, and returns ranked matches. Your code stays on your machine unless you explicitly publish a remote index.
+It extracts top-level symbols and attached documentation, computes embeddings with the selected provider, and returns ranked matches. Local `llama.cpp` embeddings are the default; OpenRouter is optional when you explicitly select `--provider openrouter`.
 
 ## What unch does
 
@@ -15,7 +15,7 @@ When you know what a piece of code does but cannot remember its name, file, or e
 
 - Local-first by default
 - Symbol-aware indexing instead of raw line search
-- Local GGUF embeddings
+- Local GGUF embeddings by default, optional OpenRouter embeddings
 - `auto`, `semantic`, and `lexical` search modes
 - Optional remote publishing through GitHub Actions
 
@@ -24,6 +24,7 @@ When you know what a piece of code does but cannot remember its name, file, or e
 `unch` uses Tree-sitter-based symbol extraction for:
 
 - Go
+- Rust
 - TypeScript
 - JavaScript
 - Python
@@ -34,7 +35,7 @@ For unsupported files or parser failures, `index` can still use the legacy prefi
 
 - You know the behavior you want, but not the exact symbol name
 - You want docs and API surface searchable together
-- You want semantic search over a local repo without sending code to a hosted service
+- You want semantic search over a local repo without sending code to a hosted service when using the default local provider
 
 ## Next steps
 

--- a/mintlify/reference/compatibility.mdx
+++ b/mintlify/reference/compatibility.mdx
@@ -40,6 +40,7 @@ description: Support matrix, upgrade rules, and versioning contract for unch.
 | Area | Status | Notes |
 | --- | --- | --- |
 | Go indexing | Supported | Tree-sitter-based symbol extraction |
+| Rust indexing | Supported | Tree-sitter-based symbol extraction |
 | TypeScript indexing | Supported | Tree-sitter-based symbol extraction |
 | JavaScript indexing | Supported | Tree-sitter-based symbol extraction |
 | Python indexing | Supported | Tree-sitter-based symbol extraction |


### PR DESCRIPTION
## Summary

Refreshes README, GitHub docs, and Mintlify docs for the features that landed after `v0.3.12`.

## Changes

- Adds Rust to supported language lists and compatibility matrices.
- Adds MCP usage docs, including a new Mintlify `commands/mcp` page.
- Updates the commands overview and Mintlify navigation for `unch start mcp`.
- Clarifies local-first wording now that OpenRouter is available as an explicit provider.
- Updates storage/how-it-works docs for provider/model snapshots and dimension-specific vector tables.

## Validation

- Checked docs against current CLI help for `index`, `search`, `auth`, and `start mcp`.
- Parsed `mintlify/docs.json` as JSON.
- Documentation-only change; no code tests required.
