### PR TITLE
Add v0.4.4 release notes

### DIFF
--- a/.github/releases/v0.4.4.md
+++ b/.github/releases/v0.4.4.md
@@ -1,0 +1,18 @@
+# unch v0.4.4
+
+`v0.4.4` is a small MCP and Codex reliability release. It makes the Codex integration safer to use across real workspaces and refreshes the project documentation around the current setup flow.
+
+## Highlights
+
+- MCP tools now accept an optional `directory` argument, so `workspace_status`, `search_code`, and `index_repository` can operate on the active repository instead of the directory where the MCP server process was launched
+- The MCP backend now routes tool calls to a repository-scoped backend and keeps `workspace_status` cheap: checking another workspace does not create `.semsearch`
+- The Codex MCP setup docs were simplified around the recommended flow: install the npm wrapper, run `unch codex install`, then restart Codex
+- The npm package docs now point users at the same Codex setup flow as the main README and Mintlify docs
+- `CONTRIBUTING.md` now includes a fuller project overview, module map, and development workflow for contributors
+
+## Upgrade notes
+
+- If you use Codex with the npm wrapper, update and re-run `unch codex install`, then restart Codex
+- The MCP tool names are unchanged: `workspace_status`, `search_code`, and `index_repository`
+- Existing `.semsearch` indexes remain compatible; this release changes MCP workspace routing, not the index format
+- Source installs can use `go install github.com/uchebnick/unch/cmd/unch@v0.4.4`


### PR DESCRIPTION
## Summary

- Add release notes for `v0.4.4` covering the MCP directory routing, Codex setup docs, npm docs refresh, and contributing guide updates.

## Tests

- Not run; documentation-only change.