### PR TITLE
Support directory-scoped MCP tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ After restart, ask Codex a codebase question as usual. The skill tells Codex to 
 - `search_code` to search indexed code symbols before opening many files
 - `index_repository` to build or refresh the index when needed
 
+All MCP tools accept an optional `directory` argument. The installed skill passes the active repository path so `unch` searches the workspace Codex is currently editing, even if the MCP server was launched from somewhere else.
+
 Codex starts the stdio server for you with `unch start mcp`; you normally do not need to run that command by hand.
 
 ## What It Supports Today

--- a/internal/cli/mcp_backend.go
+++ b/internal/cli/mcp_backend.go
@@ -22,6 +22,10 @@ type mcpBackendConfig struct {
 	RootAbs           string
 	TargetPaths       semsearch.Paths
 	IndexPath         string
+	StateDirInput     string
+	StateDirExplicit  bool
+	DBInput           string
+	DBExplicit        bool
 	RequestedProvider string
 	RequestedModel    string
 	RequestedLibPath  string
@@ -48,6 +52,9 @@ type mcpBackend struct {
 	runMu sync.Mutex
 	mu    sync.Mutex
 
+	childrenMu sync.Mutex
+	children   map[string]*mcpBackend
+
 	prepared *preparedMCPResources
 }
 
@@ -60,10 +67,24 @@ func (b *mcpBackend) Version() string {
 }
 
 func (b *mcpBackend) Close() error {
+	b.childrenMu.Lock()
+	children := make([]*mcpBackend, 0, len(b.children))
+	for _, child := range b.children {
+		children = append(children, child)
+	}
+	b.children = nil
+	b.childrenMu.Unlock()
+
+	var firstErr error
+	for _, child := range children {
+		if err := child.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	var firstErr error
 	if b.prepared != nil {
 		if b.prepared.repo != nil {
 			if err := b.prepared.repo.Close(); err != nil && firstErr == nil {
@@ -78,7 +99,15 @@ func (b *mcpBackend) Close() error {
 	return firstErr
 }
 
-func (b *mcpBackend) WorkspaceStatus(_ context.Context) (unchmcp.WorkspaceStatusResult, error) {
+func (b *mcpBackend) WorkspaceStatus(ctx context.Context, params unchmcp.WorkspaceStatusParams) (unchmcp.WorkspaceStatusResult, error) {
+	backend, err := b.backendForDirectory(params.Directory)
+	if err != nil {
+		return unchmcp.WorkspaceStatusResult{}, err
+	}
+	return backend.workspaceStatus(ctx)
+}
+
+func (b *mcpBackend) workspaceStatus(_ context.Context) (unchmcp.WorkspaceStatusResult, error) {
 	result := unchmcp.WorkspaceStatusResult{
 		Root:              b.cfg.RootAbs,
 		StateDir:          b.cfg.TargetPaths.LocalDir,
@@ -137,6 +166,15 @@ func (b *mcpBackend) WorkspaceStatus(_ context.Context) (unchmcp.WorkspaceStatus
 }
 
 func (b *mcpBackend) SearchCode(ctx context.Context, params unchmcp.SearchCodeParams) (unchmcp.SearchCodeResult, error) {
+	backend, err := b.backendForDirectory(params.Directory)
+	if err != nil {
+		return unchmcp.SearchCodeResult{}, err
+	}
+	params.Directory = ""
+	return backend.searchCode(ctx, params)
+}
+
+func (b *mcpBackend) searchCode(ctx context.Context, params unchmcp.SearchCodeParams) (unchmcp.SearchCodeResult, error) {
 	b.runMu.Lock()
 	defer b.runMu.Unlock()
 
@@ -215,6 +253,15 @@ func (b *mcpBackend) SearchCode(ctx context.Context, params unchmcp.SearchCodePa
 }
 
 func (b *mcpBackend) IndexRepository(ctx context.Context, params unchmcp.IndexRepositoryParams) (unchmcp.IndexRepositoryResult, error) {
+	backend, err := b.backendForDirectory(params.Directory)
+	if err != nil {
+		return unchmcp.IndexRepositoryResult{}, err
+	}
+	params.Directory = ""
+	return backend.indexRepository(ctx, params)
+}
+
+func (b *mcpBackend) indexRepository(ctx context.Context, params unchmcp.IndexRepositoryParams) (unchmcp.IndexRepositoryResult, error) {
 	b.runMu.Lock()
 	defer b.runMu.Unlock()
 
@@ -313,6 +360,77 @@ func (b *mcpBackend) IndexRepository(ctx context.Context, params unchmcp.IndexRe
 	}, nil
 }
 
+func (b *mcpBackend) backendForDirectory(directory string) (*mcpBackend, error) {
+	rootAbs, ok, err := normalizeMCPDirectory(directory)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || rootAbs == b.cfg.RootAbs {
+		return b, nil
+	}
+
+	b.childrenMu.Lock()
+	defer b.childrenMu.Unlock()
+
+	if b.children == nil {
+		b.children = map[string]*mcpBackend{}
+	}
+	if child, ok := b.children[rootAbs]; ok {
+		return child, nil
+	}
+
+	targetPaths, indexPath, _, err := previewStateTarget(
+		rootAbs,
+		b.cfg.StateDirInput,
+		b.cfg.StateDirExplicit,
+		b.cfg.DBInput,
+		b.cfg.DBExplicit,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	child := newMCPBackend(mcpBackendConfig{
+		RootAbs:           rootAbs,
+		TargetPaths:       targetPaths,
+		IndexPath:         indexPath,
+		StateDirInput:     b.cfg.StateDirInput,
+		StateDirExplicit:  b.cfg.StateDirExplicit,
+		DBInput:           b.cfg.DBInput,
+		DBExplicit:        b.cfg.DBExplicit,
+		RequestedProvider: b.cfg.RequestedProvider,
+		RequestedModel:    b.cfg.RequestedModel,
+		RequestedLibPath:  b.cfg.RequestedLibPath,
+		ContextSize:       b.cfg.ContextSize,
+		Verbose:           b.cfg.Verbose,
+	})
+	child.scanner = b.scanner
+	child.models = b.models
+	child.runtimes = b.runtimes
+	b.children[rootAbs] = child
+	return child, nil
+}
+
+func normalizeMCPDirectory(directory string) (string, bool, error) {
+	clean := strings.TrimSpace(directory)
+	if clean == "" {
+		return "", false, nil
+	}
+
+	rootAbs, err := filepath.Abs(clean)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve directory: %w", err)
+	}
+	rootAbs = filepath.Clean(rootAbs)
+
+	if info, err := os.Stat(rootAbs); err != nil {
+		return "", false, fmt.Errorf("stat directory: %w", err)
+	} else if !info.IsDir() {
+		return "", false, fmt.Errorf("directory is not a directory: %s", rootAbs)
+	}
+	return rootAbs, true, nil
+}
+
 func (b *mcpBackend) ensurePrepared(ctx context.Context) (*preparedMCPResources, error) {
 	b.mu.Lock()
 	if b.prepared != nil {
@@ -321,6 +439,10 @@ func (b *mcpBackend) ensurePrepared(ctx context.Context) (*preparedMCPResources,
 		return prepared, nil
 	}
 	b.mu.Unlock()
+
+	if _, err := semsearch.PathsForLocalDir(b.cfg.TargetPaths.LocalDir); err != nil {
+		return nil, fmt.Errorf("prepare state directory: %w", err)
+	}
 
 	preparedEmbedder, err := prepareEmbedder(
 		ctx,

--- a/internal/cli/mcp_backend_test.go
+++ b/internal/cli/mcp_backend_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	unchmcp "github.com/uchebnick/unch/internal/mcp"
+)
+
+func TestMCPBackendWorkspaceStatusUsesDirectoryArgument(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	other := t.TempDir()
+
+	paths, indexPath, _, err := previewStateTarget(root, "", false, "", false)
+	if err != nil {
+		t.Fatalf("previewStateTarget() error: %v", err)
+	}
+	backend := newMCPBackend(mcpBackendConfig{
+		RootAbs:           root,
+		TargetPaths:       paths,
+		IndexPath:         indexPath,
+		RequestedProvider: "llama.cpp",
+	})
+
+	status, err := backend.WorkspaceStatus(context.Background(), unchmcp.WorkspaceStatusParams{
+		Directory: other,
+	})
+	if err != nil {
+		t.Fatalf("WorkspaceStatus() error: %v", err)
+	}
+
+	if status.Root != other {
+		t.Fatalf("Root = %q, want %q", status.Root, other)
+	}
+	if want := filepath.Join(other, ".semsearch"); status.StateDir != want {
+		t.Fatalf("StateDir = %q, want %q", status.StateDir, want)
+	}
+	if _, err := os.Stat(filepath.Join(other, ".semsearch")); !os.IsNotExist(err) {
+		t.Fatalf("workspace_status created state dir unexpectedly: %v", err)
+	}
+}
+
+func TestMCPBackendWorkspaceStatusRejectsFileDirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	paths, indexPath, _, err := previewStateTarget(root, "", false, "", false)
+	if err != nil {
+		t.Fatalf("previewStateTarget() error: %v", err)
+	}
+	filePath := filepath.Join(root, "main.go")
+	if err := os.WriteFile(filePath, []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error: %v", filePath, err)
+	}
+
+	backend := newMCPBackend(mcpBackendConfig{
+		RootAbs:           root,
+		TargetPaths:       paths,
+		IndexPath:         indexPath,
+		RequestedProvider: "llama.cpp",
+	})
+
+	if _, err := backend.WorkspaceStatus(context.Background(), unchmcp.WorkspaceStatusParams{
+		Directory: filePath,
+	}); err == nil {
+		t.Fatalf("WorkspaceStatus() error = nil, want file directory error")
+	}
+}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -91,27 +91,27 @@ func runStartMCP(ctx context.Context, program string, args []string) error {
 	if err != nil {
 		return fmt.Errorf("resolve root: %w", err)
 	}
+	rootAbs = filepath.Clean(rootAbs)
 
-	previewPaths, _, _, err := previewStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
+	targetPaths, resolvedIndexPath, _, err := previewStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
 	if err != nil {
 		return err
 	}
 	if parsedProvider, err := appembed.ParseProvider(*provider); err == nil && parsedProvider == appembed.ProviderOpenRouter {
-		if err := preflightProviderConfig(parsedProvider, previewPaths.LocalDir); err != nil {
+		if err := preflightProviderConfig(parsedProvider, targetPaths.LocalDir); err != nil {
 			printMissingProviderCredentialsWarning(parsedProvider)
 			return err
 		}
-	}
-
-	targetPaths, resolvedIndexPath, _, err := resolveStateTarget(rootAbs, *stateDir, stateDirWasExplicit, *dbPath, dbWasExplicit)
-	if err != nil {
-		return err
 	}
 
 	backend := newMCPBackend(mcpBackendConfig{
 		RootAbs:           rootAbs,
 		TargetPaths:       targetPaths,
 		IndexPath:         resolvedIndexPath,
+		StateDirInput:     strings.TrimSpace(*stateDir),
+		StateDirExplicit:  stateDirWasExplicit,
+		DBInput:           strings.TrimSpace(*dbPath),
+		DBExplicit:        dbWasExplicit,
 		RequestedProvider: strings.TrimSpace(*provider),
 		RequestedModel:    strings.TrimSpace(*modelPath),
 		RequestedLibPath:  strings.TrimSpace(*libPath),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -14,7 +14,7 @@ type fakeService struct{}
 
 func (fakeService) Version() string { return "vtest" }
 
-func (fakeService) WorkspaceStatus(context.Context) (WorkspaceStatusResult, error) {
+func (fakeService) WorkspaceStatus(context.Context, WorkspaceStatusParams) (WorkspaceStatusResult, error) {
 	return WorkspaceStatusResult{
 		Root:              "/repo",
 		StateDir:          "/repo/.semsearch",
@@ -58,6 +58,28 @@ func (fakeService) IndexRepository(context.Context, IndexRepositoryParams) (Inde
 		IndexedFiles:   7,
 		IndexedSymbols: 42,
 	}, nil
+}
+
+type capturingService struct {
+	fakeService
+	workspaceParams WorkspaceStatusParams
+	searchParams    SearchCodeParams
+	indexParams     IndexRepositoryParams
+}
+
+func (s *capturingService) WorkspaceStatus(ctx context.Context, params WorkspaceStatusParams) (WorkspaceStatusResult, error) {
+	s.workspaceParams = params
+	return s.fakeService.WorkspaceStatus(ctx, params)
+}
+
+func (s *capturingService) SearchCode(ctx context.Context, params SearchCodeParams) (SearchCodeResult, error) {
+	s.searchParams = params
+	return s.fakeService.SearchCode(ctx, params)
+}
+
+func (s *capturingService) IndexRepository(ctx context.Context, params IndexRepositoryParams) (IndexRepositoryResult, error) {
+	s.indexParams = params
+	return s.fakeService.IndexRepository(ctx, params)
 }
 
 func TestServerInitialize(t *testing.T) {
@@ -131,6 +153,10 @@ func TestServerToolsList(t *testing.T) {
 	for _, tool := range tools {
 		item := tool.(map[string]any)
 		descriptions[item["name"].(string)] = item["description"].(string)
+		properties := item["inputSchema"].(map[string]any)["properties"].(map[string]any)
+		if _, ok := properties["directory"]; !ok {
+			t.Fatalf("%s schema missing directory property", item["name"])
+		}
 	}
 	if !strings.Contains(descriptions["workspace_status"], "Call this first") {
 		t.Fatalf("workspace_status description = %q", descriptions["workspace_status"])
@@ -146,7 +172,10 @@ func TestServerToolsList(t *testing.T) {
 func TestServerWorkspaceStatusToolCall(t *testing.T) {
 	t.Parallel()
 
-	resp := serveOne(t, toolCall("workspace_status", map[string]any{}))
+	service := &capturingService{}
+	resp := serveOneWithService(t, service, toolCall("workspace_status", map[string]any{
+		"directory": "/repo",
+	}))
 	result := resp["result"].(map[string]any)
 	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
 	if !strings.Contains(text, "root: /repo") {
@@ -156,14 +185,19 @@ func TestServerWorkspaceStatusToolCall(t *testing.T) {
 	if got := structured["provider"]; got != "llama.cpp" {
 		t.Fatalf("provider = %v, want llama.cpp", got)
 	}
+	if got := service.workspaceParams.Directory; got != "/repo" {
+		t.Fatalf("workspace_status directory = %q, want /repo", got)
+	}
 }
 
 func TestServerSearchCodeToolCall(t *testing.T) {
 	t.Parallel()
 
-	resp := serveOne(t, toolCall("search_code", map[string]any{
-		"query":   "run cli",
-		"details": true,
+	service := &capturingService{}
+	resp := serveOneWithService(t, service, toolCall("search_code", map[string]any{
+		"directory": "/repo",
+		"query":     "run cli",
+		"details":   true,
 	}))
 	result := resp["result"].(map[string]any)
 	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
@@ -174,13 +208,18 @@ func TestServerSearchCodeToolCall(t *testing.T) {
 	if got := structured["query"]; got != "run cli" {
 		t.Fatalf("structuredContent.query = %v", got)
 	}
+	if got := service.searchParams.Directory; got != "/repo" {
+		t.Fatalf("search_code directory = %q, want /repo", got)
+	}
 }
 
 func TestServerIndexRepositoryToolCall(t *testing.T) {
 	t.Parallel()
 
-	resp := serveOne(t, toolCall("index_repository", map[string]any{
-		"excludes": []string{"node_modules", "dist"},
+	service := &capturingService{}
+	resp := serveOneWithService(t, service, toolCall("index_repository", map[string]any{
+		"directory": "/repo",
+		"excludes":  []string{"node_modules", "dist"},
 	}))
 	result := resp["result"].(map[string]any)
 	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
@@ -190,6 +229,9 @@ func TestServerIndexRepositoryToolCall(t *testing.T) {
 	structured := result["structuredContent"].(map[string]any)
 	if got := int(structured["indexed_symbols"].(float64)); got != 42 {
 		t.Fatalf("indexed_symbols = %d, want 42", got)
+	}
+	if got := service.indexParams.Directory; got != "/repo" {
+		t.Fatalf("index_repository directory = %q, want /repo", got)
 	}
 }
 
@@ -266,17 +308,29 @@ func TestServerNotificationIgnored(t *testing.T) {
 func serveOne(t *testing.T, request map[string]any) map[string]any {
 	t.Helper()
 
+	return serveOneWithService(t, fakeService{}, request)
+}
+
+func serveOneWithService(t *testing.T, service Service, request map[string]any) map[string]any {
+	t.Helper()
+
 	input := bytes.NewBuffer(nil)
 	writeTestFrame(t, input, request)
-	output := serveRaw(t, input)
+	output := serveRawWithService(t, service, input)
 	return readTestFrame(t, bufio.NewReader(output))
 }
 
 func serveRaw(t *testing.T, input *bytes.Buffer) *bytes.Buffer {
 	t.Helper()
 
+	return serveRawWithService(t, fakeService{}, input)
+}
+
+func serveRawWithService(t *testing.T, service Service, input *bytes.Buffer) *bytes.Buffer {
+	t.Helper()
+
 	output := bytes.NewBuffer(nil)
-	server := NewServer(fakeService{})
+	server := NewServer(service)
 	if err := server.Serve(context.Background(), input, output); err != nil {
 		t.Fatalf("Serve() error: %v", err)
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -34,14 +34,23 @@ type listToolsResult struct {
 	NextCursor string           `json:"nextCursor,omitempty"`
 }
 
+func directoryProperty() map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": "Optional absolute repository/workspace path to operate on. Pass the active workspace path when the MCP server may have been launched from another directory.",
+	}
+}
+
 func toolDefinitions() []toolDefinition {
 	return []toolDefinition{
 		{
 			Name:        "workspace_status",
 			Description: "Call this first. Returns the current repository root, .semsearch state directory, selected provider/model, manifest data, and whether a local index is already present.",
 			InputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{},
+				"type": "object",
+				"properties": map[string]any{
+					"directory": directoryProperty(),
+				},
 			},
 		},
 		{
@@ -50,6 +59,7 @@ func toolDefinitions() []toolDefinition {
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
+					"directory": directoryProperty(),
 					"query": map[string]any{
 						"type":        "string",
 						"description": "Short natural-language, identifier, API, behavior, or error-handling query. Examples: \"request router middleware\", \"UserRepository Create\", \"MCP Content-Length framing\".",
@@ -87,6 +97,7 @@ func toolDefinitions() []toolDefinition {
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
+					"directory": directoryProperty(),
 					"excludes": map[string]any{
 						"type":        "array",
 						"items":       map[string]any{"type": "string"},
@@ -115,10 +126,11 @@ func toolDefinitions() []toolDefinition {
 func (s *Server) callTool(ctx context.Context, params toolCallParams) (toolCallResult, error) {
 	switch params.Name {
 	case "workspace_status":
-		if err := decodeToolArgs(params.Arguments, &struct{}{}); err != nil {
+		var args WorkspaceStatusParams
+		if err := decodeToolArgs(params.Arguments, &args); err != nil {
 			return toolCallResult{}, err
 		}
-		result, err := s.service.WorkspaceStatus(ctx)
+		result, err := s.service.WorkspaceStatus(ctx, args)
 		if err != nil {
 			return toolErrorResult(err), nil
 		}

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -4,12 +4,17 @@ import "context"
 
 type Service interface {
 	Version() string
-	WorkspaceStatus(context.Context) (WorkspaceStatusResult, error)
+	WorkspaceStatus(context.Context, WorkspaceStatusParams) (WorkspaceStatusResult, error)
 	SearchCode(context.Context, SearchCodeParams) (SearchCodeResult, error)
 	IndexRepository(context.Context, IndexRepositoryParams) (IndexRepositoryResult, error)
 }
 
+type WorkspaceStatusParams struct {
+	Directory string `json:"directory,omitempty"`
+}
+
 type SearchCodeParams struct {
+	Directory   string   `json:"directory,omitempty"`
 	Query       string   `json:"query"`
 	Limit       int      `json:"limit,omitempty"`
 	Mode        string   `json:"mode,omitempty"`
@@ -41,6 +46,7 @@ type SearchCodeResult struct {
 }
 
 type IndexRepositoryParams struct {
+	Directory     string   `json:"directory,omitempty"`
 	Excludes      []string `json:"excludes,omitempty"`
 	Gitignore     string   `json:"gitignore,omitempty"`
 	CommentPrefix string   `json:"comment_prefix,omitempty"`

--- a/mintlify/commands/mcp.mdx
+++ b/mintlify/commands/mcp.mdx
@@ -29,6 +29,8 @@ Codex starts the stdio MCP server for you. You normally do not need to run `unch
 
 ## Tools
 
+All tools accept an optional `directory` argument. Codex should pass the absolute path of the active repository so the MCP server operates on the workspace being edited, not on the directory where the server process was launched.
+
 ### `workspace_status`
 
 Returns the repository root, state directory, selected provider/model, index path, manifest metadata, and whether an index is already present.


### PR DESCRIPTION
## Summary

- Add an optional `directory` argument to all unch MCP tools: `workspace_status`, `search_code`, and `index_repository`.
- Route MCP calls to a backend scoped to the requested repository directory instead of always using the MCP process launch directory.
- Keep `workspace_status` cheap: it previews the target state path and does not create `.semsearch`.
- Document the `directory` argument in README and Mintlify MCP docs.

Fixes #98.

## Tests

- `go test ./internal/mcp ./internal/cli`
- `go test ./...`
- real stdio smoke via `go run ./cmd/unch start mcp` + `workspace_status` with `directory`