### PR TITLE
Batch OpenRouter embeddings during indexing

### DIFF
--- a/internal/embed/openrouter/embedder.go
+++ b/internal/embed/openrouter/embedder.go
@@ -15,11 +15,13 @@ import (
 )
 
 const defaultBaseURL = "https://openrouter.ai/api/v1"
+const defaultBatchSize = 128
 
 type Config struct {
 	ModelID     string
 	APIKey      string
 	BaseURL     string
+	Dimensions  int
 	HTTPReferer string
 	AppTitle    string
 	HTTPClient  *http.Client
@@ -33,6 +35,7 @@ type Embedder struct {
 	httpReferer string
 	appTitle    string
 	modelID     string
+	dimensions  int
 	formatter   appembed.Formatter
 	dim         int
 }
@@ -41,6 +44,7 @@ type embeddingsRequest struct {
 	Model          string   `json:"model"`
 	Input          []string `json:"input"`
 	EncodingFormat string   `json:"encoding_format,omitempty"`
+	Dimensions     int      `json:"dimensions,omitempty"`
 }
 
 type embeddingsResponse struct {
@@ -51,6 +55,49 @@ type embeddingsResponse struct {
 	Error *struct {
 		Message string `json:"message"`
 	} `json:"error,omitempty"`
+}
+
+type requestError struct {
+	statusCode int
+	status     string
+	message    string
+	retryAfter time.Duration
+	cause      error
+}
+
+func (e requestError) Error() string {
+	if e.cause != nil {
+		return "request OpenRouter embeddings: " + e.cause.Error()
+	}
+	message := strings.TrimSpace(e.message)
+	if message != "" {
+		return "OpenRouter embeddings request failed: " + message
+	}
+	if e.status != "" {
+		return "OpenRouter embeddings request failed: status " + e.status
+	}
+	return "OpenRouter embeddings request failed"
+}
+
+func (e requestError) Unwrap() error {
+	return e.cause
+}
+
+func (e requestError) Temporary() bool {
+	return e.cause != nil || e.statusCode == http.StatusTooManyRequests || e.statusCode >= 500
+}
+
+func (e requestError) RetryAfter() time.Duration {
+	return e.retryAfter
+}
+
+func (e requestError) SplitBatch() bool {
+	message := strings.ToLower(e.message)
+	return e.statusCode == http.StatusRequestEntityTooLarge ||
+		e.statusCode == http.StatusBadRequest && strings.Contains(message, "too") ||
+		strings.Contains(message, "maximum") ||
+		strings.Contains(message, "context length") ||
+		strings.Contains(message, "token")
 }
 
 func New(ctx context.Context, cfg Config) (*Embedder, error) {
@@ -69,7 +116,7 @@ func New(ctx context.Context, cfg Config) (*Embedder, error) {
 	}
 	client := cfg.HTTPClient
 	if client == nil {
-		client = &http.Client{Timeout: 60 * time.Second}
+		client = &http.Client{Timeout: 180 * time.Second}
 	}
 	formatter := cfg.Formatter
 	if formatter == nil {
@@ -83,6 +130,7 @@ func New(ctx context.Context, cfg Config) (*Embedder, error) {
 		httpReferer: strings.TrimSpace(cfg.HTTPReferer),
 		appTitle:    strings.TrimSpace(cfg.AppTitle),
 		modelID:     modelID,
+		dimensions:  cfg.Dimensions,
 		formatter:   formatter,
 	}
 
@@ -119,16 +167,74 @@ func (e *Embedder) EmbedIndexedSymbol(path string, symbol indexing.IndexedSymbol
 	return e.embedInput(context.Background(), e.formatter.FormatIndexedSymbolDocument(path, symbol))
 }
 
+func (e *Embedder) EmbedIndexedSymbolBatch(items []indexing.EmbedItem) ([][]float32, error) {
+	inputs := make([]string, 0, len(items))
+	for _, item := range items {
+		input := strings.TrimSpace(e.formatter.FormatIndexedSymbolDocument(item.Path, item.Symbol))
+		if input == "" {
+			inputs = append(inputs, "")
+			continue
+		}
+		inputs = append(inputs, input)
+	}
+	return e.embedInputsInBatches(inputs)
+}
+
+func (e *Embedder) embedInputsInBatches(inputs []string) ([][]float32, error) {
+	vectors := make([][]float32, len(inputs))
+	for start := 0; start < len(inputs); start += defaultBatchSize {
+		end := start + defaultBatchSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		batch := inputs[start:end]
+		nonEmptyInputs := make([]string, 0, len(batch))
+		nonEmptyIndexes := make([]int, 0, len(batch))
+		for i, input := range batch {
+			if input == "" {
+				continue
+			}
+			nonEmptyIndexes = append(nonEmptyIndexes, start+i)
+			nonEmptyInputs = append(nonEmptyInputs, input)
+		}
+		if len(nonEmptyInputs) == 0 {
+			continue
+		}
+		batchVectors, err := e.embedInputs(context.Background(), nonEmptyInputs)
+		if err != nil {
+			return nil, err
+		}
+		if len(batchVectors) != len(nonEmptyInputs) {
+			return nil, fmt.Errorf("OpenRouter returned %d embeddings for %d inputs", len(batchVectors), len(nonEmptyInputs))
+		}
+		for i, vec := range batchVectors {
+			vectors[nonEmptyIndexes[i]] = vec
+		}
+	}
+	return vectors, nil
+}
+
 func (e *Embedder) embedInput(ctx context.Context, input string) ([]float32, error) {
 	input = strings.TrimSpace(input)
 	if input == "" {
 		return nil, nil
 	}
+	vectors, err := e.embedInputs(ctx, []string{input})
+	if err != nil {
+		return nil, err
+	}
+	return vectors[0], nil
+}
 
+func (e *Embedder) embedInputs(ctx context.Context, inputs []string) ([][]float32, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
 	reqBody, err := json.Marshal(embeddingsRequest{
 		Model:          e.modelID,
-		Input:          []string{input},
+		Input:          inputs,
 		EncodingFormat: "float",
+		Dimensions:     e.dimensions,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("encode embeddings request: %w", err)
@@ -149,7 +255,7 @@ func (e *Embedder) embedInput(ctx context.Context, input string) ([]float32, err
 
 	resp, err := e.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request OpenRouter embeddings: %w", err)
+		return nil, requestError{cause: err}
 	}
 	defer func() {
 		_ = resp.Body.Close()
@@ -166,22 +272,61 @@ func (e *Embedder) embedInput(ctx context.Context, input string) ([]float32, err
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message := ""
 		if payload.Error != nil && strings.TrimSpace(payload.Error.Message) != "" {
-			return nil, fmt.Errorf("OpenRouter embeddings request failed: %s", strings.TrimSpace(payload.Error.Message))
+			message = strings.TrimSpace(payload.Error.Message)
 		}
-		return nil, fmt.Errorf("OpenRouter embeddings request failed: status %s", resp.Status)
+		return nil, requestError{
+			statusCode: resp.StatusCode,
+			status:     resp.Status,
+			message:    message,
+			retryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
+		}
 	}
 	if payload.Error != nil && strings.TrimSpace(payload.Error.Message) != "" {
 		return nil, fmt.Errorf("OpenRouter embeddings request failed: %s", strings.TrimSpace(payload.Error.Message))
 	}
-	if len(payload.Data) == 0 || len(payload.Data[0].Embedding) == 0 {
+	if len(payload.Data) == 0 {
 		return nil, fmt.Errorf("OpenRouter embeddings response did not contain an embedding")
 	}
-	if e.dim > 0 && len(payload.Data[0].Embedding) != e.dim {
-		return nil, fmt.Errorf("unexpected OpenRouter embedding dimension: got=%d want=%d", len(payload.Data[0].Embedding), e.dim)
+
+	vectors := make([][]float32, len(inputs))
+	for _, item := range payload.Data {
+		if item.Index < 0 || item.Index >= len(inputs) {
+			return nil, fmt.Errorf("OpenRouter returned embedding with out-of-range index %d", item.Index)
+		}
+		if len(item.Embedding) == 0 {
+			return nil, fmt.Errorf("OpenRouter embeddings response contained an empty embedding")
+		}
+		if e.dim > 0 && len(item.Embedding) != e.dim {
+			return nil, fmt.Errorf("unexpected OpenRouter embedding dimension: got=%d want=%d", len(item.Embedding), e.dim)
+		}
+		vector := make([]float32, len(item.Embedding))
+		copy(vector, item.Embedding)
+		vectors[item.Index] = vector
+	}
+	for i, vector := range vectors {
+		if len(vector) == 0 {
+			return nil, fmt.Errorf("OpenRouter embeddings response missing embedding for input %d", i)
+		}
 	}
 
-	vector := make([]float32, len(payload.Data[0].Embedding))
-	copy(vector, payload.Data[0].Embedding)
-	return vector, nil
+	return vectors, nil
+}
+
+func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := time.ParseDuration(value + "s"); err == nil {
+		return seconds
+	}
+	if when, err := http.ParseTime(value); err == nil {
+		delay := time.Until(when)
+		if delay > 0 {
+			return delay
+		}
+	}
+	return 0
 }

--- a/internal/embed/openrouter/embedder_test.go
+++ b/internal/embed/openrouter/embedder_test.go
@@ -1,0 +1,48 @@
+package openrouterembed
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRequestErrorClassifiesRateLimit(t *testing.T) {
+	err := requestError{
+		statusCode: http.StatusTooManyRequests,
+		status:     "429 Too Many Requests",
+		retryAfter: 2 * time.Second,
+	}
+
+	if !err.Temporary() {
+		t.Fatalf("Temporary() = false, want true")
+	}
+	if got := err.RetryAfter(); got != 2*time.Second {
+		t.Fatalf("RetryAfter() = %s, want 2s", got)
+	}
+	if err.SplitBatch() {
+		t.Fatalf("SplitBatch() = true, want false for rate limit")
+	}
+}
+
+func TestRequestErrorClassifiesOversizedBatch(t *testing.T) {
+	err := requestError{
+		statusCode: http.StatusRequestEntityTooLarge,
+		status:     "413 Payload Too Large",
+		message:    "payload too large",
+	}
+
+	if !err.SplitBatch() {
+		t.Fatalf("SplitBatch() = false, want true")
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	if got := parseRetryAfter("3"); got != 3*time.Second {
+		t.Fatalf("parseRetryAfter(seconds) = %s, want 3s", got)
+	}
+
+	when := time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat)
+	if got := parseRetryAfter(when); got <= 0 {
+		t.Fatalf("parseRetryAfter(http date) = %s, want positive duration", got)
+	}
+}

--- a/internal/indexing/service.go
+++ b/internal/indexing/service.go
@@ -2,7 +2,10 @@ package indexing
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
+	"time"
 )
 
 type Reporter interface {
@@ -34,6 +37,21 @@ type Embedder interface {
 	IndexedSymbolHash(path string, symbol IndexedSymbol) string
 	EmbedIndexedSymbol(path string, symbol IndexedSymbol) ([]float32, error)
 }
+
+type EmbedItem struct {
+	Path   string
+	Symbol IndexedSymbol
+}
+
+type BatchEmbedder interface {
+	EmbedIndexedSymbolBatch(items []EmbedItem) ([][]float32, error)
+}
+
+const embeddingBatchSize = 64
+const embeddingWorkerCount = 3
+const embeddingMaxAttempts = 5
+const embeddingRetryBaseDelay = 750 * time.Millisecond
+const embeddingBatchMaxDelay = 100 * time.Millisecond
 
 type Params struct {
 	Root                 string
@@ -75,6 +93,36 @@ type runState struct {
 	reusedFiles        int
 	reusedSymbols      int
 	result             Result
+	embeddings         embeddingBuffer
+}
+
+type pendingEmbedding struct {
+	path   string
+	symbol IndexedSymbol
+	hash   string
+}
+
+type embeddingRequest struct {
+	item     pendingEmbedding
+	attempt  int
+	queuedAt time.Time
+}
+
+type embeddingBatchRequest struct {
+	items []embeddingRequest
+}
+
+type embeddingBatchResult struct {
+	request embeddingBatchRequest
+	vectors [][]float32
+	err     error
+}
+
+type embeddingBuffer struct {
+	hashes   map[string]struct{}
+	requests chan embeddingRequest
+	done     chan error
+	batcher  BatchEmbedder
 }
 
 // Run scans the repository, embeds extracted symbols, and activates the new index version.
@@ -115,9 +163,14 @@ func (s Service) Run(ctx context.Context, params Params, reporter Reporter) (Res
 		snapshotID:         snapshotID,
 		totalFiles:         len(params.CurrentFileHashes),
 		result:             Result{Version: snapshotID},
+		embeddings:         embeddingBuffer{hashes: make(map[string]struct{})},
 	}
+	state.startEmbeddingPipeline()
 
 	if err := state.walk(); err != nil {
+		if pipelineErr := state.finishEmbeddingPipeline(); pipelineErr != nil {
+			return Result{}, fmt.Errorf("%w; embedding pipeline: %v", err, pipelineErr)
+		}
 		return Result{}, err
 	}
 	if err := state.finalize(); err != nil {
@@ -214,26 +267,354 @@ func (r *runState) reindexFile(path string, rel string) error {
 func (r *runState) indexJob(job FileJob) error {
 	for _, symbol := range job.Symbols {
 		hash := r.service.Embedder.IndexedSymbolHash(job.Path, symbol)
-
 		exists, err := r.service.Repo.EmbeddingExists(r.ctx, r.provider, r.modelID, hash)
 		if err != nil {
 			return fmt.Errorf("check embedding exists: %w", err)
 		}
 		if !exists {
-			vec, err := r.service.Embedder.EmbedIndexedSymbol(job.Path, symbol)
-			if err != nil {
-				return fmt.Errorf("embed symbol at %s:%d: %w", job.Path, symbol.Line, err)
-			}
-			if err := r.service.Repo.AddEmbedding(r.ctx, r.provider, r.modelID, hash, vec); err != nil {
-				return fmt.Errorf("store embedding: %w", err)
+			if err := r.queueMissingEmbedding(job.Path, symbol, hash); err != nil {
+				return err
 			}
 		}
-
 		if err := r.service.Repo.InsertSymbol(r.ctx, r.snapshotID, r.provider, r.modelID, job.Path, symbol, hash); err != nil {
 			return fmt.Errorf("insert symbol: %w", err)
 		}
 	}
 	return nil
+}
+
+func (r *runState) startEmbeddingPipeline() {
+	batcher, ok := r.service.Embedder.(BatchEmbedder)
+	if !ok {
+		return
+	}
+	r.embeddings.batcher = batcher
+	r.embeddings.requests = make(chan embeddingRequest, embeddingBatchSize*embeddingWorkerCount)
+	r.embeddings.done = make(chan error, 1)
+	go func() {
+		r.embeddings.done <- r.runEmbeddingPipeline(batcher, r.embeddings.requests)
+	}()
+}
+
+func (r *runState) finishEmbeddingPipeline() error {
+	if r.embeddings.requests == nil {
+		return nil
+	}
+	close(r.embeddings.requests)
+	r.embeddings.requests = nil
+	return <-r.embeddings.done
+}
+
+func (r *runState) queueMissingEmbedding(path string, symbol IndexedSymbol, hash string) error {
+	if _, ok := r.embeddings.hashes[hash]; ok {
+		return nil
+	}
+	r.embeddings.hashes[hash] = struct{}{}
+	item := pendingEmbedding{
+		path:   path,
+		symbol: symbol,
+		hash:   hash,
+	}
+
+	if r.embeddings.requests != nil {
+		select {
+		case <-r.ctx.Done():
+			return r.ctx.Err()
+		case r.embeddings.requests <- embeddingRequest{item: item, attempt: 1, queuedAt: time.Now()}:
+			return nil
+		}
+	}
+
+	vec, err := r.service.Embedder.EmbedIndexedSymbol(path, symbol)
+	if err != nil {
+		return fmt.Errorf("embed symbol at %s:%d: %w", path, symbol.Line, err)
+	}
+	if err := r.service.Repo.AddEmbedding(r.ctx, r.provider, r.modelID, hash, vec); err != nil {
+		return fmt.Errorf("store embedding: %w", err)
+	}
+	return nil
+}
+
+func (r *runState) flushEmbeddingBatches(batcher BatchEmbedder, batch []pendingEmbedding) error {
+	requests := make(chan embeddingRequest, len(batch))
+	now := time.Now()
+	for _, item := range batch {
+		requests <- embeddingRequest{item: item, attempt: 1, queuedAt: now}
+	}
+	close(requests)
+	return r.runEmbeddingPipeline(batcher, requests)
+}
+
+func (r *runState) runEmbeddingPipeline(batcher BatchEmbedder, requests <-chan embeddingRequest) error {
+	jobs := make(chan embeddingBatchRequest, embeddingWorkerCount)
+	results := make(chan embeddingBatchResult, embeddingWorkerCount)
+
+	var workers sync.WaitGroup
+	for i := 0; i < embeddingWorkerCount; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			embeddingBatchWorker(r.ctx, batcher, jobs, results)
+		}()
+	}
+
+	pending := make([]embeddingRequest, 0, embeddingBatchSize)
+	queue := make([]embeddingBatchRequest, 0)
+	active := 0
+	inputClosed := false
+
+	closeWorkers := func() {
+		close(jobs)
+		workers.Wait()
+	}
+	finishWithError := func(err error) error {
+		closeWorkers()
+		drainEmbeddingRequests(r.ctx, requests)
+		return err
+	}
+
+	for {
+		if len(pending) >= embeddingBatchSize {
+			queue = append(queue, popEmbeddingBatch(&pending, embeddingBatchSize))
+		}
+		for len(queue) > 0 && active < embeddingWorkerCount {
+			select {
+			case <-r.ctx.Done():
+				closeWorkers()
+				return r.ctx.Err()
+			case jobs <- queue[0]:
+				queue = queue[1:]
+				active++
+			}
+		}
+		if inputClosed && len(pending) == 0 && len(queue) == 0 && active == 0 {
+			closeWorkers()
+			return nil
+		}
+
+		timer := embeddingBatchTimer(pending)
+		select {
+		case <-r.ctx.Done():
+			closeWorkers()
+			return r.ctx.Err()
+		case req, ok := <-requests:
+			if !ok {
+				inputClosed = true
+				if len(pending) > 0 {
+					queue = append(queue, popEmbeddingBatch(&pending, len(pending)))
+				}
+				continue
+			}
+			if req.queuedAt.IsZero() {
+				req.queuedAt = time.Now()
+			}
+			pending = append(pending, req)
+		case <-timer:
+			if len(pending) > 0 {
+				queue = append(queue, popEmbeddingBatch(&pending, len(pending)))
+			}
+		case result := <-results:
+			active--
+			if result.err != nil {
+				retryBatches, err := retryEmbeddingBatch(r.ctx, result.request, result.err)
+				if err != nil {
+					return finishWithError(err)
+				}
+				queue = append(queue, retryBatches...)
+				continue
+			}
+			if err := r.storeEmbeddingBatchResult(result); err != nil {
+				return finishWithError(err)
+			}
+		}
+	}
+}
+
+func drainEmbeddingRequests(ctx context.Context, requests <-chan embeddingRequest) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-requests:
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
+func popEmbeddingBatch(pending *[]embeddingRequest, size int) embeddingBatchRequest {
+	if size > len(*pending) {
+		size = len(*pending)
+	}
+	items := make([]embeddingRequest, size)
+	copy(items, (*pending)[:size])
+	*pending = (*pending)[size:]
+	return embeddingBatchRequest{items: items}
+}
+
+func embeddingBatchTimer(pending []embeddingRequest) <-chan time.Time {
+	if len(pending) == 0 {
+		return nil
+	}
+	delay := embeddingBatchMaxDelay - time.Since(pending[0].queuedAt)
+	if delay <= 0 {
+		delay = 1
+	}
+	return time.After(delay)
+}
+
+func (r *runState) storeEmbeddingBatchResult(result embeddingBatchResult) error {
+	if len(result.vectors) != len(result.request.items) {
+		return fmt.Errorf("embed symbols: got %d vectors for %d symbols", len(result.vectors), len(result.request.items))
+	}
+	for i, vec := range result.vectors {
+		item := result.request.items[i].item
+		if err := r.service.Repo.AddEmbedding(r.ctx, r.provider, r.modelID, item.hash, vec); err != nil {
+			return fmt.Errorf("store embedding: %w", err)
+		}
+	}
+	return nil
+}
+
+func embeddingBatchWorker(ctx context.Context, batcher BatchEmbedder, jobs <-chan embeddingBatchRequest, results chan<- embeddingBatchResult) {
+	for request := range jobs {
+		items := make([]EmbedItem, 0, len(request.items))
+		for _, item := range request.items {
+			items = append(items, EmbedItem{Path: item.item.path, Symbol: item.item.symbol})
+		}
+		vectors, err := batcher.EmbedIndexedSymbolBatch(items)
+		select {
+		case <-ctx.Done():
+			return
+		case results <- embeddingBatchResult{request: request, vectors: vectors, err: err}:
+		}
+	}
+}
+
+func retryEmbeddingBatch(ctx context.Context, request embeddingBatchRequest, err error) ([]embeddingBatchRequest, error) {
+	if len(request.items) == 0 {
+		return nil, nil
+	}
+
+	nextAttempt := maxEmbeddingAttempt(request.items) + 1
+	if nextAttempt > embeddingMaxAttempts {
+		return nil, fmt.Errorf("embed symbols after %d attempts: %w", embeddingMaxAttempts, err)
+	}
+
+	if shouldSplitEmbeddingBatch(err) && len(request.items) > 1 {
+		return splitEmbeddingBatchForRetry(request, nextAttempt), nil
+	}
+
+	if !isRetryableEmbeddingError(err) && len(request.items) <= 1 {
+		return nil, fmt.Errorf("embed symbol at %s:%d: %w", request.items[0].item.path, request.items[0].item.symbol.Line, err)
+	}
+
+	if delay := embeddingRetryDelay(err, nextAttempt); delay > 0 {
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	retry := make([]embeddingRequest, len(request.items))
+	now := time.Now()
+	for i, item := range request.items {
+		item.attempt = nextAttempt
+		item.queuedAt = now
+		retry[i] = item
+	}
+	return []embeddingBatchRequest{{items: retry}}, nil
+}
+
+func splitEmbeddingBatchForRetry(request embeddingBatchRequest, nextAttempt int) []embeddingBatchRequest {
+	if len(request.items) <= 1 {
+		item := request.items[0]
+		item.attempt = nextAttempt
+		item.queuedAt = time.Now()
+		return []embeddingBatchRequest{{items: []embeddingRequest{item}}}
+	}
+
+	items := make([]embeddingRequest, len(request.items))
+	now := time.Now()
+	for i, item := range request.items {
+		item.attempt = nextAttempt
+		item.queuedAt = now
+		items[i] = item
+	}
+	mid := len(items) / 2
+	return []embeddingBatchRequest{
+		{items: items[:mid]},
+		{items: items[mid:]},
+	}
+}
+
+func maxEmbeddingAttempt(items []embeddingRequest) int {
+	maxAttempt := 0
+	for _, item := range items {
+		if item.attempt > maxAttempt {
+			maxAttempt = item.attempt
+		}
+	}
+	return maxAttempt
+}
+
+type retryAfterEmbeddingError interface {
+	RetryAfter() time.Duration
+}
+
+type temporaryEmbeddingError interface {
+	Temporary() bool
+}
+
+type splitBatchEmbeddingError interface {
+	SplitBatch() bool
+}
+
+func isRetryableEmbeddingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var retryAfter retryAfterEmbeddingError
+	if errors.As(err, &retryAfter) && retryAfter.RetryAfter() > 0 {
+		return true
+	}
+	var temporary temporaryEmbeddingError
+	if errors.As(err, &temporary) {
+		return temporary.Temporary()
+	}
+	return false
+}
+
+func shouldSplitEmbeddingBatch(err error) bool {
+	if err == nil {
+		return false
+	}
+	var splitter splitBatchEmbeddingError
+	if errors.As(err, &splitter) {
+		return splitter.SplitBatch()
+	}
+	return !isRetryableEmbeddingError(err)
+}
+
+func embeddingRetryDelay(err error, attempt int) time.Duration {
+	var retryAfter retryAfterEmbeddingError
+	if errors.As(err, &retryAfter) {
+		if delay := retryAfter.RetryAfter(); delay > 0 {
+			return min(delay, 10*time.Second)
+		}
+	}
+	if attempt < 1 {
+		attempt = 1
+	}
+	delay := embeddingRetryBaseDelay << min(attempt-1, 4)
+	if delay > 10*time.Second {
+		return 10 * time.Second
+	}
+	return delay
 }
 
 func (r *runState) advanceProgress() {
@@ -249,6 +630,9 @@ func (r *runState) advanceProgress() {
 func (r *runState) finalize() error {
 	if r.processedFiles > 0 && r.reporter != nil {
 		r.reporter.CountProgress("Indexing", r.processedFiles, r.processedFiles)
+	}
+	if err := r.finishEmbeddingPipeline(); err != nil {
+		return err
 	}
 	if err := r.service.Repo.ActivateSnapshot(r.ctx, r.provider, r.modelID, r.snapshotID); err != nil {
 		return fmt.Errorf("activate snapshot: %w", err)

--- a/internal/indexing/service_test.go
+++ b/internal/indexing/service_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 )
 
 type testScanner struct {
@@ -97,6 +99,68 @@ func (e *testEmbedder) IndexedSymbolHash(path string, symbol IndexedSymbol) stri
 func (e *testEmbedder) EmbedIndexedSymbol(path string, symbol IndexedSymbol) ([]float32, error) {
 	e.embedCalls++
 	return []float32{1, 2, 3}, nil
+}
+
+type testBatchEmbedder struct {
+	mu         sync.Mutex
+	calls      int
+	batchSizes []int
+	errForCall map[int]error
+	splitLarge bool
+}
+
+func (e *testBatchEmbedder) IndexedSymbolHash(path string, symbol IndexedSymbol) string {
+	return path + ":" + symbol.QualifiedName
+}
+
+func (e *testBatchEmbedder) EmbedIndexedSymbol(path string, symbol IndexedSymbol) ([]float32, error) {
+	return []float32{1, 2, 3}, nil
+}
+
+func (e *testBatchEmbedder) EmbedIndexedSymbolBatch(items []EmbedItem) ([][]float32, error) {
+	e.mu.Lock()
+	e.calls++
+	call := e.calls
+	e.batchSizes = append(e.batchSizes, len(items))
+	err := e.errForCall[call]
+	splitLarge := e.splitLarge && len(items) > 1
+	e.mu.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
+	if splitLarge {
+		return nil, testEmbeddingError{split: true}
+	}
+
+	vectors := make([][]float32, len(items))
+	for i := range items {
+		vectors[i] = []float32{float32(i), 2, 3}
+	}
+	return vectors, nil
+}
+
+type testEmbeddingError struct {
+	temporary  bool
+	split      bool
+	retryAfter time.Duration
+}
+
+func (e testEmbeddingError) Error() string { return "test embedding error" }
+func (e testEmbeddingError) Temporary() bool {
+	return e.temporary
+}
+func (e testEmbeddingError) RetryAfter() time.Duration {
+	if e.retryAfter > 0 {
+		return e.retryAfter
+	}
+	if e.temporary {
+		return time.Nanosecond
+	}
+	return 0
+}
+func (e testEmbeddingError) SplitBatch() bool {
+	return e.split
 }
 
 type testReporter struct {
@@ -273,6 +337,107 @@ func TestServiceRunCopiesUnchangedFilesFromCurrentSnapshot(t *testing.T) {
 	}
 	if hashes.inserted["a.go"] == "" || hashes.inserted["b.go"] == "" {
 		t.Fatalf("expected per-file hashes to be inserted, got %#v", hashes.inserted)
+	}
+}
+
+func TestFlushEmbeddingBatchesRetriesTemporaryErrors(t *testing.T) {
+	t.Parallel()
+
+	repo := &testRepo{existing: map[string]bool{}}
+	batcher := &testBatchEmbedder{
+		errForCall: map[int]error{
+			1: testEmbeddingError{temporary: true},
+		},
+	}
+	state := runState{
+		service: Service{
+			Repo:     repo,
+			Embedder: batcher,
+		},
+		ctx:      context.Background(),
+		provider: "openrouter",
+		modelID:  "qwen",
+	}
+
+	err := state.flushEmbeddingBatches(batcher, []pendingEmbedding{
+		{path: "a.go", symbol: IndexedSymbol{Line: 1, QualifiedName: "A"}, hash: "a"},
+		{path: "b.go", symbol: IndexedSymbol{Line: 2, QualifiedName: "B"}, hash: "b"},
+	})
+	if err != nil {
+		t.Fatalf("flushEmbeddingBatches() error: %v", err)
+	}
+	if batcher.calls != 2 {
+		t.Fatalf("batch calls = %d, want 2", batcher.calls)
+	}
+	if len(repo.added) != 2 {
+		t.Fatalf("stored embeddings = %v, want 2", repo.added)
+	}
+}
+
+func TestFlushEmbeddingBatchesSplitsFailedBatches(t *testing.T) {
+	t.Parallel()
+
+	repo := &testRepo{existing: map[string]bool{}}
+	batcher := &testBatchEmbedder{splitLarge: true}
+	state := runState{
+		service: Service{
+			Repo:     repo,
+			Embedder: batcher,
+		},
+		ctx:      context.Background(),
+		provider: "openrouter",
+		modelID:  "qwen",
+	}
+
+	err := state.flushEmbeddingBatches(batcher, []pendingEmbedding{
+		{path: "a.go", symbol: IndexedSymbol{Line: 1, QualifiedName: "A"}, hash: "a"},
+		{path: "b.go", symbol: IndexedSymbol{Line: 2, QualifiedName: "B"}, hash: "b"},
+	})
+	if err != nil {
+		t.Fatalf("flushEmbeddingBatches() error: %v", err)
+	}
+	if len(repo.added) != 2 {
+		t.Fatalf("stored embeddings = %v, want 2", repo.added)
+	}
+	if len(batcher.batchSizes) < 3 {
+		t.Fatalf("batch sizes = %v, want initial batch plus split retries", batcher.batchSizes)
+	}
+	if batcher.batchSizes[0] != 2 {
+		t.Fatalf("first batch size = %d, want 2", batcher.batchSizes[0])
+	}
+}
+
+func TestRetryEmbeddingBatchUpdatesAttemptAndQueuedAt(t *testing.T) {
+	t.Parallel()
+
+	retries, err := retryEmbeddingBatch(context.Background(), embeddingBatchRequest{items: []embeddingRequest{
+		{item: pendingEmbedding{path: "a.go", symbol: IndexedSymbol{Line: 1, QualifiedName: "A"}, hash: "a"}, attempt: 1},
+		{item: pendingEmbedding{path: "b.go", symbol: IndexedSymbol{Line: 2, QualifiedName: "B"}, hash: "b"}, attempt: 1},
+	}}, testEmbeddingError{split: true})
+	if err != nil {
+		t.Fatalf("retryEmbeddingBatch() error: %v", err)
+	}
+	if len(retries) != 2 {
+		t.Fatalf("retry batch count = %d, want 2", len(retries))
+	}
+	for _, retry := range retries {
+		for _, item := range retry.items {
+			if item.attempt != 2 {
+				t.Fatalf("retry attempt = %d, want 2", item.attempt)
+			}
+			if item.queuedAt.IsZero() {
+				t.Fatalf("retry queuedAt was not set")
+			}
+		}
+	}
+}
+
+func TestEmbeddingRetryDelayCapsRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	delay := embeddingRetryDelay(testEmbeddingError{retryAfter: time.Hour}, 2)
+	if delay != 10*time.Second {
+		t.Fatalf("retry delay = %s, want 10s", delay)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add batched OpenRouter embedding requests for indexed symbols
- run indexing embeddings through a bounded worker pool
- retry temporary failures, split oversized batches, and respect capped Retry-After delays

## Tests
- go test ./internal/indexing ./internal/embed/openrouter
- go test ./...