### PR TITLE
Document npm as primary install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@
 
 ## Install
 
+npm is the recommended install path:
+
+```bash
+npm install -g @uchebnick/unch
+```
+
+It installs the `unch` CLI and downloads the matching native release binary for your platform.
+
 Homebrew on macOS:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![Release](https://img.shields.io/github/v/release/uchebnick/unch?display_name=tag)](https://github.com/uchebnick/unch/releases/latest)
 [![Homebrew Tap](https://img.shields.io/badge/Homebrew-uchebnick%2Ftap-FBB040?logo=homebrew&logoColor=white)](https://github.com/uchebnick/homebrew-tap)
+[![npm downloads](https://img.shields.io/npm/dt/%40uchebnick%2Funch?logo=npm&label=npm%20downloads)](https://www.npmjs.com/package/@uchebnick/unch)
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/uchebnick/unch/gh-pages/coverage/coverage-badge.json)](https://github.com/uchebnick/unch/actions/workflows/ci.yml)
 [![Go 1.25+](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white)](https://github.com/uchebnick/unch)
 [![Docs](https://img.shields.io/badge/Docs-unch.mintlify.app-0F172A)](https://unch.mintlify.app/)

--- a/mintlify/index.mdx
+++ b/mintlify/index.mdx
@@ -13,7 +13,7 @@ Everything stays local by default. Remote publishing is optional.
 
 <CardGroup cols={2}>
   <Card title="Installation" icon="download" href="/installation">
-    Install via Homebrew, shell installer, PowerShell, or `go install`.
+    Install with npm, or choose Homebrew, shell installer, PowerShell, or `go install`.
   </Card>
   <Card title="Quick Start" icon="rocket" href="/quickstart">
     Index a repo and run your first search in under a minute.

--- a/mintlify/installation.mdx
+++ b/mintlify/installation.mdx
@@ -1,23 +1,23 @@
 ---
 title: Installation
-description: Install unch with Homebrew, shell installer, PowerShell, go install, or build from source.
+description: Install unch with npm, Homebrew, shell installer, PowerShell, go install, or build from source.
 ---
 
 <CardGroup cols={3}>
   <Card title="Fastest path" icon="bolt">
-    Use Homebrew on macOS or the shell and PowerShell installers on release-supported targets.
+    Use npm for the simplest cross-platform install.
+  </Card>
+  <Card title="Native installers" icon="box-archive">
+    Homebrew, shell installer, and PowerShell installer are available when you prefer platform-native flows.
   </Card>
   <Card title="Most flexible" icon="sliders">
     Use `go install` or build from source when you want a local checkout or custom toolchain flow.
-  </Card>
-  <Card title="Release coverage" icon="box-archive">
-    Published archives cover macOS, Linux, and Windows on both `arm64` and `x86_64`.
   </Card>
 </CardGroup>
 
 ## Requirements
 
-On supported release targets, the installers use published archives by default, so Go is not required.
+The npm package and release installers use published archives by default, so Go is not required on supported targets.
 
 If you install with `go install`, build from source, or install on a target without a matching release archive, you need:
 
@@ -29,6 +29,21 @@ On Windows source builds, that means an MSYS2 or MinGW-style toolchain, or an eq
 ## Choose an install path
 
 <Tabs>
+  <Tab title="npm (recommended)">
+    ```bash
+    npm install -g @uchebnick/unch
+    ```
+
+    This installs the `unch` CLI and downloads the matching native release binary for your platform.
+
+    Verify it:
+
+    ```bash
+    unch --version
+    unch --help
+    ```
+  </Tab>
+
   <Tab title="Homebrew (macOS)">
     ```bash
     brew install uchebnick/tap/unch


### PR DESCRIPTION
## Summary

Adds npm as the primary documented install path and keeps the total npm downloads badge in the README.

## Changes

- Add total npm downloads badge to README.
- Put `npm install -g @uchebnick/unch` first in README install docs.
- Make npm the recommended tab in Mintlify installation docs.
- Update the Mintlify landing page install card to mention npm first.

## Validation

- Markdown/docs-only change
- Badge uses shields.io `npm/dt` for total downloads
