### PR TITLE
Add v0.4.0 release notes

### DIFF
--- a/.github/releases/v0.4.0.md
+++ b/.github/releases/v0.4.0.md
@@ -1,6 +1,6 @@
-# unch v0.3.13
+# unch v0.4.0
 
-`v0.3.13` is a workflow expansion release. It adds OpenRouter embeddings, Rust symbol indexing, multi-dimension index snapshots, and a clean MCP server so agents can search a repository through `unch` without reading half the tree first.
+`v0.4.0` is a workflow expansion release. It adds OpenRouter embeddings, Rust symbol indexing, multi-dimension index snapshots, and a clean MCP server so agents can search a repository through `unch` without reading half the tree first.
 
 ## Highlights
 
@@ -17,4 +17,4 @@
 - Local index storage moves to schema version 2. Existing v1 indexes are reset automatically, so run `unch index --root .` once after upgrading
 - OpenRouter credentials can be saved globally in `~/.config/unch/tokens.json`; use `unch auth openrouter --local --token ...` only when you intentionally want repository-local credentials in `.semsearch/tokens.json`
 - MCP uses stdio only in this release. Configure clients with command `unch` and arguments `start mcp`, or run `unch start mcp` directly from the repository root
-- If you install from source, use `go install github.com/uchebnick/unch/cmd/unch@v0.3.13`
+- If you install from source, use `go install github.com/uchebnick/unch/cmd/unch@v0.4.0`


### PR DESCRIPTION
## Summary
- rename the release notes from v0.3.13 to v0.4.0
- update the source install command to use the v0.4.0 tag

## Testing
- not run (release notes only)