### PR TITLE
Publish npm package from release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,29 @@ jobs:
         with:
           version: v2.7.2
 
+  npm-wrapper:
+    name: npm-wrapper
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Test npm package
+        working-directory: npm/unch
+        run: |
+          set -euo pipefail
+          npm test
+          npm version 1.2.3 --no-git-tag-version
+          test "$(node -p 'require("./package.json").version')" = "1.2.3"
+          npm pack --dry-run
+          npm publish --dry-run --access public
+
   test-matrix:
     name: test (${{ matrix.label }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,9 +218,52 @@ jobs:
             dist/*.zip
             dist/checksums.txt
 
+  publish-npm:
+    name: publish-npm
+    needs: release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish npm package
+        working-directory: npm/unch
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN is not set" >&2
+            exit 1
+          fi
+
+          version="${GITHUB_REF_NAME#v}"
+          package_name="$(node -p 'require("./package.json").name')"
+
+          npm version "${version}" --no-git-tag-version
+          npm test
+          npm pack --dry-run
+
+          if npm view "${package_name}@${version}" version >/dev/null 2>&1; then
+            echo "${package_name}@${version} is already published; skipping"
+            exit 0
+          fi
+
+          npm publish --access public
+
   notify-release:
     name: notify-release
-    needs: release
+    needs:
+      - release
+      - publish-npm
     runs-on: ubuntu-latest
 
     steps:

--- a/npm/unch/.gitignore
+++ b/npm/unch/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+*.tgz

--- a/npm/unch/README.md
+++ b/npm/unch/README.md
@@ -1,0 +1,36 @@
+# @uchebnick/unch
+
+npm installer wrapper for the [`unch`](https://github.com/uchebnick/unch) semantic code search CLI.
+
+```bash
+npm install -g @uchebnick/unch
+unch --version
+unch --help
+```
+
+The package downloads the matching native binary from GitHub Releases during `postinstall`.
+
+## MCP
+
+For MCP clients, use:
+
+- Name: `unch`
+- Command: `unch-mcp`
+- Arguments: leave empty
+- Working directory: the repository you want to search
+
+`unch-mcp` is a small launcher for `unch start mcp`. The MCP server also exposes a prompt named `unch`, so clients that render MCP prompts as slash commands can show it as `/unch`.
+
+If your client supports MCP prompts, run `/unch` before a codebase question to nudge the assistant to call `workspace_status`, `search_code`, and `index_repository` in the right order.
+
+Supported targets:
+
+- macOS `arm64`, `x64`
+- Linux `arm64`, `x64`
+- Windows `arm64`, `x64`
+
+Environment overrides:
+
+- `UNCH_NPM_TAG=v0.4.1` downloads a specific release tag.
+- `UNCH_BINARY_URL=https://...` or `UNCH_BINARY_URL=file:///...` downloads or reads a custom archive.
+- `UNCH_SKIP_DOWNLOAD=1` skips download for package smoke tests.

--- a/npm/unch/bin/unch-mcp.js
+++ b/npm/unch/bin/unch-mcp.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const binaryName = process.platform === "win32" ? "unch.exe" : "unch";
+const binaryPath = path.join(__dirname, "..", "vendor", binaryName);
+
+if (!fs.existsSync(binaryPath)) {
+  console.error("unch native binary is missing.");
+  console.error("Try reinstalling the package: npm install -g @uchebnick/unch");
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, ["start", "mcp", ...process.argv.slice(2)], {
+  stdio: "inherit",
+  windowsHide: false
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+
+process.exit(result.status ?? 0);

--- a/npm/unch/bin/unch.js
+++ b/npm/unch/bin/unch.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const binaryName = process.platform === "win32" ? "unch.exe" : "unch";
+const binaryPath = path.join(__dirname, "..", "vendor", binaryName);
+
+if (!fs.existsSync(binaryPath)) {
+  console.error("unch native binary is missing.");
+  console.error("Try reinstalling the package: npm install -g @uchebnick/unch");
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), {
+  stdio: "inherit",
+  windowsHide: false
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+
+process.exit(result.status ?? 0);

--- a/npm/unch/package.json
+++ b/npm/unch/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@uchebnick/unch",
+  "version": "0.0.0",
+  "description": "npm installer wrapper for the unch semantic code search CLI",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/uchebnick/unch#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/uchebnick/unch.git",
+    "directory": "npm/unch"
+  },
+  "bugs": {
+    "url": "https://github.com/uchebnick/unch/issues"
+  },
+  "bin": {
+    "unch": "bin/unch.js",
+    "unch-mcp": "bin/unch-mcp.js"
+  },
+  "scripts": {
+    "postinstall": "node scripts/install.js",
+    "test": "node scripts/platform.test.js",
+    "test:mcp": "node scripts/mcp-smoke.js"
+  },
+  "files": [
+    "bin",
+    "scripts",
+    "README.md"
+  ],
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/npm/unch/scripts/install.js
+++ b/npm/unch/scripts/install.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const https = require("node:https");
+const os = require("node:os");
+const path = require("node:path");
+const { fileURLToPath } = require("node:url");
+const { spawnSync } = require("node:child_process");
+const { assetFor, releaseTagForVersion } = require("./platform");
+
+const packageRoot = path.join(__dirname, "..");
+const packageJSON = require(path.join(packageRoot, "package.json"));
+const vendorDir = path.join(packageRoot, "vendor");
+
+async function main() {
+  if (process.env.UNCH_SKIP_DOWNLOAD === "1") {
+    console.error("Skipping unch binary download because UNCH_SKIP_DOWNLOAD=1");
+    return;
+  }
+
+  const asset = assetFor();
+  const tag = process.env.UNCH_NPM_TAG || releaseTagForVersion(packageJSON.version);
+  const url = process.env.UNCH_BINARY_URL || `https://github.com/uchebnick/unch/releases/download/${tag}/${asset.name}`;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "unch-npm-"));
+  const archivePath = path.join(tmpDir, asset.name);
+
+  try {
+    console.error(`Installing unch ${tag} for ${process.platform}/${process.arch}`);
+    await fetchArchive(url, archivePath);
+
+    const extractDir = path.join(tmpDir, "extract");
+    fs.mkdirSync(extractDir, { recursive: true });
+    extractArchive(asset.archive, archivePath, extractDir);
+
+    const extractedBinary = findFile(extractDir, asset.binary);
+    if (!extractedBinary) {
+      throw new Error(`archive did not contain ${asset.binary}`);
+    }
+
+    fs.mkdirSync(vendorDir, { recursive: true });
+    const targetPath = path.join(vendorDir, asset.binary);
+    fs.copyFileSync(extractedBinary, targetPath);
+    if (process.platform !== "win32") {
+      fs.chmodSync(targetPath, 0o755);
+    }
+    console.error(`Installed ${asset.binary}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function fetchArchive(source, destination) {
+  const localPath = localArchivePath(source);
+  if (localPath) {
+    fs.copyFileSync(localPath, destination);
+    return;
+  }
+  await download(source, destination);
+}
+
+function localArchivePath(source) {
+  const value = String(source || "").trim();
+  if (value.startsWith("file://")) {
+    return fileURLToPath(value);
+  }
+  if (/^https:\/\//i.test(value)) {
+    return "";
+  }
+  return value;
+}
+
+function download(url, destination, redirectsLeft = 5) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, (response) => {
+      if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
+        response.resume();
+        if (!response.headers.location || redirectsLeft <= 0) {
+          reject(new Error(`download redirect failed for ${url}`));
+          return;
+        }
+        const nextURL = new URL(response.headers.location, url).toString();
+        download(nextURL, destination, redirectsLeft - 1).then(resolve, reject);
+        return;
+      }
+
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`download failed: ${response.statusCode} ${response.statusMessage}`));
+        return;
+      }
+
+      const file = fs.createWriteStream(destination);
+      response.pipe(file);
+      file.on("finish", () => file.close(resolve));
+      file.on("error", reject);
+    });
+
+    request.on("error", reject);
+  });
+}
+
+function extractArchive(type, archivePath, extractDir) {
+  if (type === "tar.gz") {
+    run("tar", ["-xzf", archivePath, "-C", extractDir]);
+    return;
+  }
+
+  if (type === "zip") {
+    const tarResult = spawnSync("tar", ["-xf", archivePath, "-C", extractDir], {
+      stdio: "ignore",
+      windowsHide: true
+    });
+    if (tarResult.status === 0) {
+      return;
+    }
+
+    if (process.platform === "win32") {
+      run("powershell.exe", [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `Expand-Archive -LiteralPath ${quotePowerShell(archivePath)} -DestinationPath ${quotePowerShell(extractDir)} -Force`
+      ]);
+      return;
+    }
+
+    run("unzip", ["-q", archivePath, "-d", extractDir]);
+    return;
+  }
+
+  throw new Error(`unsupported archive type ${type}`);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    windowsHide: true
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${command} exited with status ${result.status}`);
+  }
+}
+
+function findFile(root, name) {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isFile() && entry.name === name) {
+      return fullPath;
+    }
+    if (entry.isDirectory()) {
+      const found = findFile(fullPath, name);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return "";
+}
+
+function quotePowerShell(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`Failed to install unch: ${error.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  download,
+  extractArchive,
+  findFile
+};

--- a/npm/unch/scripts/mcp-smoke.js
+++ b/npm/unch/scripts/mcp-smoke.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+
+const command = process.env.UNCH_MCP_COMMAND || "unch-mcp";
+
+function frame(message) {
+  const body = Buffer.from(JSON.stringify(message));
+  return Buffer.concat([
+    Buffer.from(`Content-Length: ${body.length}\r\n\r\n`),
+    body
+  ]);
+}
+
+function readFrames(buffer) {
+  const messages = [];
+  let offset = 0;
+  while (offset < buffer.length) {
+    const headerEnd = buffer.indexOf("\r\n\r\n", offset);
+    assert.notEqual(headerEnd, -1, "missing MCP header terminator");
+
+    const header = buffer.slice(offset, headerEnd).toString("utf8");
+    const match = /^Content-Length:\s*(\d+)$/im.exec(header);
+    assert.ok(match, `missing Content-Length header: ${header}`);
+
+    const length = Number(match[1]);
+    const bodyStart = headerEnd + 4;
+    const bodyEnd = bodyStart + length;
+    assert.ok(bodyEnd <= buffer.length, "truncated MCP frame");
+
+    messages.push(JSON.parse(buffer.slice(bodyStart, bodyEnd).toString("utf8")));
+    offset = bodyEnd;
+  }
+  return messages;
+}
+
+async function main() {
+  const child = spawn(command, [], {
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32",
+    windowsHide: true
+  });
+
+  const stdout = [];
+  const stderr = [];
+  child.stdout.on("data", (chunk) => stdout.push(chunk));
+  child.stderr.on("data", (chunk) => stderr.push(chunk));
+
+  child.stdin.write(frame({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: { protocolVersion: "2025-11-25" }
+  }));
+  child.stdin.write(frame({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "prompts/list"
+  }));
+  child.stdin.write(frame({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "prompts/get",
+    params: {
+      name: "unch",
+      arguments: { query: "router middleware" }
+    }
+  }));
+  child.stdin.end();
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", resolve);
+  });
+
+  const stderrText = Buffer.concat(stderr).toString("utf8");
+  assert.equal(exitCode, 0, stderrText);
+  assert.equal(stderrText, "");
+
+  const messages = readFrames(Buffer.concat(stdout));
+  assert.equal(messages.length, 3);
+  assert.ok(messages[0].result.capabilities.prompts);
+  assert.equal(messages[1].result.prompts[0].name, "unch");
+
+  const promptText = messages[2].result.messages[0].content.text;
+  assert.match(promptText, /workspace_status/);
+  assert.match(promptText, /search_code/);
+  assert.match(promptText, /router middleware/);
+
+  console.log("mcp smoke ok");
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/npm/unch/scripts/platform.js
+++ b/npm/unch/scripts/platform.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const platformAssets = {
+  "darwin:arm64": {
+    name: "unch_Darwin_arm64.tar.gz",
+    binary: "unch",
+    archive: "tar.gz"
+  },
+  "darwin:x64": {
+    name: "unch_Darwin_x86_64.tar.gz",
+    binary: "unch",
+    archive: "tar.gz"
+  },
+  "linux:arm64": {
+    name: "unch_Linux_arm64.tar.gz",
+    binary: "unch",
+    archive: "tar.gz"
+  },
+  "linux:x64": {
+    name: "unch_Linux_x86_64.tar.gz",
+    binary: "unch",
+    archive: "tar.gz"
+  },
+  "win32:arm64": {
+    name: "unch_Windows_arm64.zip",
+    binary: "unch.exe",
+    archive: "zip"
+  },
+  "win32:x64": {
+    name: "unch_Windows_x86_64.zip",
+    binary: "unch.exe",
+    archive: "zip"
+  }
+};
+
+function assetFor(platform = process.platform, arch = process.arch) {
+  const key = `${platform}:${arch}`;
+  const asset = platformAssets[key];
+  if (!asset) {
+    const supported = Object.keys(platformAssets).join(", ");
+    throw new Error(`unsupported platform ${key}; supported: ${supported}`);
+  }
+  return asset;
+}
+
+function releaseTagForVersion(version) {
+  const normalized = String(version || "").trim();
+  if (!normalized) {
+    throw new Error("package version is empty");
+  }
+  return normalized.startsWith("v") ? normalized : `v${normalized}`;
+}
+
+module.exports = {
+  assetFor,
+  releaseTagForVersion
+};

--- a/npm/unch/scripts/platform.test.js
+++ b/npm/unch/scripts/platform.test.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { assetFor, releaseTagForVersion } = require("./platform");
+
+assert.equal(assetFor("darwin", "arm64").name, "unch_Darwin_arm64.tar.gz");
+assert.equal(assetFor("darwin", "x64").name, "unch_Darwin_x86_64.tar.gz");
+assert.equal(assetFor("linux", "arm64").name, "unch_Linux_arm64.tar.gz");
+assert.equal(assetFor("linux", "x64").name, "unch_Linux_x86_64.tar.gz");
+assert.equal(assetFor("win32", "arm64").name, "unch_Windows_arm64.zip");
+assert.equal(assetFor("win32", "x64").name, "unch_Windows_x86_64.zip");
+
+assert.equal(releaseTagForVersion("0.3.11"), "v0.3.11");
+assert.equal(releaseTagForVersion("v0.3.11"), "v0.3.11");
+
+assert.throws(() => assetFor("freebsd", "x64"), /unsupported platform/);
+assert.throws(() => releaseTagForVersion(""), /package version is empty/);
+
+console.log("platform mapping ok");


### PR DESCRIPTION
## Summary
- add the @uchebnick/unch npm wrapper package to main
- add npm wrapper validation to CI, including dynamic version and publish dry-run checks
- publish the npm package from the release workflow using NPM_TOKEN, with the npm version derived from the release tag
- make release notifications wait for npm publish to complete

## Testing
- npm test
- npm version 1.2.3 --no-git-tag-version
- npm pack --dry-run
- npm publish --dry-run --access public
- git diff --check