### PR TITLE
Add v0.4.3 release notes

### DIFF
--- a/.github/releases/v0.4.3.md
+++ b/.github/releases/v0.4.3.md
@@ -1,0 +1,16 @@
+# unch v0.4.3
+
+`v0.4.3` is a small Codex and npm polish release. It focuses on making the npm-installed workflow easier to turn into a working agent setup after installing `@uchebnick/unch`.
+
+## Highlights
+
+- Added `unch codex install` to the npm wrapper flow, so a user can install the package, register the MCP server, and install the local `unch` Codex skill with one explicit command
+- The Codex setup writes the skill to `~/.codex/skills/unch/SKILL.md`, configures longer MCP startup/tool timeouts, and removes the old `~/.codex/prompts/unch.md` prompt if it exists
+- Refreshed README, npm package docs, and Mintlify installation docs around npm as the recommended install path and Codex skill setup
+- Aligned the npm MCP smoke test with the current tools-only MCP server by checking `tools/list` and `workspace_status` instead of the removed prompt API
+
+## Upgrade notes
+
+- If you installed `@uchebnick/unch` before this release and want Codex integration, run `unch codex install` once and restart Codex
+- The MCP server still exposes the stable tools `workspace_status`, `search_code`, and `index_repository`
+- Source installs can use `go install github.com/uchebnick/unch/cmd/unch@v0.4.3`

--- a/npm/unch/scripts/mcp-smoke.js
+++ b/npm/unch/scripts/mcp-smoke.js
@@ -56,15 +56,15 @@ async function main() {
   child.stdin.write(frame({
     jsonrpc: "2.0",
     id: 2,
-    method: "prompts/list"
+    method: "tools/list"
   }));
   child.stdin.write(frame({
     jsonrpc: "2.0",
     id: 3,
-    method: "prompts/get",
+    method: "tools/call",
     params: {
-      name: "unch",
-      arguments: { query: "router middleware" }
+      name: "workspace_status",
+      arguments: {}
     }
   }));
   child.stdin.end();
@@ -80,13 +80,18 @@ async function main() {
 
   const messages = readFrames(Buffer.concat(stdout));
   assert.equal(messages.length, 3);
-  assert.ok(messages[0].result.capabilities.prompts);
-  assert.equal(messages[1].result.prompts[0].name, "unch");
+  assert.ok(messages[0].result.capabilities.tools);
 
-  const promptText = messages[2].result.messages[0].content.text;
-  assert.match(promptText, /workspace_status/);
-  assert.match(promptText, /search_code/);
-  assert.match(promptText, /router middleware/);
+  const toolNames = messages[1].result.tools.map((tool) => tool.name).sort();
+  assert.deepEqual(toolNames, ["index_repository", "search_code", "workspace_status"]);
+
+  const status = messages[2].result.structuredContent;
+  assert.equal(typeof status.root, "string");
+  assert.equal(typeof status.state_dir, "string");
+  assert.equal(typeof status.index_present, "boolean");
+
+  const statusText = messages[2].result.content[0].text;
+  assert.match(statusText, /unch MCP workspace/);
 
   console.log("mcp smoke ok");
 }


### PR DESCRIPTION
## Summary
- add v0.4.3 release notes for npm/Codex setup
- align npm MCP smoke test with the tools-only MCP server
- confirm README, npm docs, and Mintlify already describe the Codex skill flow

## Tests
- npm test
- go build -o npm/unch/vendor/unch ./cmd/unch && npm run test:mcp